### PR TITLE
Nest behaviors

### DIFF
--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -380,6 +380,10 @@ function Get_center_of_survivors()
         sum_y = sum_y + y
         count = count + 1
     end
+    if count == 0 then
+        -- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
+        return GetMapBox():Center()
+    end
     local center = point(DivRound(sum_x,count),DivRound(sum_y,count))
     return center
 end

--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -16,67 +16,67 @@ MapVar('NA_NestRoleZoom', 3)
 MapVar('NA_NestRoleName', false)
 
 function NA_Mod_Set(id)
-    id = id or CurrentModId
-    if CurrentModId ~= id or not CurrentModOptions then return end
-    --ilu_set_map_vars() --
-    local options = CurrentModOptions
-    local nest_notif = options.nests_awaken_notifications
-    local nest_level = 1
-    --(nest_notif)
-    if nest_notif == 'Full Popup' then
-        nest_level = 2
-    elseif nest_notif == 'Notifications Only' then
-        nest_level = 1
-    elseif nest_notif == 'Do not Alert me (<style TextNegative>Warning Dangerous</style>)' then
-        nest_level = 0
-    end
-    Nest_Notifications = nest_level
-    local per_species = options.max_nest
-    Per_species_nest_max = per_species or 13
-    Max_nests_allowed = options.max_global_nests or 15
-    local visual_selection = options.NA_Visuals
-    if visual_selection == 'Always on' then
-        NA_NestRoleZoom = 3
-    elseif visual_selection == 'Far (~80 meters)' then
-        NA_NestRoleZoom = 2
-    elseif visual_selection == 'Close (Same as Resource Piles) (~20 meters)' then
-        NA_NestRoleZoom = 1
-    elseif visual_selection == 'Always off' then
-        NA_NestRoleZoom = 0
-    end
-    if options.NA_show_name then
-        NA_NestRoleName = true
-    else
-        NA_NestRoleName = false
-    end
+	id = id or CurrentModId
+	if CurrentModId ~= id or not CurrentModOptions then return end
+	--ilu_set_map_vars() --
+	local options = CurrentModOptions
+	local nest_notif = options.nests_awaken_notifications
+	local nest_level = 1
+	--(nest_notif)
+	if nest_notif == 'Full Popup' then
+		nest_level = 2
+	elseif nest_notif == 'Notifications Only' then
+		nest_level = 1
+	elseif nest_notif == 'Do not Alert me (<style TextNegative>Warning Dangerous</style>)' then
+		nest_level = 0
+	end
+	Nest_Notifications = nest_level
+	local per_species = options.max_nest
+	Per_species_nest_max = per_species or 13
+	Max_nests_allowed = options.max_global_nests or 15
+	local visual_selection = options.NA_Visuals
+	if visual_selection == 'Always on' then
+		NA_NestRoleZoom = 3
+	elseif visual_selection == 'Far (~80 meters)' then
+		NA_NestRoleZoom = 2
+	elseif visual_selection == 'Close (Same as Resource Piles) (~20 meters)' then
+		NA_NestRoleZoom = 1
+	elseif visual_selection == 'Always off' then
+		NA_NestRoleZoom = 0
+	end
+	if options.NA_show_name then
+		NA_NestRoleName = true
+	else
+		NA_NestRoleName = false
+	end
 end
 
 function Setup_nest_mod()
-    CreateGameTimeThread(function()
-        WaitMsg("DlcsLoaded")
-        local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
-        for _, v in ipairs(species) do
-            if v.nest_class and not Nest_Species_Savegame_Stats[v.id] then
-                local spawnflag = false
-                if v.nest_class == 'ScissorhandsNest' or v.nest_class == 'ShriekerNest' then
-                    spawnflag = true
-                elseif v.nest_class == 'ConsortiumNest' and IsDlcAvailable('Robots') then
-                    spawnflag = true
-                end
-                Nest_Species_Savegame_Stats[v.id] = {}
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
-                Nest_Species_Savegame_Stats[v.id]['spawnflag'] = spawnflag
-            end
-        end
-        if Nest_scouting_quadrants == {} then
-            CreateMapGrid()
-        end
-        Faction_aggression_threshold = Max(0, 6 - Get_difficulty_offset())
-        Msg("UpdateNestRoleVisuals")
-    end)
+	CreateGameTimeThread(function()
+		WaitMsg("DlcsLoaded")
+		local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
+		for _, v in ipairs(species) do
+			if v.nest_class and not Nest_Species_Savegame_Stats[v.id] then
+				local spawnflag = false
+				if v.nest_class == 'ScissorhandsNest' or v.nest_class == 'ShriekerNest' then
+					spawnflag = true
+				elseif v.nest_class == 'ConsortiumNest' and IsDlcAvailable('Robots') then
+					spawnflag = true
+				end
+				Nest_Species_Savegame_Stats[v.id] = {}
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
+				Nest_Species_Savegame_Stats[v.id]['spawnflag'] = spawnflag
+			end
+		end
+		if Nest_scouting_quadrants == {} then
+			CreateMapGrid()
+		end
+		Faction_aggression_threshold = Max(0, 6 - Get_difficulty_offset())
+		Msg("UpdateNestRoleVisuals")
+	end)
 end
 
 OnMsg.ApplyModOptions = NA_Mod_Set
@@ -86,414 +86,414 @@ OnMsg.LoadGame = Setup_nest_mod    -- savegame load
 
 -- note we are switching cases, and no MapVar in use should start with a lowercase character
 function SavegameFixups.NA_MapVarCleanup()
-    local flag = false
-    if MapVarValues["global_nest_spawn_cd"] ~= 0 then
-        Global_nest_spawn_cd = MapVarValues["global_nest_spawn_cd"]
-        MapVarValues["Global_nest_spawn_cd"] = 0
-        flag = true
-    end
-    if MapVarValues["Nest_Notifications"] ~= 1 then
-        Nest_Notifications = MapVarValues["Nest_Notifications"]
-        MapVarValues["Nest_Notifications"] = 1
-        flag = true
-    end
-    if MapVarValues['per_species_nest_max'] ~= 13 then
-        Per_species_nest_max = MapVarValues['per_species_nest_max']
-        MapVarValues['Per_species_nest_max'] = 13
-        flag = true
-    end
-    if MapVarValues["faction_aggression_threshold"] ~= 0 then
-        Faction_aggression_threshold = MapVarValues["faction_aggression_threshold"]
-        MapVarValues["Faction_aggression_threshold"] = 0
-        flag = true
-    end
-    if MapVarValues["nest_tutorial"] ~= false then
-        Nest_tutorial = MapVarValues["nest_tutorial"]
-        MapVarValues["Nest_tutorial"] = 1
-        flag = true
-    end
-    if MapVarValues["Nest_Notifications"] ~= 1 then
-        Nest_Notifications = MapVarValues["Nest_Notifications"]
-        MapVarValues["Nest_Notifications"] = 1
-        flag = true
-    end
-    if MapVarValues["Max_nests_allowed"] ~= 1 then
-        Nest_Notifications = MapVarValues["Nest_Notifications"]
-        MapVarValues["Nest_Notifications"] = 1
-        flag = true
-    end
-    local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
-    for _, v in ipairs(species) do
-        if v.nest_class then
-            if not Nest_Species_Savegame_Stats[v.id] then
-                Nest_Species_Savegame_Stats[v.id] = {}
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
-            end
-            if MapVarValues[v.id .. '_nest_spawn_cd'] ~= 0 then
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = MapVarValues[v.id .. '_nest_spawn_cd']
-                -- we are not resetting this MapVar because we will never use this MapVar
-                flag = true
-            end
-            if MapVarValues[v.id .. '_evo_cd'] ~= 0 then
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = MapVarValues[v.id .. '_evo_cd']
-                -- we are not resetting this MapVar because we will never use this MapVar
-                flag = true
-            end
-            if MapVarValues[v.id .. '_stored_aggr'] ~= 0 then
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = MapVarValues[v.id .. '_stored_aggr']
-                -- we are not resetting this MapVar because we will never use this MapVar
-                flag = true
-            end
-            if MapVarValues[v.id .. '_aggro_events'] ~= 0 then
-                Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = MapVarValues[v.id .. '_aggro_events']
-                -- we are not resetting this MapVar because we will never use this MapVar
-                flag = true
-            end
-        end
-    end
-    if flag then
-        Bkob_Log("NA had to clean up some vars!")
-    end
+	local flag = false
+	if MapVarValues["global_nest_spawn_cd"] ~= 0 then
+		Global_nest_spawn_cd = MapVarValues["global_nest_spawn_cd"]
+		MapVarValues["Global_nest_spawn_cd"] = 0
+		flag = true
+	end
+	if MapVarValues["Nest_Notifications"] ~= 1 then
+		Nest_Notifications = MapVarValues["Nest_Notifications"]
+		MapVarValues["Nest_Notifications"] = 1
+		flag = true
+	end
+	if MapVarValues['per_species_nest_max'] ~= 13 then
+		Per_species_nest_max = MapVarValues['per_species_nest_max']
+		MapVarValues['Per_species_nest_max'] = 13
+		flag = true
+	end
+	if MapVarValues["faction_aggression_threshold"] ~= 0 then
+		Faction_aggression_threshold = MapVarValues["faction_aggression_threshold"]
+		MapVarValues["Faction_aggression_threshold"] = 0
+		flag = true
+	end
+	if MapVarValues["nest_tutorial"] ~= false then
+		Nest_tutorial = MapVarValues["nest_tutorial"]
+		MapVarValues["Nest_tutorial"] = 1
+		flag = true
+	end
+	if MapVarValues["Nest_Notifications"] ~= 1 then
+		Nest_Notifications = MapVarValues["Nest_Notifications"]
+		MapVarValues["Nest_Notifications"] = 1
+		flag = true
+	end
+	if MapVarValues["Max_nests_allowed"] ~= 1 then
+		Nest_Notifications = MapVarValues["Nest_Notifications"]
+		MapVarValues["Nest_Notifications"] = 1
+		flag = true
+	end
+	local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
+	for _, v in ipairs(species) do
+		if v.nest_class then
+			if not Nest_Species_Savegame_Stats[v.id] then
+				Nest_Species_Savegame_Stats[v.id] = {}
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
+			end
+			if MapVarValues[v.id .. '_nest_spawn_cd'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = MapVarValues[v.id .. '_nest_spawn_cd']
+				-- we are not resetting this MapVar because we will never use this MapVar
+				flag = true
+			end
+			if MapVarValues[v.id .. '_evo_cd'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = MapVarValues[v.id .. '_evo_cd']
+				-- we are not resetting this MapVar because we will never use this MapVar
+				flag = true
+			end
+			if MapVarValues[v.id .. '_stored_aggr'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = MapVarValues[v.id .. '_stored_aggr']
+				-- we are not resetting this MapVar because we will never use this MapVar
+				flag = true
+			end
+			if MapVarValues[v.id .. '_aggro_events'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = MapVarValues[v.id .. '_aggro_events']
+				-- we are not resetting this MapVar because we will never use this MapVar
+				flag = true
+			end
+		end
+	end
+	if flag then
+		Bkob_Log("NA had to clean up some vars!")
+	end
 end
 
 --------------- SAVEGAME FIXUPS ---------------
 -- brute force method.... not ideal
 function SavegameFixups.NA_Disaster_clean()
-    if GameState.SolarEclipse then
-        DisasterPresets['SolarEclipse']:StopDisaster()
-    end
+	if GameState.SolarEclipse then
+		DisasterPresets['SolarEclipse']:StopDisaster()
+	end
 end
 
 function SavegameFixups.NA_Disaster_clean()
-    if GameState.SolarEclipse then
-        DisasterPresets['SolarEclipse']:StopDisaster()
-    end
+	if GameState.SolarEclipse then
+		DisasterPresets['SolarEclipse']:StopDisaster()
+	end
 end
 
 function SavegameFixups.Nest_cap_clean()
-    Align_global_nest_cap()
+	Align_global_nest_cap()
 end
 
 function Align_global_nest_cap()
-    local nests = MapGet(true, "TerritorialNest")
-    local cap = Max_nests_allowed
-    if not cap then
-        cap = 19
-    end
-    DebugPrint("Checking if I need to delete nests!")
-    DebugPrint(#nests - cap)
-    if #nests > (cap) then
-        DebugPrint("Still need to delete!")
-        local types = ClassDescendantsList('TerritorialNest')
-        local min = DivRound(cap, #types) - 1
-        local needed_delete = #nests - cap
-        local saved = {}
-        local count = 0
-        for _, nest in ipairs(nests) do
-            DebugPrint("looking at this nest: ")
-            DebugPrint(count)
-            count = count + 1
-            if saved[nest.class] and saved[nest.class] > min and needed_delete > 0 then
-                DebugPrint("Deleting this nest!")
-                -- delete
-                local members = nest.nest_members
-                for i = #members, 1, -1 do
-                    members[i]:SetNest(false)
-                end
-                for i = #members, 1, -1 do
-                    members[i]:CheatDelete()
-                end
-                nest:CheatDelete()
-                needed_delete = needed_delete - 1
-            elseif not saved[nest.class] then
-                DebugPrint("Saving this nest!")
-                saved[nest.class] = 1
-                DebugPrint("This many saved of this class: ")
-                DebugPrint(nest.class)
-                DebugPrint(saved[nest.class])
-            else
-                DebugPrint("Saving this nest!")
-                saved[nest.class] = saved[nest.class] + 1
-                DebugPrint("This many saved of this class: ")
-                DebugPrint(nest.class)
-                DebugPrint(saved[nest.class])
-            end
-        end
-    end
+	local nests = MapGet(true, "TerritorialNest")
+	local cap = Max_nests_allowed
+	if not cap then
+		cap = 19
+	end
+	DebugPrint("Checking if I need to delete nests!")
+	DebugPrint(#nests - cap)
+	if #nests > (cap) then
+		DebugPrint("Still need to delete!")
+		local types = ClassDescendantsList('TerritorialNest')
+		local min = DivRound(cap, #types) - 1
+		local needed_delete = #nests - cap
+		local saved = {}
+		local count = 0
+		for _, nest in ipairs(nests) do
+			DebugPrint("looking at this nest: ")
+			DebugPrint(count)
+			count = count + 1
+			if saved[nest.class] and saved[nest.class] > min and needed_delete > 0 then
+				DebugPrint("Deleting this nest!")
+				-- delete
+				local members = nest.nest_members
+				for i = #members, 1, -1 do
+					members[i]:SetNest(false)
+				end
+				for i = #members, 1, -1 do
+					members[i]:CheatDelete()
+				end
+				nest:CheatDelete()
+				needed_delete = needed_delete - 1
+			elseif not saved[nest.class] then
+				DebugPrint("Saving this nest!")
+				saved[nest.class] = 1
+				DebugPrint("This many saved of this class: ")
+				DebugPrint(nest.class)
+				DebugPrint(saved[nest.class])
+			else
+				DebugPrint("Saving this nest!")
+				saved[nest.class] = saved[nest.class] + 1
+				DebugPrint("This many saved of this class: ")
+				DebugPrint(nest.class)
+				DebugPrint(saved[nest.class])
+			end
+		end
+	end
 end
 
 ------------------------------ HELPER FUNCTIONS ------------------------------
 function Bkob_Log_NA(hard_string, var)
-    DebugPrint(hard_string)
-    if var then
-        DebugPrint(var)
-    end
-    DebugPrint("\n")
-    if EE_debug == 'all' then
-        print(hard_string)
-        print(var)
-    end
+	DebugPrint(hard_string)
+	if var then
+		DebugPrint(var)
+	end
+	DebugPrint("\n")
+	if EE_debug == 'all' then
+		print(hard_string)
+		print(var)
+	end
 end
 
 -- input a string or classdef, output the nesting species classdef (If we can find it)
 function find_nest_species(input)
-    local str_check = type(input) == 'string'
-    local nest_spec_check, nest_entity_check
-    if str_check then
-        nest_spec_check = Presets.NestingSpeciesPreset.Default[input]
-        nest_entity_check = g_Classes[input]
-    else
-        nest_spec_check = IsKindOf(input, "NestingSpecies")
-        nest_entity_check = IsKindOf(input, "TerritorialNest")
-    end
-    if nest_entity_check then
-        return get_species_from_nest(nest_entity_check.id)
-    end
-    if nest_spec_check then
-        return nest_spec_check
-    end
-    return false
+	local str_check = type(input) == 'string'
+	local nest_spec_check, nest_entity_check
+	if str_check then
+		nest_spec_check = Presets.NestingSpeciesPreset.Default[input]
+		nest_entity_check = g_Classes[input]
+	else
+		nest_spec_check = IsKindOf(input, "NestingSpecies")
+		nest_entity_check = IsKindOf(input, "TerritorialNest")
+	end
+	if nest_entity_check then
+		return get_species_from_nest(nest_entity_check.id)
+	end
+	if nest_spec_check then
+		return nest_spec_check
+	end
+	return false
 end
 
 function Get_difficulty_offset()
-    local difficulty_offset = 2
-    local difficulty = GetGameDifficulty()
-    if difficulty == 'Easy' then
-        difficulty_offset = 1
-    elseif difficulty == 'Medium' then
-        difficulty_offset = 2
-    elseif difficulty == 'Hard' then
-        difficulty_offset = 3
-    elseif difficulty == 'VeryHard' then
-        difficulty_offset = 4
-    elseif difficulty == 'Insane' then
-        difficulty_offset = 5
-    elseif difficulty == 'PXImpossible' then
-        difficulty_offset = 6
-    else
-        difficulty_offset = 7
-    end
-    return difficulty_offset
+	local difficulty_offset = 2
+	local difficulty = GetGameDifficulty()
+	if difficulty == 'Easy' then
+		difficulty_offset = 1
+	elseif difficulty == 'Medium' then
+		difficulty_offset = 2
+	elseif difficulty == 'Hard' then
+		difficulty_offset = 3
+	elseif difficulty == 'VeryHard' then
+		difficulty_offset = 4
+	elseif difficulty == 'Insane' then
+		difficulty_offset = 5
+	elseif difficulty == 'PXImpossible' then
+		difficulty_offset = 6
+	else
+		difficulty_offset = 7
+	end
+	return difficulty_offset
 end
 
 --assuming a string of the nest class
 function get_species_from_nest(nest_class)
-    local found = false
-    for _, v in ipairs(ClassDescendantsList('TerritorialNest')) do
-        if v == nest_class then
-            found = true
-        end
-    end
-    if not found then return end
-    local entries = #Presets.NestingSpeciesPreset.Default
-    for i = 1, entries do
-        local species = Presets.NestingSpeciesPreset.Default[i]
-        if species and species.unit_species then
-            if species.nest_class == nest_class then
-                return species.id
-            end
-        end
-    end
+	local found = false
+	for _, v in ipairs(ClassDescendantsList('TerritorialNest')) do
+		if v == nest_class then
+			found = true
+		end
+	end
+	if not found then return end
+	local entries = #Presets.NestingSpeciesPreset.Default
+	for i = 1, entries do
+		local species = Presets.NestingSpeciesPreset.Default[i]
+		if species and species.unit_species then
+			if species.nest_class == nest_class then
+				return species.id
+			end
+		end
+	end
 end
 
 function Get_nest_species_by_region(region)
-    region = region or Region.id
-    DebugPrint("Getting nest class id by region\n")
-    if region == 'Desertum' then
-        return get_species_from_nest('ShriekerNest')
-    elseif region == 'Sobrius' then
-        return get_species_from_nest("ShriekerNest")
-    elseif region == 'Saltu' then
-        return get_species_from_nest('ScissorhandsNest')
-    else
-        return get_species_from_nest('ShriekerNest')
-    end
+	region = region or Region.id
+	DebugPrint("Getting nest class id by region\n")
+	if region == 'Desertum' then
+		return get_species_from_nest('ShriekerNest')
+	elseif region == 'Sobrius' then
+		return get_species_from_nest("ShriekerNest")
+	elseif region == 'Saltu' then
+		return get_species_from_nest('ScissorhandsNest')
+	else
+		return get_species_from_nest('ShriekerNest')
+	end
 end
 
 function Get_nest_entity_by_region(region)
-    region = region or Region.id
-    DebugPrint("Getting nest class id by region\n")
-    if region == 'Desertum' then
-        return ('ShriekerNest')
-    elseif region == 'Sobrius' then
-        return get_species_from_nest("ShriekerNest")
-    elseif region == 'Saltu' then
-        return get_species_from_nest('ScissorhandsNest')
-    else
-        return get_species_from_nest('ShriekerNest')
-    end
+	region = region or Region.id
+	DebugPrint("Getting nest class id by region\n")
+	if region == 'Desertum' then
+		return ('ShriekerNest')
+	elseif region == 'Sobrius' then
+		return get_species_from_nest("ShriekerNest")
+	elseif region == 'Saltu' then
+		return get_species_from_nest('ScissorhandsNest')
+	else
+		return get_species_from_nest('ShriekerNest')
+	end
 end
 
 function Is_DLC_Present()
-    DebugPrint("Checking if DLC loaded\n")
-    return TradingShips['SmallCargoShip']
+	DebugPrint("Checking if DLC loaded\n")
+	return TradingShips['SmallCargoShip']
 end
 
 function mark_spawned_nest(nest_type)
-    Global_nest_spawn_cd = GameTime() + MoonInstance.AttackCooldownMin
-    local species_name = get_species_from_nest(nest_type)
-    print(species_name)
-    local species_def = Presets.NestingSpeciesPreset.Default[species_name]
-    print(species_def)
-    local species_id = species_def.id
-    print(species_id)
-    if Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] then
-        Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] = GameTime() +
-            (MoonInstance.AttackCooldownMin * 3)
-    else
-        DebugPrint("Nesting species does not have an entry in map vars for their nest spawn cd! Alert mod author!")
-    end
+	Global_nest_spawn_cd = GameTime() + MoonInstance.AttackCooldownMin
+	local species_name = get_species_from_nest(nest_type)
+	print(species_name)
+	local species_def = Presets.NestingSpeciesPreset.Default[species_name]
+	print(species_def)
+	local species_id = species_def.id
+	print(species_id)
+	if Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] then
+		Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] = GameTime() +
+			(MoonInstance.AttackCooldownMin * 3)
+	else
+		DebugPrint("Nesting species does not have an entry in map vars for their nest spawn cd! Alert mod author!")
+	end
 end
 
 function NA_log_nest_evolved(nest)
-    local notif_level = Nest_Notifications or 1
-    if notif_level == 2 then
-        ForceActivateStoryBit('nests_evolving', self, true)
-    elseif notif_level == 1 then
-        AddGameNotification("nests_evolving", nil, nil, { nest })
-    end
+	local notif_level = Nest_Notifications or 1
+	if notif_level == 2 then
+		ForceActivateStoryBit('nests_evolving', self, true)
+	elseif notif_level == 1 then
+		AddGameNotification("nests_evolving", nil, nil, { nest })
+	end
 end
 
 function NA_tutorial()
-    if Nest_tutorial then return end
-    Presets.TutorialHint.Default['nests_awaken_tutorial']:ShowNotification()
-    Nest_tutorial = true
+	if Nest_tutorial then return end
+	Presets.TutorialHint.Default['nests_awaken_tutorial']:ShowNotification()
+	Nest_tutorial = true
 end
 
 function Get_center_of_survivors()
-    local surv = GetValidSurvivorsOnMap()
-    local sum_x = 0
-    local sum_y = 0
-    local count = 0
-    local x = 0
-    local y = 0
-    for _, v in ipairs(surv) do
-        x, y, _ = v:GetVisualPosXYZ()
-        sum_x = sum_x + x
-        sum_y = sum_y + y
-        count = count + 1
-    end
-    if count == 0 then
-        -- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
-        return GetMapBox():Center()
-    end
-    local center = point(DivRound(sum_x, count), DivRound(sum_y, count))
-    return center
+	local surv = GetValidSurvivorsOnMap()
+	local sum_x = 0
+	local sum_y = 0
+	local count = 0
+	local x = 0
+	local y = 0
+	for _, v in ipairs(surv) do
+		x, y, _ = v:GetVisualPosXYZ()
+		sum_x = sum_x + x
+		sum_y = sum_y + y
+		count = count + 1
+	end
+	if count == 0 then
+		-- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
+		return GetMapBox():Center()
+	end
+	local center = point(DivRound(sum_x, count), DivRound(sum_y, count))
+	return center
 end
 
 function NA_QA(full_log)
-    Setup_nest_mod()
-    Build_species_pivot_table()
-    build_pivot_tables()
-    EE_Instantiate()
-    full_log = full_log or false
-    EE_debug = full_log
-    print("Testing regions default nests")
-    print(Get_nest_entity_by_region('Desertum') == 'nesting_shriekers')
-    print(Get_nest_entity_by_region('Sobrius') == 'nesting_shriekers')
-    print(Get_nest_entity_by_region('Saltu') == 'nesting_scissorhands')
-    --assert(Get_nest_by_region('Desertum')=='nesting_shriekers')
-    --assert(Get_nest_by_region('Sobrius')=='nesting_shriekers')
-    --assert(Get_nest_by_region('Saltu')=='nesting_scissorhands')
-    Bkob_Log("Testing Nest spawner storybits!")
-    local all_nest_species = Presets.NestingSpeciesPreset.Default
-    -- this ensures there is one of each nest on the map for continued testing
-    local og_EP = EventProgress
-    for _, v in ipairs(all_nest_species) do
-        if not v.nest_class then goto continue end
-        if v.nest_class then
-            ForceActivateStoryBit(v.spawner_storybit, nil, "immediate", nil, true)
-        end
-        CreateRealTimeThread(function(nestclass)
-            print("Testing nest: " .. nestclass)
-            Sleep(5000)
-            local nest_on_map = MapGetFirst(true, nestclass)
-            local EP_nums = { 100, 800, 1200, 5000, 15000, 30000, 75000, 140000, 300000 }
-            local def = g_Classes[nestclass]
-            local attack_at = GameTime() + (2 * hour_duration)
-            local attacked = false
-            local deleted = false
-            local og_hatch = def.hatchling_class
-            local og_adult = def.adult_class
-            local og_elder = def.elder_class
-            local elder_chain = Find_evo_chain(og_elder)
-            local reset = function(nest)
-                nest.hatchling_class = og_hatch
-                nest.adult_class = og_adult
-                nest.elder_class = og_elder
-            end
-            nest_on_map:expand()
-            for i = 1, 10 do
-                nest_on_map:consume_closest_node()
-            end
-            nest_on_map:SwitchState("sleepy")
-            print("State should be sleepy: " .. nest_on_map.state)
-            nest_on_map:SwitchState("awake")
-            print("State should be awake: " .. nest_on_map.state)
-            nest_on_map:SwitchState("asleep")
-            print("State should be asleep: " .. nest_on_map.state)
-            for _, int in ipairs(EP_nums) do
-                print("Testing with EP: ")
-                print(int)
-                EventProgress = int
-                local correct_elder = elder_chain:get_correct_evo(int)
-                nest_on_map:change_nest_herd()
-                local possible = #correct_elder
-                table.insert_unique(correct_elder, nest_on_map.elder_class)
-                if possible ~= #correct_elder then
-                    print("Something went wrong evolving!")
-                end
-                Sleep(6000)
-                nest_on_map:attack()
-                reset(nest_on_map)
-            end
-        end, v.nest_class)
-        ::continue::
-    end
-    print("Testing resources!")
-    local res_table = get_nest_res_table()
-    for _, res in ipairs(table.keys(res_table)) do
-        print(res)
-        for _, species_entry in ipairs(res_table[res]) do
-            print("This should aggro: " .. species_entry.species)
-            local to_send = {}
-            to_send[res] = species_entry.chance
-            print(to_send)
-            for i = 1, 20 do
-                Resource_aggression_check(to_send)
-            end
-        end
-    end
-    EventProgress = og_EP
+	Setup_nest_mod()
+	Build_species_pivot_table()
+	build_pivot_tables()
+	EE_Instantiate()
+	full_log = full_log or false
+	EE_debug = full_log
+	print("Testing regions default nests")
+	print(Get_nest_entity_by_region('Desertum') == 'nesting_shriekers')
+	print(Get_nest_entity_by_region('Sobrius') == 'nesting_shriekers')
+	print(Get_nest_entity_by_region('Saltu') == 'nesting_scissorhands')
+	--assert(Get_nest_by_region('Desertum')=='nesting_shriekers')
+	--assert(Get_nest_by_region('Sobrius')=='nesting_shriekers')
+	--assert(Get_nest_by_region('Saltu')=='nesting_scissorhands')
+	Bkob_Log("Testing Nest spawner storybits!")
+	local all_nest_species = Presets.NestingSpeciesPreset.Default
+	-- this ensures there is one of each nest on the map for continued testing
+	local og_EP = EventProgress
+	for _, v in ipairs(all_nest_species) do
+		if not v.nest_class then goto continue end
+		if v.nest_class then
+			ForceActivateStoryBit(v.spawner_storybit, nil, "immediate", nil, true)
+		end
+		CreateRealTimeThread(function(nestclass)
+			print("Testing nest: " .. nestclass)
+			Sleep(5000)
+			local nest_on_map = MapGetFirst(true, nestclass)
+			local EP_nums = { 100, 800, 1200, 5000, 15000, 30000, 75000, 140000, 300000 }
+			local def = g_Classes[nestclass]
+			local attack_at = GameTime() + (2 * hour_duration)
+			local attacked = false
+			local deleted = false
+			local og_hatch = def.hatchling_class
+			local og_adult = def.adult_class
+			local og_elder = def.elder_class
+			local elder_chain = Find_evo_chain(og_elder)
+			local reset = function(nest)
+				nest.hatchling_class = og_hatch
+				nest.adult_class = og_adult
+				nest.elder_class = og_elder
+			end
+			nest_on_map:expand()
+			for i = 1, 10 do
+				nest_on_map:consume_closest_node()
+			end
+			nest_on_map:SwitchState("sleepy")
+			print("State should be sleepy: " .. nest_on_map.state)
+			nest_on_map:SwitchState("awake")
+			print("State should be awake: " .. nest_on_map.state)
+			nest_on_map:SwitchState("asleep")
+			print("State should be asleep: " .. nest_on_map.state)
+			for _, int in ipairs(EP_nums) do
+				print("Testing with EP: ")
+				print(int)
+				EventProgress = int
+				local correct_elder = elder_chain:get_correct_evo(int)
+				nest_on_map:change_nest_herd()
+				local possible = #correct_elder
+				table.insert_unique(correct_elder, nest_on_map.elder_class)
+				if possible ~= #correct_elder then
+					print("Something went wrong evolving!")
+				end
+				Sleep(6000)
+				nest_on_map:attack()
+				reset(nest_on_map)
+			end
+		end, v.nest_class)
+		::continue::
+	end
+	print("Testing resources!")
+	local res_table = get_nest_res_table()
+	for _, res in ipairs(table.keys(res_table)) do
+		print(res)
+		for _, species_entry in ipairs(res_table[res]) do
+			print("This should aggro: " .. species_entry.species)
+			local to_send = {}
+			to_send[res] = species_entry.chance
+			print(to_send)
+			for i = 1, 20 do
+				Resource_aggression_check(to_send)
+			end
+		end
+	end
+	EventProgress = og_EP
 end
 
 function Get_species_nests()
-    local ret = {}
-    for i = 1, #Presets.NestingSpeciesPreset.Default do
-        local nest_def = Presets.NestingSpeciesPreset.Default[i]
-        if nest_def and nest_def.nest_class then
-            ret[#ret + 1] = nest_def.nest_class
-        end
-    end
-    return ret
+	local ret = {}
+	for i = 1, #Presets.NestingSpeciesPreset.Default do
+		local nest_def = Presets.NestingSpeciesPreset.Default[i]
+		if nest_def and nest_def.nest_class then
+			ret[#ret + 1] = nest_def.nest_class
+		end
+	end
+	return ret
 end
 
 function UnitInvader:GetNestClass()
-    local species = self:Get_Nesting_Species()
-    return Presets.NestingSpeciesPreset.Default[species].nest_class
+	local species = self:Get_Nesting_Species()
+	return Presets.NestingSpeciesPreset.Default[species].nest_class
 end
 
 function UnitInvader:Get_Nesting_Species()
-    for i = 1, #Presets.NestingSpeciesPreset.Default do
-        if Presets.NestingSpeciesPreset.Default[i] then
-            local nestS = Presets.NestingSpeciesPreset.Default[i]
-            if self.SpeciesGroup == nestS.unit_species then return nestS.id end
-        end
-    end
-    return false
+	for i = 1, #Presets.NestingSpeciesPreset.Default do
+		if Presets.NestingSpeciesPreset.Default[i] then
+			local nestS = Presets.NestingSpeciesPreset.Default[i]
+			if self.SpeciesGroup == nestS.unit_species then return nestS.id end
+		end
+	end
+	return false
 end
 
 --[[
@@ -523,336 +523,336 @@ quadrants[1] = {
 }
 --]]
 function CreateMapGrid()
-    local minx, miny, maxx, maxy = GetPlayBox():xyxy()
-    NA_X_length = MulDivRound(maxx - minx, 1, 5)
-    NA_Y_length = MulDivRound(maxy - miny, 1, 5)
+	local minx, miny, maxx, maxy = GetPlayBox():xyxy()
+	NA_X_length = MulDivRound(maxx - minx, 1, 5)
+	NA_Y_length = MulDivRound(maxy - miny, 1, 5)
 
-    local species = Presets.NestingSpeciesPreset.Default
-    for _, v in ipairs(species) do
-        if v.nest_class then
-            for quadrant = 1, 25 do
-                if not Nest_scouting_quadrants[quadrant] then
-                    Nest_scouting_quadrants[quadrant] = {}
-                end
-                if not Nest_scouting_quadrants[quadrant][v.id] then
-                    Nest_scouting_quadrants[quadrant][v.id] = {
-                        last_scout = 0,
-                        player_detected = false,
-                        map_objs = {},
-                        other_species = {},
-                    }
-                end
-            end
-        end
-    end
-    return Nest_scouting_quadrants
+	local species = Presets.NestingSpeciesPreset.Default
+	for _, v in ipairs(species) do
+		if v.nest_class then
+			for quadrant = 1, 25 do
+				if not Nest_scouting_quadrants[quadrant] then
+					Nest_scouting_quadrants[quadrant] = {}
+				end
+				if not Nest_scouting_quadrants[quadrant][v.id] then
+					Nest_scouting_quadrants[quadrant][v.id] = {
+						last_scout = 0,
+						player_detected = false,
+						map_objs = {},
+						other_species = {},
+					}
+				end
+			end
+		end
+	end
+	return Nest_scouting_quadrants
 end
 
 function DebugQuadrant(no)
-    print("Quadrant: " .. no)
-    local this_quad = Nest_scouting_quadrants[no]
-    for _, species in ipairs(table.keys(this_quad)) do
-        if this_quad[species]['last_scout'] ~= 0 then
-            print("Has been explored by species: " .. species)
-            print("On day: " .. this_quad[species]['last_scout'])
-            print("And had recorded " .. #this_quad[species]['map_objs'] .. "  of other species")
-            print("Other species detected: ")
-            print(table.keys(this_quad[species]['other_species']))
-        else
-            print("Has not been explored by species: " .. species)
-        end
-    end
+	print("Quadrant: " .. no)
+	local this_quad = Nest_scouting_quadrants[no]
+	for _, species in ipairs(table.keys(this_quad)) do
+		if this_quad[species]['last_scout'] ~= 0 then
+			print("Has been explored by species: " .. species)
+			print("On day: " .. this_quad[species]['last_scout'])
+			print("And had recorded " .. #this_quad[species]['map_objs'] .. "  of other species")
+			print("Other species detected: ")
+			print(table.keys(this_quad[species]['other_species']))
+		else
+			print("Has not been explored by species: " .. species)
+		end
+	end
 end
 
 function DebugGetQuadrantSummary(quad)
-    quad = quad or 0
-    if quad < 1 then
-        for q = 1, 25 do
-            DebugQuadrant(q)
-        end
-    else
-        DebugQuadrant(quad)
-    end
+	quad = quad or 0
+	if quad < 1 then
+		for q = 1, 25 do
+			DebugQuadrant(q)
+		end
+	else
+		DebugQuadrant(quad)
+	end
 end
 
 --- Quadrant Functions
 function Get_box_from_quadrant(quadrant_number)
-    if not NA_Y_length or not NA_X_length then
-        CreateMapGrid()
-    end
-    if not quadrant_number then return end
-    --print("Making box for quadrant: ",quadrant_number,'\n')
-    local start_x, _, _, start_y = GetPlayBox():xyxy()
-    --print('\nX start',start_x,'Y start',start_y,'\n')
-    local quad_obj = Uncollapse_quad(quadrant_number)
-    local box_y_end = start_y - ((quad_obj.y - 1) * NA_Y_length)
-    local box_y_start = box_y_end - NA_Y_length
-    --print("y quad: ",quad_obj.y,'\n')
-    --print("starts at ",box_y_start," and stops at ",box_y_end,'\n')
-    local box_x_start = start_x + ((quad_obj.x - 1) * NA_X_length)
-    local box_x_end = box_x_start + NA_X_length
-    --print("x quad: ",quad_obj.x,'\n')
-    --print("starts at ",box_x_start," and stops at ",box_x_end,'\n')
-    return box(box_x_start, box_y_start, 0, box_x_end, box_y_end, 0)
+	if not NA_Y_length or not NA_X_length then
+		CreateMapGrid()
+	end
+	if not quadrant_number then return end
+	--print("Making box for quadrant: ",quadrant_number,'\n')
+	local start_x, _, _, start_y = GetPlayBox():xyxy()
+	--print('\nX start',start_x,'Y start',start_y,'\n')
+	local quad_obj = Uncollapse_quad(quadrant_number)
+	local box_y_end = start_y - ((quad_obj.y - 1) * NA_Y_length)
+	local box_y_start = box_y_end - NA_Y_length
+	--print("y quad: ",quad_obj.y,'\n')
+	--print("starts at ",box_y_start," and stops at ",box_y_end,'\n')
+	local box_x_start = start_x + ((quad_obj.x - 1) * NA_X_length)
+	local box_x_end = box_x_start + NA_X_length
+	--print("x quad: ",quad_obj.x,'\n')
+	--print("starts at ",box_x_start," and stops at ",box_x_end,'\n')
+	return box(box_x_start, box_y_start, 0, box_x_end, box_y_end, 0)
 end
 
 function Cheat_find_all_in_quadrant(quad_no, classname)
-    classname = classname or 'TerritorialNest'
-    local box = Get_box_from_quadrant(quad_no)
-    if not box then
-        --print('something went wrong getting the box!')
-        return {}
-    end
-    return MapGet(box, classname)
+	classname = classname or 'TerritorialNest'
+	local box = Get_box_from_quadrant(quad_no)
+	if not box then
+		--print('something went wrong getting the box!')
+		return {}
+	end
+	return MapGet(box, classname)
 end
 
 function compare_quad_maths(entity)
-    CreateMapGrid()
-    print("Unit is at ", entity:GetPosXYZ())
-    print('\n')
-    local quad_no = Get_quadrant_from_obj(entity, true)
-    local quad_box = Get_box_from_quadrant(quad_no)
-    print("Quad box is: \n")
-    print(quad_box)
-    print("Entity is at this position:")
-    print(entity:GetPosXYZ())
-    print("Is this entity inside the quadrants box that it reports to be in?")
-    print(is_inside_of(quad_box, entity))
+	CreateMapGrid()
+	print("Unit is at ", entity:GetPosXYZ())
+	print('\n')
+	local quad_no = Get_quadrant_from_obj(entity, true)
+	local quad_box = Get_box_from_quadrant(quad_no)
+	print("Quad box is: \n")
+	print(quad_box)
+	print("Entity is at this position:")
+	print(entity:GetPosXYZ())
+	print("Is this entity inside the quadrants box that it reports to be in?")
+	print(is_inside_of(quad_box, entity))
 end
 
 function Player_presence_in_quadrant(quad_no)
-    local box = Get_box_from_quadrant(quad_no)
-    if not box then return false end
-    local players_stuff = MapCount(box, function(thing)
-        return IsValid(thing) and thing.player
-    end)
-    print("There are ", players_stuff, ' in this quadrant!\n')
-    return players_stuff > 0
+	local box = Get_box_from_quadrant(quad_no)
+	if not box then return false end
+	local players_stuff = MapCount(box, function(thing)
+		return IsValid(thing) and thing.player
+	end)
+	print("There are ", players_stuff, ' in this quadrant!\n')
+	return players_stuff > 0
 end
 
 -- This is expected to be a map object
 function Get_quadrant_from_obj(entity, int_flag)
-    if NA_X_length == 0 or NA_Y_length == 0 then
-        CreateMapGrid()
-    end
-    local minx, miny, maxx, maxy = GetPlayBox():xyxy()
-    --print("\nStarting to count x coords at ",minx,'\n')
-    --print("Starting to count y coords at ",maxy,'but going down!\n')
-    int_flag = int_flag or false
-    local x, y, z = entity:GetPosXYZ()
-    local quad_x
-    local quad_y
-    --print("Unit is at this x position: ",x,'\n')
-    local x_rel = x - minx
-    local y_rel = y - miny
-    --print("Which is ",MulDivRound(x_rel*100,1,maxx-minx),'% across the map in x!\n')
-    --print("Unit is at this y position: ",y,'\n')
-    --print("Which is ",MulDivRound(y_rel*100,1,maxy-miny),'% across the map in y!\n')
-    for i = 1, 5, 1 do
-        if not quad_y then
-            local lowest_y = maxy - (i * NA_Y_length)
-            local highest_y = maxy - ((i - 1) * NA_Y_length)
-            print("Checking this y quadrant, ", i, '\n')
-            print('Which starts at y: ', lowest_y, ' and ends at ', highest_y, '\n')
-            if y < highest_y and y > lowest_y then
-                print("Which is more than this quadrant border: ", y, '\n')
-                quad_y = i
-            end
-        end
-    end
-    if not quad_y then
-        --print("This unit is currently out of bounds!",'\n')
-    end
+	if NA_X_length == 0 or NA_Y_length == 0 then
+		CreateMapGrid()
+	end
+	local minx, miny, maxx, maxy = GetPlayBox():xyxy()
+	--print("\nStarting to count x coords at ",minx,'\n')
+	--print("Starting to count y coords at ",maxy,'but going down!\n')
+	int_flag = int_flag or false
+	local x, y, z = entity:GetPosXYZ()
+	local quad_x
+	local quad_y
+	--print("Unit is at this x position: ",x,'\n')
+	local x_rel = x - minx
+	local y_rel = y - miny
+	--print("Which is ",MulDivRound(x_rel*100,1,maxx-minx),'% across the map in x!\n')
+	--print("Unit is at this y position: ",y,'\n')
+	--print("Which is ",MulDivRound(y_rel*100,1,maxy-miny),'% across the map in y!\n')
+	for i = 1, 5, 1 do
+		if not quad_y then
+			local lowest_y = maxy - (i * NA_Y_length)
+			local highest_y = maxy - ((i - 1) * NA_Y_length)
+			print("Checking this y quadrant, ", i, '\n')
+			print('Which starts at y: ', lowest_y, ' and ends at ', highest_y, '\n')
+			if y < highest_y and y > lowest_y then
+				print("Which is more than this quadrant border: ", y, '\n')
+				quad_y = i
+			end
+		end
+	end
+	if not quad_y then
+		--print("This unit is currently out of bounds!",'\n')
+	end
 
-    local quad_x
-    for q = 1, 5, 1 do
-        if not quad_x then
-            --print("Checking this x quadrant, ",q,'\n')
-            --print('Which starts at x: ',minx + ((q-1) * NA_X_length), ' and ends at ',minx + (q * NA_X_length),'\n')
-            local check = minx + (q * NA_X_length)
-            if x < check then
-                --print("Which is more than this quadrant border: ",x,' < ',check,'\n')
-                quad_x = q
-            end
-        end
-    end
-    if not quad_x then
-        --print("This unit is currently out of bounds!",'\n')
-    end
-    if int_flag then
-        local times_5 = quad_y - 1
-        print("Returning quadrant no: ", times_5 * 5 + quad_x, '\n')
-        return times_5 * 5 + quad_x
-    else
-        print("Returning quadrant obj: ", { x = quad_x, y = quad_y }, '\n')
-        return { x = quad_x, y = quad_y }
-    end
+	local quad_x
+	for q = 1, 5, 1 do
+		if not quad_x then
+			--print("Checking this x quadrant, ",q,'\n')
+			--print('Which starts at x: ',minx + ((q-1) * NA_X_length), ' and ends at ',minx + (q * NA_X_length),'\n')
+			local check = minx + (q * NA_X_length)
+			if x < check then
+				--print("Which is more than this quadrant border: ",x,' < ',check,'\n')
+				quad_x = q
+			end
+		end
+	end
+	if not quad_x then
+		--print("This unit is currently out of bounds!",'\n')
+	end
+	if int_flag then
+		local times_5 = quad_y - 1
+		print("Returning quadrant no: ", times_5 * 5 + quad_x, '\n')
+		return times_5 * 5 + quad_x
+	else
+		print("Returning quadrant obj: ", { x = quad_x, y = quad_y }, '\n')
+		return { x = quad_x, y = quad_y }
+	end
 end
 
 function Collapse_quad(quad_obj)
-    local times_5 = quad_obj.y - 1
-    local quad_no = (times_5 * 5) + quad_obj.x
-    return quad_no
+	local times_5 = quad_obj.y - 1
+	local quad_no = (times_5 * 5) + quad_obj.x
+	return quad_no
 end
 
 function Uncollapse_quad(quad_no)
-    local y = MulDivTrunc(quad_no - 1, 1, 5)
-    local x = quad_no - (y * 5)
-    y = y + 1
-    return { x = x, y = y }
+	local y = MulDivTrunc(quad_no - 1, 1, 5)
+	local x = quad_no - (y * 5)
+	y = y + 1
+	return { x = x, y = y }
 end
 
 function Get_adjacent_quads(quad_int)
-    local quads = {}
-    if quad_int - 1 > 0 then
-        quads[#quads + 1] = quad_int - 1
-    end
-    if quad_int + 1 <= 25 and quad_int % 5 ~= 0 then
-        quads[#quads + 1] = quad_int + 1
-    end
-    if quad_int + 5 <= 25 then
-        quads[#quads + 1] = quad_int + 5
-    end
-    if quad_int - 5 > 0 then
-        quads[#quads + 1] = quad_int - 5
-    end
-    return quads
+	local quads = {}
+	if quad_int - 1 > 0 then
+		quads[#quads + 1] = quad_int - 1
+	end
+	if quad_int + 1 <= 25 and quad_int % 5 ~= 0 then
+		quads[#quads + 1] = quad_int + 1
+	end
+	if quad_int + 5 <= 25 then
+		quads[#quads + 1] = quad_int + 5
+	end
+	if quad_int - 5 > 0 then
+		quads[#quads + 1] = quad_int - 5
+	end
+	return quads
 end
 
 function Reset_quadrant(quad_no, species)
-    Nest_scouting_quadrants[quad_no][species].last_scout = GameTime()
-    Nest_scouting_quadrants[quad_no][species].player_detected = false
-    Nest_scouting_quadrants[quad_no][species].map_objs = {}
-    Nest_scouting_quadrants[quad_no][species].other_species = {}
+	Nest_scouting_quadrants[quad_no][species].last_scout = GameTime()
+	Nest_scouting_quadrants[quad_no][species].player_detected = false
+	Nest_scouting_quadrants[quad_no][species].map_objs = {}
+	Nest_scouting_quadrants[quad_no][species].other_species = {}
 end
 
 -- Removed this function from debug mode to test scouting / overrides needed for behaviors
 function UnitInvader:DbgPrintInvaderBehaviours()
-    if not self.invader_behaviours then
-        print("never had invader behaviours")
-        return
-    end
-    if IsValidThread(self.invader_behaviours_thread) then
-        print("invader behaviours are running")
-    else
-        print("invader behaviours aren't running")
-    end
-    local previous = {}
-    local current, current_until
-    local now = GameTime()
-    if self.forced_aggression_until then
-        local str = "aggressive"
-        local against = {}
-        for _, group in ipairs(self.forced_aggression_groups) do
-            table.insert(against, "(grp)" .. group)
-        end
-        for _, label in ipairs(self.forced_aggression_labels) do
-            table.insert(against, "(lbl)" .. label)
-        end
-        for _, class in ipairs(self.forced_aggression_classes) do
-            table.insert(against, "(cls)" .. class)
-        end
-        if next(against) then
-            str = str .. " against " .. table.concat(against, ", ")
-        end
-        if now < self.forced_aggression_until then
-            current = str
-            current_until = self.forced_aggression_until
-        else
-            table.insert(previous, "aggressive")
-        end
-    elseif self.food_binge_until then
-        if now < self.food_binge_until then
-            current = "food binge"
-            current_until = self.food_binge_until
-        else
-            table.insert(previous, "food binge")
-        end
-    elseif self.time_to_despawn then
-        if now < self.time_to_despawn then
-            current = "despawn"
-            current_until = self.time_to_despawn
-        else
-            table.insert(previous, "despawn")
-        end
-    elseif self.pathing then
-        print("new behavior detected!")
-        current = "passive pathing"
-        current_until = self.path_until
-        -- inject new checks above this stay_awake_until, as this is the catchall from teh base bevahior bool
-    elseif self.combat_passive_until then
-        if now < self.combat_passive_until then
-            current = "passive"
-            current_until = self.combat_passive_until
-        else
-            table.insert(previous, "passive")
-        end
-    elseif self.stay_awake_until and
-        self.combat_rage_until == self.stay_awake_until
-    then
-        if now < self.stay_awake_until then
-            current = "berserk"
-            current_until = self.combat_rage_until
-        else
-            table.insert(previous, "berserk")
-        end
-    else
-        current = "(possibly) idle"
-        current_until = max_int
-    end
-    if next(previous) then
-        print("previous behaviours (in no particular order):")
-        for i, str in ipairs(previous) do
-            previous[i] = " - " .. str
-        end
-    end
-    if current then
-        local until_str = (current_until == max_int) and "forever" or
-            ("for " .. tostring(current_until / (const.HourDuration * 1.0)) .. " more hours")
-        print("current behaviour:", current, until_str)
-    end
-    if next(self.invader_behaviours) then
-        print("future behaviours:")
-        for i, behavior in ipairs(self.invader_behaviours) do
-            print("-", _InternalTranslate(behavior.EditorView, behavior))
-        end
-    end
+	if not self.invader_behaviours then
+		print("never had invader behaviours")
+		return
+	end
+	if IsValidThread(self.invader_behaviours_thread) then
+		print("invader behaviours are running")
+	else
+		print("invader behaviours aren't running")
+	end
+	local previous = {}
+	local current, current_until
+	local now = GameTime()
+	if self.forced_aggression_until then
+		local str = "aggressive"
+		local against = {}
+		for _, group in ipairs(self.forced_aggression_groups) do
+			table.insert(against, "(grp)" .. group)
+		end
+		for _, label in ipairs(self.forced_aggression_labels) do
+			table.insert(against, "(lbl)" .. label)
+		end
+		for _, class in ipairs(self.forced_aggression_classes) do
+			table.insert(against, "(cls)" .. class)
+		end
+		if next(against) then
+			str = str .. " against " .. table.concat(against, ", ")
+		end
+		if now < self.forced_aggression_until then
+			current = str
+			current_until = self.forced_aggression_until
+		else
+			table.insert(previous, "aggressive")
+		end
+	elseif self.food_binge_until then
+		if now < self.food_binge_until then
+			current = "food binge"
+			current_until = self.food_binge_until
+		else
+			table.insert(previous, "food binge")
+		end
+	elseif self.time_to_despawn then
+		if now < self.time_to_despawn then
+			current = "despawn"
+			current_until = self.time_to_despawn
+		else
+			table.insert(previous, "despawn")
+		end
+	elseif self.pathing then
+		print("new behavior detected!")
+		current = "passive pathing"
+		current_until = self.path_until
+		-- inject new checks above this stay_awake_until, as this is the catchall from teh base bevahior bool
+	elseif self.combat_passive_until then
+		if now < self.combat_passive_until then
+			current = "passive"
+			current_until = self.combat_passive_until
+		else
+			table.insert(previous, "passive")
+		end
+	elseif self.stay_awake_until and
+		self.combat_rage_until == self.stay_awake_until
+	then
+		if now < self.stay_awake_until then
+			current = "berserk"
+			current_until = self.combat_rage_until
+		else
+			table.insert(previous, "berserk")
+		end
+	else
+		current = "(possibly) idle"
+		current_until = max_int
+	end
+	if next(previous) then
+		print("previous behaviours (in no particular order):")
+		for i, str in ipairs(previous) do
+			previous[i] = " - " .. str
+		end
+	end
+	if current then
+		local until_str = (current_until == max_int) and "forever" or
+			("for " .. tostring(current_until / (const.HourDuration * 1.0)) .. " more hours")
+		print("current behaviour:", current, until_str)
+	end
+	if next(self.invader_behaviours) then
+		print("future behaviours:")
+		for i, behavior in ipairs(self.invader_behaviours) do
+			print("-", _InternalTranslate(behavior.EditorView, behavior))
+		end
+	end
 end
 
 function TestConnectivityRandomTile(center)
-    DbgClear()
+	DbgClear()
 
-    center = center or SelectedObj or GameStartPos
+	center = center or SelectedObj or GameStartPos
 
-    local nests = MapGet("map", "TerritorialNest")
-    local function filter_far_from_nest(x, y)
-        -- check for distance to shrieker nests
-        for _, nest in ipairs(nests or empty_table) do
-            if nest:IsCloser2D(x, y, nest.territorial_range) then
-                return false
-            end
-        end
-        return true
-    end
-    local x, y
-    local seed = InteractionRand(nil, "LandHuman")
-    local max_dist, min_dist = const.Gameplay.SurvivorSpawnNearBaseMaxRadius,
-        const.Gameplay.SurvivorSpawnNearBaseMinRadius
-    local origin = terrain.FindAreaPassable(center, 4086, 64 * guim, Human.pfclass)
+	local nests = MapGet("map", "TerritorialNest")
+	local function filter_far_from_nest(x, y)
+		-- check for distance to shrieker nests
+		for _, nest in ipairs(nests or empty_table) do
+			if nest:IsCloser2D(x, y, nest.territorial_range) then
+				return false
+			end
+		end
+		return true
+	end
+	local x, y
+	local seed = InteractionRand(nil, "LandHuman")
+	local max_dist, min_dist = const.Gameplay.SurvivorSpawnNearBaseMaxRadius,
+		const.Gameplay.SurvivorSpawnNearBaseMinRadius
+	local origin = terrain.FindAreaPassable(center, 4086, 64 * guim, Human.pfclass)
 
-    local stA = GetPreciseTicks(1000000)
-    local pos = ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096,
-        filter_far_from_nest)
-    local timeA = GetPreciseTicks(1000000) - stA
+	local stA = GetPreciseTicks(1000000)
+	local pos = ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096,
+		filter_far_from_nest)
+	local timeA = GetPreciseTicks(1000000) - stA
 
-    DbgAddVector(origin, 15 * guim, red)
-    DbgAddVector(center, 10 * guim, blue)
-    DbgAddCircle(center, min_dist, blue)
-    DbgAddCircle(center, max_dist, yellow)
-    if pos then
-        DbgAddVector(pos, 10 * guim, green)
-        DbgAddSegment(origin, pos)
-    end
+	DbgAddVector(origin, 15 * guim, red)
+	DbgAddVector(center, 10 * guim, blue)
+	DbgAddCircle(center, min_dist, blue)
+	DbgAddCircle(center, max_dist, yellow)
+	if pos then
+		DbgAddVector(pos, 10 * guim, green)
+		DbgAddSegment(origin, pos)
+	end
 
-    print("pos", pos, "time", timeA / 1000.0)
+	print("pos", pos, "time", timeA / 1000.0)
 end

--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -16,67 +16,67 @@ MapVar('NA_NestRoleZoom', 3)
 MapVar('NA_NestRoleName', false)
 
 function NA_Mod_Set(id)
-	id = id or CurrentModId
-	if CurrentModId ~= id or not CurrentModOptions then return end
-	--ilu_set_map_vars() --
-	local options = CurrentModOptions
-	local nest_notif = options.nests_awaken_notifications
-	local nest_level = 1
-	--(nest_notif)
-	if nest_notif == 'Full Popup' then
-		nest_level = 2
-	elseif nest_notif == 'Notifications Only' then
-		nest_level = 1
-	elseif nest_notif == 'Do not Alert me (<style TextNegative>Warning Dangerous</style>)' then
-		nest_level = 0
-	end
-	Nest_Notifications = nest_level
-	local per_species = options.max_nest
-	Per_species_nest_max = per_species or 13
-	Max_nests_allowed = options.max_global_nests or 15
-	local visual_selection = options.NA_Visuals
-	if visual_selection == 'Always on' then
-		NA_NestRoleZoom = 3
-	elseif visual_selection == 'Far (~80 meters)' then
-		NA_NestRoleZoom = 2
-	elseif visual_selection == 'Close (Same as Resource Piles) (~20 meters)' then
-		NA_NestRoleZoom = 1
-	elseif visual_selection == 'Always off' then
-		NA_NestRoleZoom = 0
-	end
-	if options.NA_show_name then
-		NA_NestRoleName = true
-	else
-		NA_NestRoleName = false
-	end
+    id = id or CurrentModId
+    if CurrentModId ~= id or not CurrentModOptions then return end
+    --ilu_set_map_vars() --
+    local options = CurrentModOptions
+    local nest_notif = options.nests_awaken_notifications
+    local nest_level = 1
+    --(nest_notif)
+    if nest_notif == 'Full Popup' then
+        nest_level = 2
+    elseif nest_notif == 'Notifications Only' then
+        nest_level = 1
+    elseif nest_notif == 'Do not Alert me (<style TextNegative>Warning Dangerous</style>)' then
+        nest_level = 0
+    end
+    Nest_Notifications = nest_level
+    local per_species = options.max_nest
+    Per_species_nest_max = per_species or 13
+    Max_nests_allowed = options.max_global_nests or 15
+    local visual_selection = options.NA_Visuals
+    if visual_selection == 'Always on' then
+        NA_NestRoleZoom = 3
+    elseif visual_selection == 'Far (~80 meters)' then
+        NA_NestRoleZoom = 2
+    elseif visual_selection == 'Close (Same as Resource Piles) (~20 meters)' then
+        NA_NestRoleZoom = 1
+    elseif visual_selection == 'Always off' then
+        NA_NestRoleZoom = 0
+    end
+    if options.NA_show_name then
+        NA_NestRoleName = true
+    else
+        NA_NestRoleName = false
+    end
 end
 
 function Setup_nest_mod()
-	CreateGameTimeThread(function()
-		WaitMsg("DlcsLoaded")
-		local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
-		for _, v in ipairs(species) do
-			if v.nest_class and not Nest_Species_Savegame_Stats[v.id] then
-				local spawnflag = false
-				if v.nest_class == 'ScissorhandsNest' or v.nest_class == 'ShriekerNest' then
-					spawnflag = true
-				elseif v.nest_class == 'ConsortiumNest' and IsDlcAvailable('Robots') then
-					spawnflag = true
-				end
-				Nest_Species_Savegame_Stats[v.id] = {}
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
-				Nest_Species_Savegame_Stats[v.id]['spawnflag'] = spawnflag
-			end
-		end
-		if Nest_scouting_quadrants == {} then
-			CreateMapGrid()
-		end
-		Faction_aggression_threshold = Max(0, 6 - Get_difficulty_offset())
-		Msg("UpdateNestRoleVisuals")
-	end)
+    CreateGameTimeThread(function()
+        WaitMsg("DlcsLoaded")
+        local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
+        for _, v in ipairs(species) do
+            if v.nest_class and not Nest_Species_Savegame_Stats[v.id] then
+                local spawnflag = false
+                if v.nest_class == 'ScissorhandsNest' or v.nest_class == 'ShriekerNest' then
+                    spawnflag = true
+                elseif v.nest_class == 'ConsortiumNest' and IsDlcAvailable('Robots') then
+                    spawnflag = true
+                end
+                Nest_Species_Savegame_Stats[v.id] = {}
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
+                Nest_Species_Savegame_Stats[v.id]['spawnflag'] = spawnflag
+            end
+        end
+        if Nest_scouting_quadrants == {} then
+            CreateMapGrid()
+        end
+        Faction_aggression_threshold = Max(0, 6 - Get_difficulty_offset())
+        Msg("UpdateNestRoleVisuals")
+    end)
 end
 
 OnMsg.ApplyModOptions = NA_Mod_Set
@@ -86,414 +86,414 @@ OnMsg.LoadGame = Setup_nest_mod    -- savegame load
 
 -- note we are switching cases, and no MapVar in use should start with a lowercase character
 function SavegameFixups.NA_MapVarCleanup()
-	local flag = false
-	if MapVarValues["global_nest_spawn_cd"] ~= 0 then
-		Global_nest_spawn_cd = MapVarValues["global_nest_spawn_cd"]
-		MapVarValues["Global_nest_spawn_cd"] = 0
-		flag = true
-	end
-	if MapVarValues["Nest_Notifications"] ~= 1 then
-		Nest_Notifications = MapVarValues["Nest_Notifications"]
-		MapVarValues["Nest_Notifications"] = 1
-		flag = true
-	end
-	if MapVarValues['per_species_nest_max'] ~= 13 then
-		Per_species_nest_max = MapVarValues['per_species_nest_max']
-		MapVarValues['Per_species_nest_max'] = 13
-		flag = true
-	end
-	if MapVarValues["faction_aggression_threshold"] ~= 0 then
-		Faction_aggression_threshold = MapVarValues["faction_aggression_threshold"]
-		MapVarValues["Faction_aggression_threshold"] = 0
-		flag = true
-	end
-	if MapVarValues["nest_tutorial"] ~= false then
-		Nest_tutorial = MapVarValues["nest_tutorial"]
-		MapVarValues["Nest_tutorial"] = 1
-		flag = true
-	end
-	if MapVarValues["Nest_Notifications"] ~= 1 then
-		Nest_Notifications = MapVarValues["Nest_Notifications"]
-		MapVarValues["Nest_Notifications"] = 1
-		flag = true
-	end
-	if MapVarValues["Max_nests_allowed"] ~= 1 then
-		Nest_Notifications = MapVarValues["Nest_Notifications"]
-		MapVarValues["Nest_Notifications"] = 1
-		flag = true
-	end
-	local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
-	for _, v in ipairs(species) do
-		if v.nest_class then
-			if not Nest_Species_Savegame_Stats[v.id] then
-				Nest_Species_Savegame_Stats[v.id] = {}
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
-			end
-			if MapVarValues[v.id .. '_nest_spawn_cd'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = MapVarValues[v.id .. '_nest_spawn_cd']
-				-- we are not resetting this MapVar because we will never use this MapVar
-				flag = true
-			end
-			if MapVarValues[v.id .. '_evo_cd'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = MapVarValues[v.id .. '_evo_cd']
-				-- we are not resetting this MapVar because we will never use this MapVar
-				flag = true
-			end
-			if MapVarValues[v.id .. '_stored_aggr'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = MapVarValues[v.id .. '_stored_aggr']
-				-- we are not resetting this MapVar because we will never use this MapVar
-				flag = true
-			end
-			if MapVarValues[v.id .. '_aggro_events'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = MapVarValues[v.id .. '_aggro_events']
-				-- we are not resetting this MapVar because we will never use this MapVar
-				flag = true
-			end
-		end
-	end
-	if flag then
-		Bkob_Log("NA had to clean up some vars!")
-	end
+    local flag = false
+    if MapVarValues["global_nest_spawn_cd"] ~= 0 then
+        Global_nest_spawn_cd = MapVarValues["global_nest_spawn_cd"]
+        MapVarValues["Global_nest_spawn_cd"] = 0
+        flag = true
+    end
+    if MapVarValues["Nest_Notifications"] ~= 1 then
+        Nest_Notifications = MapVarValues["Nest_Notifications"]
+        MapVarValues["Nest_Notifications"] = 1
+        flag = true
+    end
+    if MapVarValues['per_species_nest_max'] ~= 13 then
+        Per_species_nest_max = MapVarValues['per_species_nest_max']
+        MapVarValues['Per_species_nest_max'] = 13
+        flag = true
+    end
+    if MapVarValues["faction_aggression_threshold"] ~= 0 then
+        Faction_aggression_threshold = MapVarValues["faction_aggression_threshold"]
+        MapVarValues["Faction_aggression_threshold"] = 0
+        flag = true
+    end
+    if MapVarValues["nest_tutorial"] ~= false then
+        Nest_tutorial = MapVarValues["nest_tutorial"]
+        MapVarValues["Nest_tutorial"] = 1
+        flag = true
+    end
+    if MapVarValues["Nest_Notifications"] ~= 1 then
+        Nest_Notifications = MapVarValues["Nest_Notifications"]
+        MapVarValues["Nest_Notifications"] = 1
+        flag = true
+    end
+    if MapVarValues["Max_nests_allowed"] ~= 1 then
+        Nest_Notifications = MapVarValues["Nest_Notifications"]
+        MapVarValues["Nest_Notifications"] = 1
+        flag = true
+    end
+    local species = Presets.NestingSpeciesPreset.Default --nests = ClassDescendantsList("TerritorialNest")
+    for _, v in ipairs(species) do
+        if v.nest_class then
+            if not Nest_Species_Savegame_Stats[v.id] then
+                Nest_Species_Savegame_Stats[v.id] = {}
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
+            end
+            if MapVarValues[v.id .. '_nest_spawn_cd'] ~= 0 then
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = MapVarValues[v.id .. '_nest_spawn_cd']
+                -- we are not resetting this MapVar because we will never use this MapVar
+                flag = true
+            end
+            if MapVarValues[v.id .. '_evo_cd'] ~= 0 then
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = MapVarValues[v.id .. '_evo_cd']
+                -- we are not resetting this MapVar because we will never use this MapVar
+                flag = true
+            end
+            if MapVarValues[v.id .. '_stored_aggr'] ~= 0 then
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = MapVarValues[v.id .. '_stored_aggr']
+                -- we are not resetting this MapVar because we will never use this MapVar
+                flag = true
+            end
+            if MapVarValues[v.id .. '_aggro_events'] ~= 0 then
+                Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = MapVarValues[v.id .. '_aggro_events']
+                -- we are not resetting this MapVar because we will never use this MapVar
+                flag = true
+            end
+        end
+    end
+    if flag then
+        Bkob_Log("NA had to clean up some vars!")
+    end
 end
 
 --------------- SAVEGAME FIXUPS ---------------
 -- brute force method.... not ideal
 function SavegameFixups.NA_Disaster_clean()
-	if GameState.SolarEclipse then
-		DisasterPresets['SolarEclipse']:StopDisaster()
-	end
+    if GameState.SolarEclipse then
+        DisasterPresets['SolarEclipse']:StopDisaster()
+    end
 end
 
 function SavegameFixups.NA_Disaster_clean()
-	if GameState.SolarEclipse then
-		DisasterPresets['SolarEclipse']:StopDisaster()
-	end
+    if GameState.SolarEclipse then
+        DisasterPresets['SolarEclipse']:StopDisaster()
+    end
 end
 
 function SavegameFixups.Nest_cap_clean()
-	Align_global_nest_cap()
+    Align_global_nest_cap()
 end
 
 function Align_global_nest_cap()
-	local nests = MapGet(true, "TerritorialNest")
-	local cap = Max_nests_allowed
-	if not cap then
-		cap = 19
-	end
-	DebugPrint("Checking if I need to delete nests!")
-	DebugPrint(#nests - cap)
-	if #nests > (cap) then
-		DebugPrint("Still need to delete!")
-		local types = ClassDescendantsList('TerritorialNest')
-		local min = DivRound(cap, #types) - 1
-		local needed_delete = #nests - cap
-		local saved = {}
-		local count = 0
-		for _, nest in ipairs(nests) do
-			DebugPrint("looking at this nest: ")
-			DebugPrint(count)
-			count = count + 1
-			if saved[nest.class] and saved[nest.class] > min and needed_delete > 0 then
-				DebugPrint("Deleting this nest!")
-				-- delete
-				local members = nest.nest_members
-				for i = #members, 1, -1 do
-					members[i]:SetNest(false)
-				end
-				for i = #members, 1, -1 do
-					members[i]:CheatDelete()
-				end
-				nest:CheatDelete()
-				needed_delete = needed_delete - 1
-			elseif not saved[nest.class] then
-				DebugPrint("Saving this nest!")
-				saved[nest.class] = 1
-				DebugPrint("This many saved of this class: ")
-				DebugPrint(nest.class)
-				DebugPrint(saved[nest.class])
-			else
-				DebugPrint("Saving this nest!")
-				saved[nest.class] = saved[nest.class] + 1
-				DebugPrint("This many saved of this class: ")
-				DebugPrint(nest.class)
-				DebugPrint(saved[nest.class])
-			end
-		end
-	end
+    local nests = MapGet(true, "TerritorialNest")
+    local cap = Max_nests_allowed
+    if not cap then
+        cap = 19
+    end
+    DebugPrint("Checking if I need to delete nests!")
+    DebugPrint(#nests - cap)
+    if #nests > (cap) then
+        DebugPrint("Still need to delete!")
+        local types = ClassDescendantsList('TerritorialNest')
+        local min = DivRound(cap, #types) - 1
+        local needed_delete = #nests - cap
+        local saved = {}
+        local count = 0
+        for _, nest in ipairs(nests) do
+            DebugPrint("looking at this nest: ")
+            DebugPrint(count)
+            count = count + 1
+            if saved[nest.class] and saved[nest.class] > min and needed_delete > 0 then
+                DebugPrint("Deleting this nest!")
+                -- delete
+                local members = nest.nest_members
+                for i = #members, 1, -1 do
+                    members[i]:SetNest(false)
+                end
+                for i = #members, 1, -1 do
+                    members[i]:CheatDelete()
+                end
+                nest:CheatDelete()
+                needed_delete = needed_delete - 1
+            elseif not saved[nest.class] then
+                DebugPrint("Saving this nest!")
+                saved[nest.class] = 1
+                DebugPrint("This many saved of this class: ")
+                DebugPrint(nest.class)
+                DebugPrint(saved[nest.class])
+            else
+                DebugPrint("Saving this nest!")
+                saved[nest.class] = saved[nest.class] + 1
+                DebugPrint("This many saved of this class: ")
+                DebugPrint(nest.class)
+                DebugPrint(saved[nest.class])
+            end
+        end
+    end
 end
 
 ------------------------------ HELPER FUNCTIONS ------------------------------
 function Bkob_Log_NA(hard_string, var)
-	DebugPrint(hard_string)
-	if var then
-		DebugPrint(var)
-	end
-	DebugPrint("\n")
-	if EE_debug == 'all' then
-		print(hard_string)
-		print(var)
-	end
+    DebugPrint(hard_string)
+    if var then
+        DebugPrint(var)
+    end
+    DebugPrint("\n")
+    if EE_debug == 'all' then
+        print(hard_string)
+        print(var)
+    end
 end
 
 -- input a string or classdef, output the nesting species classdef (If we can find it)
 function find_nest_species(input)
-	local str_check = type(input) == 'string'
-	local nest_spec_check, nest_entity_check
-	if str_check then
-		nest_spec_check = Presets.NestingSpeciesPreset.Default[input]
-		nest_entity_check = g_Classes[input]
-	else
-		nest_spec_check = IsKindOf(input, "NestingSpecies")
-		nest_entity_check = IsKindOf(input, "TerritorialNest")
-	end
-	if nest_entity_check then
-		return get_species_from_nest(nest_entity_check.id)
-	end
-	if nest_spec_check then
-		return nest_spec_check
-	end
-	return false
+    local str_check = type(input) == 'string'
+    local nest_spec_check, nest_entity_check
+    if str_check then
+        nest_spec_check = Presets.NestingSpeciesPreset.Default[input]
+        nest_entity_check = g_Classes[input]
+    else
+        nest_spec_check = IsKindOf(input, "NestingSpecies")
+        nest_entity_check = IsKindOf(input, "TerritorialNest")
+    end
+    if nest_entity_check then
+        return get_species_from_nest(nest_entity_check.id)
+    end
+    if nest_spec_check then
+        return nest_spec_check
+    end
+    return false
 end
 
 function Get_difficulty_offset()
-	local difficulty_offset = 2
-	local difficulty = GetGameDifficulty()
-	if difficulty == 'Easy' then
-		difficulty_offset = 1
-	elseif difficulty == 'Medium' then
-		difficulty_offset = 2
-	elseif difficulty == 'Hard' then
-		difficulty_offset = 3
-	elseif difficulty == 'VeryHard' then
-		difficulty_offset = 4
-	elseif difficulty == 'Insane' then
-		difficulty_offset = 5
-	elseif difficulty == 'PXImpossible' then
-		difficulty_offset = 6
-	else
-		difficulty_offset = 7
-	end
-	return difficulty_offset
+    local difficulty_offset = 2
+    local difficulty = GetGameDifficulty()
+    if difficulty == 'Easy' then
+        difficulty_offset = 1
+    elseif difficulty == 'Medium' then
+        difficulty_offset = 2
+    elseif difficulty == 'Hard' then
+        difficulty_offset = 3
+    elseif difficulty == 'VeryHard' then
+        difficulty_offset = 4
+    elseif difficulty == 'Insane' then
+        difficulty_offset = 5
+    elseif difficulty == 'PXImpossible' then
+        difficulty_offset = 6
+    else
+        difficulty_offset = 7
+    end
+    return difficulty_offset
 end
 
 --assuming a string of the nest class
 function get_species_from_nest(nest_class)
-	local found = false
-	for _, v in ipairs(ClassDescendantsList('TerritorialNest')) do
-		if v == nest_class then
-			found = true
-		end
-	end
-	if not found then return end
-	local entries = #Presets.NestingSpeciesPreset.Default
-	for i = 1, entries do
-		local species = Presets.NestingSpeciesPreset.Default[i]
-		if species and species.unit_species then
-			if species.nest_class == nest_class then
-				return species.id
-			end
-		end
-	end
+    local found = false
+    for _, v in ipairs(ClassDescendantsList('TerritorialNest')) do
+        if v == nest_class then
+            found = true
+        end
+    end
+    if not found then return end
+    local entries = #Presets.NestingSpeciesPreset.Default
+    for i = 1, entries do
+        local species = Presets.NestingSpeciesPreset.Default[i]
+        if species and species.unit_species then
+            if species.nest_class == nest_class then
+                return species.id
+            end
+        end
+    end
 end
 
 function Get_nest_species_by_region(region)
-	region = region or Region.id
-	DebugPrint("Getting nest class id by region\n")
-	if region == 'Desertum' then
-		return get_species_from_nest('ShriekerNest')
-	elseif region == 'Sobrius' then
-		return get_species_from_nest("ShriekerNest")
-	elseif region == 'Saltu' then
-		return get_species_from_nest('ScissorhandsNest')
-	else
-		return get_species_from_nest('ShriekerNest')
-	end
+    region = region or Region.id
+    DebugPrint("Getting nest class id by region\n")
+    if region == 'Desertum' then
+        return get_species_from_nest('ShriekerNest')
+    elseif region == 'Sobrius' then
+        return get_species_from_nest("ShriekerNest")
+    elseif region == 'Saltu' then
+        return get_species_from_nest('ScissorhandsNest')
+    else
+        return get_species_from_nest('ShriekerNest')
+    end
 end
 
 function Get_nest_entity_by_region(region)
-	region = region or Region.id
-	DebugPrint("Getting nest class id by region\n")
-	if region == 'Desertum' then
-		return ('ShriekerNest')
-	elseif region == 'Sobrius' then
-		return get_species_from_nest("ShriekerNest")
-	elseif region == 'Saltu' then
-		return get_species_from_nest('ScissorhandsNest')
-	else
-		return get_species_from_nest('ShriekerNest')
-	end
+    region = region or Region.id
+    DebugPrint("Getting nest class id by region\n")
+    if region == 'Desertum' then
+        return ('ShriekerNest')
+    elseif region == 'Sobrius' then
+        return get_species_from_nest("ShriekerNest")
+    elseif region == 'Saltu' then
+        return get_species_from_nest('ScissorhandsNest')
+    else
+        return get_species_from_nest('ShriekerNest')
+    end
 end
 
 function Is_DLC_Present()
-	DebugPrint("Checking if DLC loaded\n")
-	return TradingShips['SmallCargoShip']
+    DebugPrint("Checking if DLC loaded\n")
+    return TradingShips['SmallCargoShip']
 end
 
 function mark_spawned_nest(nest_type)
-	Global_nest_spawn_cd = GameTime() + MoonInstance.AttackCooldownMin
-	local species_name = get_species_from_nest(nest_type)
-	print(species_name)
-	local species_def = Presets.NestingSpeciesPreset.Default[species_name]
-	print(species_def)
-	local species_id = species_def.id
-	print(species_id)
-	if Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] then
-		Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] = GameTime() +
-			(MoonInstance.AttackCooldownMin * 3)
-	else
-		DebugPrint("Nesting species does not have an entry in map vars for their nest spawn cd! Alert mod author!")
-	end
+    Global_nest_spawn_cd = GameTime() + MoonInstance.AttackCooldownMin
+    local species_name = get_species_from_nest(nest_type)
+    print(species_name)
+    local species_def = Presets.NestingSpeciesPreset.Default[species_name]
+    print(species_def)
+    local species_id = species_def.id
+    print(species_id)
+    if Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] then
+        Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] = GameTime() +
+            (MoonInstance.AttackCooldownMin * 3)
+    else
+        DebugPrint("Nesting species does not have an entry in map vars for their nest spawn cd! Alert mod author!")
+    end
 end
 
 function NA_log_nest_evolved(nest)
-	local notif_level = Nest_Notifications or 1
-	if notif_level == 2 then
-		ForceActivateStoryBit('nests_evolving', self, true)
-	elseif notif_level == 1 then
-		AddGameNotification("nests_evolving", nil, nil, { nest })
-	end
+    local notif_level = Nest_Notifications or 1
+    if notif_level == 2 then
+        ForceActivateStoryBit('nests_evolving', self, true)
+    elseif notif_level == 1 then
+        AddGameNotification("nests_evolving", nil, nil, { nest })
+    end
 end
 
 function NA_tutorial()
-	if Nest_tutorial then return end
-	Presets.TutorialHint.Default['nests_awaken_tutorial']:ShowNotification()
-	Nest_tutorial = true
+    if Nest_tutorial then return end
+    Presets.TutorialHint.Default['nests_awaken_tutorial']:ShowNotification()
+    Nest_tutorial = true
 end
 
 function Get_center_of_survivors()
-	local surv = GetValidSurvivorsOnMap()
-	local sum_x = 0
-	local sum_y = 0
-	local count = 0
-	local x = 0
-	local y = 0
-	for _, v in ipairs(surv) do
-		x, y, _ = v:GetVisualPosXYZ()
-		sum_x = sum_x + x
-		sum_y = sum_y + y
-		count = count + 1
-	end
-	if count == 0 then
-		-- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
-		return GetMapBox():Center()
-	end
-	local center = point(DivRound(sum_x, count), DivRound(sum_y, count))
-	return center
+    local surv = GetValidSurvivorsOnMap()
+    local sum_x = 0
+    local sum_y = 0
+    local count = 0
+    local x = 0
+    local y = 0
+    for _, v in ipairs(surv) do
+        x, y, _ = v:GetVisualPosXYZ()
+        sum_x = sum_x + x
+        sum_y = sum_y + y
+        count = count + 1
+    end
+    if count == 0 then
+        -- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
+        return GetMapBox():Center()
+    end
+    local center = point(DivRound(sum_x, count), DivRound(sum_y, count))
+    return center
 end
 
 function NA_QA(full_log)
-	Setup_nest_mod()
-	Build_species_pivot_table()
-	build_pivot_tables()
-	EE_Instantiate()
-	full_log = full_log or false
-	EE_debug = full_log
-	print("Testing regions default nests")
-	print(Get_nest_entity_by_region('Desertum') == 'nesting_shriekers')
-	print(Get_nest_entity_by_region('Sobrius') == 'nesting_shriekers')
-	print(Get_nest_entity_by_region('Saltu') == 'nesting_scissorhands')
-	--assert(Get_nest_by_region('Desertum')=='nesting_shriekers')
-	--assert(Get_nest_by_region('Sobrius')=='nesting_shriekers')
-	--assert(Get_nest_by_region('Saltu')=='nesting_scissorhands')
-	Bkob_Log("Testing Nest spawner storybits!")
-	local all_nest_species = Presets.NestingSpeciesPreset.Default
-	-- this ensures there is one of each nest on the map for continued testing
-	local og_EP = EventProgress
-	for _, v in ipairs(all_nest_species) do
-		if not v.nest_class then goto continue end
-		if v.nest_class then
-			ForceActivateStoryBit(v.spawner_storybit, nil, "immediate", nil, true)
-		end
-		CreateRealTimeThread(function(nestclass)
-			print("Testing nest: " .. nestclass)
-			Sleep(5000)
-			local nest_on_map = MapGetFirst(true, nestclass)
-			local EP_nums = { 100, 800, 1200, 5000, 15000, 30000, 75000, 140000, 300000 }
-			local def = g_Classes[nestclass]
-			local attack_at = GameTime() + (2 * hour_duration)
-			local attacked = false
-			local deleted = false
-			local og_hatch = def.hatchling_class
-			local og_adult = def.adult_class
-			local og_elder = def.elder_class
-			local elder_chain = Find_evo_chain(og_elder)
-			local reset = function(nest)
-				nest.hatchling_class = og_hatch
-				nest.adult_class = og_adult
-				nest.elder_class = og_elder
-			end
-			nest_on_map:expand()
-			for i = 1, 10 do
-				nest_on_map:consume_closest_node()
-			end
-			nest_on_map:SwitchState("sleepy")
-			print("State should be sleepy: " .. nest_on_map.state)
-			nest_on_map:SwitchState("awake")
-			print("State should be awake: " .. nest_on_map.state)
-			nest_on_map:SwitchState("asleep")
-			print("State should be asleep: " .. nest_on_map.state)
-			for _, int in ipairs(EP_nums) do
-				print("Testing with EP: ")
-				print(int)
-				EventProgress = int
-				local correct_elder = elder_chain:get_correct_evo(int)
-				nest_on_map:change_nest_herd()
-				local possible = #correct_elder
-				table.insert_unique(correct_elder, nest_on_map.elder_class)
-				if possible ~= #correct_elder then
-					print("Something went wrong evolving!")
-				end
-				Sleep(6000)
-				nest_on_map:attack()
-				reset(nest_on_map)
-			end
-		end, v.nest_class)
-		::continue::
-	end
-	print("Testing resources!")
-	local res_table = get_nest_res_table()
-	for _, res in ipairs(table.keys(res_table)) do
-		print(res)
-		for _, species_entry in ipairs(res_table[res]) do
-			print("This should aggro: " .. species_entry.species)
-			local to_send = {}
-			to_send[res] = species_entry.chance
-			print(to_send)
-			for i = 1, 20 do
-				Resource_aggression_check(to_send)
-			end
-		end
-	end
-	EventProgress = og_EP
+    Setup_nest_mod()
+    Build_species_pivot_table()
+    build_pivot_tables()
+    EE_Instantiate()
+    full_log = full_log or false
+    EE_debug = full_log
+    print("Testing regions default nests")
+    print(Get_nest_entity_by_region('Desertum') == 'nesting_shriekers')
+    print(Get_nest_entity_by_region('Sobrius') == 'nesting_shriekers')
+    print(Get_nest_entity_by_region('Saltu') == 'nesting_scissorhands')
+    --assert(Get_nest_by_region('Desertum')=='nesting_shriekers')
+    --assert(Get_nest_by_region('Sobrius')=='nesting_shriekers')
+    --assert(Get_nest_by_region('Saltu')=='nesting_scissorhands')
+    Bkob_Log("Testing Nest spawner storybits!")
+    local all_nest_species = Presets.NestingSpeciesPreset.Default
+    -- this ensures there is one of each nest on the map for continued testing
+    local og_EP = EventProgress
+    for _, v in ipairs(all_nest_species) do
+        if not v.nest_class then goto continue end
+        if v.nest_class then
+            ForceActivateStoryBit(v.spawner_storybit, nil, "immediate", nil, true)
+        end
+        CreateRealTimeThread(function(nestclass)
+            print("Testing nest: " .. nestclass)
+            Sleep(5000)
+            local nest_on_map = MapGetFirst(true, nestclass)
+            local EP_nums = { 100, 800, 1200, 5000, 15000, 30000, 75000, 140000, 300000 }
+            local def = g_Classes[nestclass]
+            local attack_at = GameTime() + (2 * hour_duration)
+            local attacked = false
+            local deleted = false
+            local og_hatch = def.hatchling_class
+            local og_adult = def.adult_class
+            local og_elder = def.elder_class
+            local elder_chain = Find_evo_chain(og_elder)
+            local reset = function(nest)
+                nest.hatchling_class = og_hatch
+                nest.adult_class = og_adult
+                nest.elder_class = og_elder
+            end
+            nest_on_map:expand()
+            for i = 1, 10 do
+                nest_on_map:consume_closest_node()
+            end
+            nest_on_map:SwitchState("sleepy")
+            print("State should be sleepy: " .. nest_on_map.state)
+            nest_on_map:SwitchState("awake")
+            print("State should be awake: " .. nest_on_map.state)
+            nest_on_map:SwitchState("asleep")
+            print("State should be asleep: " .. nest_on_map.state)
+            for _, int in ipairs(EP_nums) do
+                print("Testing with EP: ")
+                print(int)
+                EventProgress = int
+                local correct_elder = elder_chain:get_correct_evo(int)
+                nest_on_map:change_nest_herd()
+                local possible = #correct_elder
+                table.insert_unique(correct_elder, nest_on_map.elder_class)
+                if possible ~= #correct_elder then
+                    print("Something went wrong evolving!")
+                end
+                Sleep(6000)
+                nest_on_map:attack()
+                reset(nest_on_map)
+            end
+        end, v.nest_class)
+        ::continue::
+    end
+    print("Testing resources!")
+    local res_table = get_nest_res_table()
+    for _, res in ipairs(table.keys(res_table)) do
+        print(res)
+        for _, species_entry in ipairs(res_table[res]) do
+            print("This should aggro: " .. species_entry.species)
+            local to_send = {}
+            to_send[res] = species_entry.chance
+            print(to_send)
+            for i = 1, 20 do
+                Resource_aggression_check(to_send)
+            end
+        end
+    end
+    EventProgress = og_EP
 end
 
 function Get_species_nests()
-	local ret = {}
-	for i = 1, #Presets.NestingSpeciesPreset.Default do
-		local nest_def = Presets.NestingSpeciesPreset.Default[i]
-		if nest_def and nest_def.nest_class then
-			ret[#ret + 1] = nest_def.nest_class
-		end
-	end
-	return ret
+    local ret = {}
+    for i = 1, #Presets.NestingSpeciesPreset.Default do
+        local nest_def = Presets.NestingSpeciesPreset.Default[i]
+        if nest_def and nest_def.nest_class then
+            ret[#ret + 1] = nest_def.nest_class
+        end
+    end
+    return ret
 end
 
 function UnitInvader:GetNestClass()
-	local species = self:Get_Nesting_Species()
-	return Presets.NestingSpeciesPreset.Default[species].nest_class
+    local species = self:Get_Nesting_Species()
+    return Presets.NestingSpeciesPreset.Default[species].nest_class
 end
 
 function UnitInvader:Get_Nesting_Species()
-	for i = 1, #Presets.NestingSpeciesPreset.Default do
-		if Presets.NestingSpeciesPreset.Default[i] then
-			local nestS = Presets.NestingSpeciesPreset.Default[i]
-			if self.SpeciesGroup == nestS.unit_species then return nestS.id end
-		end
-	end
-	return false
+    for i = 1, #Presets.NestingSpeciesPreset.Default do
+        if Presets.NestingSpeciesPreset.Default[i] then
+            local nestS = Presets.NestingSpeciesPreset.Default[i]
+            if self.SpeciesGroup == nestS.unit_species then return nestS.id end
+        end
+    end
+    return false
 end
 
 --[[
@@ -523,336 +523,336 @@ quadrants[1] = {
 }
 --]]
 function CreateMapGrid()
-	local minx, miny, maxx, maxy = GetPlayBox():xyxy()
-	NA_X_length = MulDivRound(maxx - minx, 1, 5)
-	NA_Y_length = MulDivRound(maxy - miny, 1, 5)
+    local minx, miny, maxx, maxy = GetPlayBox():xyxy()
+    NA_X_length = MulDivRound(maxx - minx, 1, 5)
+    NA_Y_length = MulDivRound(maxy - miny, 1, 5)
 
-	local species = Presets.NestingSpeciesPreset.Default
-	for _, v in ipairs(species) do
-		if v.nest_class then
-			for quadrant = 1, 25 do
-				if not Nest_scouting_quadrants[quadrant] then
-					Nest_scouting_quadrants[quadrant] = {}
-				end
-				if not Nest_scouting_quadrants[quadrant][v.id] then
-					Nest_scouting_quadrants[quadrant][v.id] = {
-						last_scout = 0,
-						player_detected = false,
-						map_objs = {},
-						other_species = {},
-					}
-				end
-			end
-		end
-	end
-	return Nest_scouting_quadrants
+    local species = Presets.NestingSpeciesPreset.Default
+    for _, v in ipairs(species) do
+        if v.nest_class then
+            for quadrant = 1, 25 do
+                if not Nest_scouting_quadrants[quadrant] then
+                    Nest_scouting_quadrants[quadrant] = {}
+                end
+                if not Nest_scouting_quadrants[quadrant][v.id] then
+                    Nest_scouting_quadrants[quadrant][v.id] = {
+                        last_scout = 0,
+                        player_detected = false,
+                        map_objs = {},
+                        other_species = {},
+                    }
+                end
+            end
+        end
+    end
+    return Nest_scouting_quadrants
 end
 
 function DebugQuadrant(no)
-	print("Quadrant: " .. no)
-	local this_quad = Nest_scouting_quadrants[no]
-	for _, species in ipairs(table.keys(this_quad)) do
-		if this_quad[species]['last_scout'] ~= 0 then
-			print("Has been explored by species: " .. species)
-			print("On day: " .. this_quad[species]['last_scout'])
-			print("And had recorded " .. #this_quad[species]['map_objs'] .. "  of other species")
-			print("Other species detected: ")
-			print(table.keys(this_quad[species]['other_species']))
-		else
-			print("Has not been explored by species: " .. species)
-		end
-	end
+    print("Quadrant: " .. no)
+    local this_quad = Nest_scouting_quadrants[no]
+    for _, species in ipairs(table.keys(this_quad)) do
+        if this_quad[species]['last_scout'] ~= 0 then
+            print("Has been explored by species: " .. species)
+            print("On day: " .. this_quad[species]['last_scout'])
+            print("And had recorded " .. #this_quad[species]['map_objs'] .. "  of other species")
+            print("Other species detected: ")
+            print(table.keys(this_quad[species]['other_species']))
+        else
+            print("Has not been explored by species: " .. species)
+        end
+    end
 end
 
 function DebugGetQuadrantSummary(quad)
-	quad = quad or 0
-	if quad < 1 then
-		for q = 1, 25 do
-			DebugQuadrant(q)
-		end
-	else
-		DebugQuadrant(quad)
-	end
+    quad = quad or 0
+    if quad < 1 then
+        for q = 1, 25 do
+            DebugQuadrant(q)
+        end
+    else
+        DebugQuadrant(quad)
+    end
 end
 
 --- Quadrant Functions
 function Get_box_from_quadrant(quadrant_number)
-	if not NA_Y_length or not NA_X_length then
-		CreateMapGrid()
-	end
-	if not quadrant_number then return end
-	--print("Making box for quadrant: ",quadrant_number,'\n')
-	local start_x, _, _, start_y = GetPlayBox():xyxy()
-	--print('\nX start',start_x,'Y start',start_y,'\n')
-	local quad_obj = Uncollapse_quad(quadrant_number)
-	local box_y_end = start_y - ((quad_obj.y - 1) * NA_Y_length)
-	local box_y_start = box_y_end - NA_Y_length
-	--print("y quad: ",quad_obj.y,'\n')
-	--print("starts at ",box_y_start," and stops at ",box_y_end,'\n')
-	local box_x_start = start_x + ((quad_obj.x - 1) * NA_X_length)
-	local box_x_end = box_x_start + NA_X_length
-	--print("x quad: ",quad_obj.x,'\n')
-	--print("starts at ",box_x_start," and stops at ",box_x_end,'\n')
-	return box(box_x_start, box_y_start, 0, box_x_end, box_y_end, 0)
+    if not NA_Y_length or not NA_X_length then
+        CreateMapGrid()
+    end
+    if not quadrant_number then return end
+    --print("Making box for quadrant: ",quadrant_number,'\n')
+    local start_x, _, _, start_y = GetPlayBox():xyxy()
+    --print('\nX start',start_x,'Y start',start_y,'\n')
+    local quad_obj = Uncollapse_quad(quadrant_number)
+    local box_y_end = start_y - ((quad_obj.y - 1) * NA_Y_length)
+    local box_y_start = box_y_end - NA_Y_length
+    --print("y quad: ",quad_obj.y,'\n')
+    --print("starts at ",box_y_start," and stops at ",box_y_end,'\n')
+    local box_x_start = start_x + ((quad_obj.x - 1) * NA_X_length)
+    local box_x_end = box_x_start + NA_X_length
+    --print("x quad: ",quad_obj.x,'\n')
+    --print("starts at ",box_x_start," and stops at ",box_x_end,'\n')
+    return box(box_x_start, box_y_start, 0, box_x_end, box_y_end, 0)
 end
 
 function Cheat_find_all_in_quadrant(quad_no, classname)
-	classname = classname or 'TerritorialNest'
-	local box = Get_box_from_quadrant(quad_no)
-	if not box then
-		--print('something went wrong getting the box!')
-		return {}
-	end
-	return MapGet(box, classname)
+    classname = classname or 'TerritorialNest'
+    local box = Get_box_from_quadrant(quad_no)
+    if not box then
+        --print('something went wrong getting the box!')
+        return {}
+    end
+    return MapGet(box, classname)
 end
 
 function compare_quad_maths(entity)
-	CreateMapGrid()
-	print("Unit is at ", entity:GetPosXYZ())
-	print('\n')
-	local quad_no = Get_quadrant_from_obj(entity, true)
-	local quad_box = Get_box_from_quadrant(quad_no)
-	print("Quad box is: \n")
-	print(quad_box)
-	print("Entity is at this position:")
-	print(entity:GetPosXYZ())
-	print("Is this entity inside the quadrants box that it reports to be in?")
-	print(is_inside_of(quad_box, entity))
+    CreateMapGrid()
+    print("Unit is at ", entity:GetPosXYZ())
+    print('\n')
+    local quad_no = Get_quadrant_from_obj(entity, true)
+    local quad_box = Get_box_from_quadrant(quad_no)
+    print("Quad box is: \n")
+    print(quad_box)
+    print("Entity is at this position:")
+    print(entity:GetPosXYZ())
+    print("Is this entity inside the quadrants box that it reports to be in?")
+    print(is_inside_of(quad_box, entity))
 end
 
 function Player_presence_in_quadrant(quad_no)
-	local box = Get_box_from_quadrant(quad_no)
-	if not box then return false end
-	local players_stuff = MapCount(box, function(thing)
-		return IsValid(thing) and thing.player
-	end)
-	print("There are ", players_stuff, ' in this quadrant!\n')
-	return players_stuff > 0
+    local box = Get_box_from_quadrant(quad_no)
+    if not box then return false end
+    local players_stuff = MapCount(box, function(thing)
+        return IsValid(thing) and thing.player
+    end)
+    print("There are ", players_stuff, ' in this quadrant!\n')
+    return players_stuff > 0
 end
 
 -- This is expected to be a map object
 function Get_quadrant_from_obj(entity, int_flag)
-	if NA_X_length == 0 or NA_Y_length == 0 then
-		CreateMapGrid()
-	end
-	local minx, miny, maxx, maxy = GetPlayBox():xyxy()
-	--print("\nStarting to count x coords at ",minx,'\n')
-	--print("Starting to count y coords at ",maxy,'but going down!\n')
-	int_flag = int_flag or false
-	local x, y, z = entity:GetPosXYZ()
-	local quad_x
-	local quad_y
-	--print("Unit is at this x position: ",x,'\n')
-	local x_rel = x - minx
-	local y_rel = y - miny
-	--print("Which is ",MulDivRound(x_rel*100,1,maxx-minx),'% across the map in x!\n')
-	--print("Unit is at this y position: ",y,'\n')
-	--print("Which is ",MulDivRound(y_rel*100,1,maxy-miny),'% across the map in y!\n')
-	for i = 1, 5, 1 do
-		if not quad_y then
-			local lowest_y = maxy - (i * NA_Y_length)
-			local highest_y = maxy - ((i - 1) * NA_Y_length)
-			print("Checking this y quadrant, ", i, '\n')
-			print('Which starts at y: ', lowest_y, ' and ends at ', highest_y, '\n')
-			if y < highest_y and y > lowest_y then
-				print("Which is more than this quadrant border: ", y, '\n')
-				quad_y = i
-			end
-		end
-	end
-	if not quad_y then
-		--print("This unit is currently out of bounds!",'\n')
-	end
+    if NA_X_length == 0 or NA_Y_length == 0 then
+        CreateMapGrid()
+    end
+    local minx, miny, maxx, maxy = GetPlayBox():xyxy()
+    --print("\nStarting to count x coords at ",minx,'\n')
+    --print("Starting to count y coords at ",maxy,'but going down!\n')
+    int_flag = int_flag or false
+    local x, y, z = entity:GetPosXYZ()
+    local quad_x
+    local quad_y
+    --print("Unit is at this x position: ",x,'\n')
+    local x_rel = x - minx
+    local y_rel = y - miny
+    --print("Which is ",MulDivRound(x_rel*100,1,maxx-minx),'% across the map in x!\n')
+    --print("Unit is at this y position: ",y,'\n')
+    --print("Which is ",MulDivRound(y_rel*100,1,maxy-miny),'% across the map in y!\n')
+    for i = 1, 5, 1 do
+        if not quad_y then
+            local lowest_y = maxy - (i * NA_Y_length)
+            local highest_y = maxy - ((i - 1) * NA_Y_length)
+            print("Checking this y quadrant, ", i, '\n')
+            print('Which starts at y: ', lowest_y, ' and ends at ', highest_y, '\n')
+            if y < highest_y and y > lowest_y then
+                print("Which is more than this quadrant border: ", y, '\n')
+                quad_y = i
+            end
+        end
+    end
+    if not quad_y then
+        --print("This unit is currently out of bounds!",'\n')
+    end
 
-	local quad_x
-	for q = 1, 5, 1 do
-		if not quad_x then
-			--print("Checking this x quadrant, ",q,'\n')
-			--print('Which starts at x: ',minx + ((q-1) * NA_X_length), ' and ends at ',minx + (q * NA_X_length),'\n')
-			local check = minx + (q * NA_X_length)
-			if x < check then
-				--print("Which is more than this quadrant border: ",x,' < ',check,'\n')
-				quad_x = q
-			end
-		end
-	end
-	if not quad_x then
-		--print("This unit is currently out of bounds!",'\n')
-	end
-	if int_flag then
-		local times_5 = quad_y - 1
-		print("Returning quadrant no: ", times_5 * 5 + quad_x, '\n')
-		return times_5 * 5 + quad_x
-	else
-		print("Returning quadrant obj: ", { x = quad_x, y = quad_y }, '\n')
-		return { x = quad_x, y = quad_y }
-	end
+    local quad_x
+    for q = 1, 5, 1 do
+        if not quad_x then
+            --print("Checking this x quadrant, ",q,'\n')
+            --print('Which starts at x: ',minx + ((q-1) * NA_X_length), ' and ends at ',minx + (q * NA_X_length),'\n')
+            local check = minx + (q * NA_X_length)
+            if x < check then
+                --print("Which is more than this quadrant border: ",x,' < ',check,'\n')
+                quad_x = q
+            end
+        end
+    end
+    if not quad_x then
+        --print("This unit is currently out of bounds!",'\n')
+    end
+    if int_flag then
+        local times_5 = quad_y - 1
+        print("Returning quadrant no: ", times_5 * 5 + quad_x, '\n')
+        return times_5 * 5 + quad_x
+    else
+        print("Returning quadrant obj: ", { x = quad_x, y = quad_y }, '\n')
+        return { x = quad_x, y = quad_y }
+    end
 end
 
 function Collapse_quad(quad_obj)
-	local times_5 = quad_obj.y - 1
-	local quad_no = (times_5 * 5) + quad_obj.x
-	return quad_no
+    local times_5 = quad_obj.y - 1
+    local quad_no = (times_5 * 5) + quad_obj.x
+    return quad_no
 end
 
 function Uncollapse_quad(quad_no)
-	local y = MulDivTrunc(quad_no - 1, 1, 5)
-	local x = quad_no - (y * 5)
-	y = y + 1
-	return { x = x, y = y }
+    local y = MulDivTrunc(quad_no - 1, 1, 5)
+    local x = quad_no - (y * 5)
+    y = y + 1
+    return { x = x, y = y }
 end
 
 function Get_adjacent_quads(quad_int)
-	local quads = {}
-	if quad_int - 1 > 0 then
-		quads[#quads + 1] = quad_int - 1
-	end
-	if quad_int + 1 <= 25 and quad_int % 5 ~= 0 then
-		quads[#quads + 1] = quad_int + 1
-	end
-	if quad_int + 5 <= 25 then
-		quads[#quads + 1] = quad_int + 5
-	end
-	if quad_int - 5 > 0 then
-		quads[#quads + 1] = quad_int - 5
-	end
-	return quads
+    local quads = {}
+    if quad_int - 1 > 0 then
+        quads[#quads + 1] = quad_int - 1
+    end
+    if quad_int + 1 <= 25 and quad_int % 5 ~= 0 then
+        quads[#quads + 1] = quad_int + 1
+    end
+    if quad_int + 5 <= 25 then
+        quads[#quads + 1] = quad_int + 5
+    end
+    if quad_int - 5 > 0 then
+        quads[#quads + 1] = quad_int - 5
+    end
+    return quads
 end
 
 function Reset_quadrant(quad_no, species)
-	Nest_scouting_quadrants[quad_no][species].last_scout = GameTime()
-	Nest_scouting_quadrants[quad_no][species].player_detected = false
-	Nest_scouting_quadrants[quad_no][species].map_objs = {}
-	Nest_scouting_quadrants[quad_no][species].other_species = {}
+    Nest_scouting_quadrants[quad_no][species].last_scout = GameTime()
+    Nest_scouting_quadrants[quad_no][species].player_detected = false
+    Nest_scouting_quadrants[quad_no][species].map_objs = {}
+    Nest_scouting_quadrants[quad_no][species].other_species = {}
 end
 
 -- Removed this function from debug mode to test scouting / overrides needed for behaviors
 function UnitInvader:DbgPrintInvaderBehaviours()
-	if not self.invader_behaviours then
-		print("never had invader behaviours")
-		return
-	end
-	if IsValidThread(self.invader_behaviours_thread) then
-		print("invader behaviours are running")
-	else
-		print("invader behaviours aren't running")
-	end
-	local previous = {}
-	local current, current_until
-	local now = GameTime()
-	if self.forced_aggression_until then
-		local str = "aggressive"
-		local against = {}
-		for _, group in ipairs(self.forced_aggression_groups) do
-			table.insert(against, "(grp)" .. group)
-		end
-		for _, label in ipairs(self.forced_aggression_labels) do
-			table.insert(against, "(lbl)" .. label)
-		end
-		for _, class in ipairs(self.forced_aggression_classes) do
-			table.insert(against, "(cls)" .. class)
-		end
-		if next(against) then
-			str = str .. " against " .. table.concat(against, ", ")
-		end
-		if now < self.forced_aggression_until then
-			current = str
-			current_until = self.forced_aggression_until
-		else
-			table.insert(previous, "aggressive")
-		end
-	elseif self.food_binge_until then
-		if now < self.food_binge_until then
-			current = "food binge"
-			current_until = self.food_binge_until
-		else
-			table.insert(previous, "food binge")
-		end
-	elseif self.time_to_despawn then
-		if now < self.time_to_despawn then
-			current = "despawn"
-			current_until = self.time_to_despawn
-		else
-			table.insert(previous, "despawn")
-		end
-	elseif self.pathing then
-		print("new behavior detected!")
-		current = "passive pathing"
-		current_until = self.path_until
-		-- inject new checks above this stay_awake_until, as this is the catchall from teh base bevahior bool
-	elseif self.combat_passive_until then
-		if now < self.combat_passive_until then
-			current = "passive"
-			current_until = self.combat_passive_until
-		else
-			table.insert(previous, "passive")
-		end
-	elseif self.stay_awake_until and
-		self.combat_rage_until == self.stay_awake_until
-	then
-		if now < self.stay_awake_until then
-			current = "berserk"
-			current_until = self.combat_rage_until
-		else
-			table.insert(previous, "berserk")
-		end
-	else
-		current = "(possibly) idle"
-		current_until = max_int
-	end
-	if next(previous) then
-		print("previous behaviours (in no particular order):")
-		for i, str in ipairs(previous) do
-			previous[i] = " - " .. str
-		end
-	end
-	if current then
-		local until_str = (current_until == max_int) and "forever" or
-			("for " .. tostring(current_until / (const.HourDuration * 1.0)) .. " more hours")
-		print("current behaviour:", current, until_str)
-	end
-	if next(self.invader_behaviours) then
-		print("future behaviours:")
-		for i, behavior in ipairs(self.invader_behaviours) do
-			print("-", _InternalTranslate(behavior.EditorView, behavior))
-		end
-	end
+    if not self.invader_behaviours then
+        print("never had invader behaviours")
+        return
+    end
+    if IsValidThread(self.invader_behaviours_thread) then
+        print("invader behaviours are running")
+    else
+        print("invader behaviours aren't running")
+    end
+    local previous = {}
+    local current, current_until
+    local now = GameTime()
+    if self.forced_aggression_until then
+        local str = "aggressive"
+        local against = {}
+        for _, group in ipairs(self.forced_aggression_groups) do
+            table.insert(against, "(grp)" .. group)
+        end
+        for _, label in ipairs(self.forced_aggression_labels) do
+            table.insert(against, "(lbl)" .. label)
+        end
+        for _, class in ipairs(self.forced_aggression_classes) do
+            table.insert(against, "(cls)" .. class)
+        end
+        if next(against) then
+            str = str .. " against " .. table.concat(against, ", ")
+        end
+        if now < self.forced_aggression_until then
+            current = str
+            current_until = self.forced_aggression_until
+        else
+            table.insert(previous, "aggressive")
+        end
+    elseif self.food_binge_until then
+        if now < self.food_binge_until then
+            current = "food binge"
+            current_until = self.food_binge_until
+        else
+            table.insert(previous, "food binge")
+        end
+    elseif self.time_to_despawn then
+        if now < self.time_to_despawn then
+            current = "despawn"
+            current_until = self.time_to_despawn
+        else
+            table.insert(previous, "despawn")
+        end
+    elseif self.pathing then
+        print("new behavior detected!")
+        current = "passive pathing"
+        current_until = self.path_until
+        -- inject new checks above this stay_awake_until, as this is the catchall from teh base bevahior bool
+    elseif self.combat_passive_until then
+        if now < self.combat_passive_until then
+            current = "passive"
+            current_until = self.combat_passive_until
+        else
+            table.insert(previous, "passive")
+        end
+    elseif self.stay_awake_until and
+        self.combat_rage_until == self.stay_awake_until
+    then
+        if now < self.stay_awake_until then
+            current = "berserk"
+            current_until = self.combat_rage_until
+        else
+            table.insert(previous, "berserk")
+        end
+    else
+        current = "(possibly) idle"
+        current_until = max_int
+    end
+    if next(previous) then
+        print("previous behaviours (in no particular order):")
+        for i, str in ipairs(previous) do
+            previous[i] = " - " .. str
+        end
+    end
+    if current then
+        local until_str = (current_until == max_int) and "forever" or
+            ("for " .. tostring(current_until / (const.HourDuration * 1.0)) .. " more hours")
+        print("current behaviour:", current, until_str)
+    end
+    if next(self.invader_behaviours) then
+        print("future behaviours:")
+        for i, behavior in ipairs(self.invader_behaviours) do
+            print("-", _InternalTranslate(behavior.EditorView, behavior))
+        end
+    end
 end
 
 function TestConnectivityRandomTile(center)
-	DbgClear()
+    DbgClear()
 
-	center = center or SelectedObj or GameStartPos
+    center = center or SelectedObj or GameStartPos
 
-	local nests = MapGet("map", "TerritorialNest")
-	local function filter_far_from_nest(x, y)
-		-- check for distance to shrieker nests
-		for _, nest in ipairs(nests or empty_table) do
-			if nest:IsCloser2D(x, y, nest.territorial_range) then
-				return false
-			end
-		end
-		return true
-	end
-	local x, y
-	local seed = InteractionRand(nil, "LandHuman")
-	local max_dist, min_dist = const.Gameplay.SurvivorSpawnNearBaseMaxRadius,
-		const.Gameplay.SurvivorSpawnNearBaseMinRadius
-	local origin = terrain.FindAreaPassable(center, 4086, 64 * guim, Human.pfclass)
+    local nests = MapGet("map", "TerritorialNest")
+    local function filter_far_from_nest(x, y)
+        -- check for distance to shrieker nests
+        for _, nest in ipairs(nests or empty_table) do
+            if nest:IsCloser2D(x, y, nest.territorial_range) then
+                return false
+            end
+        end
+        return true
+    end
+    local x, y
+    local seed = InteractionRand(nil, "LandHuman")
+    local max_dist, min_dist = const.Gameplay.SurvivorSpawnNearBaseMaxRadius,
+        const.Gameplay.SurvivorSpawnNearBaseMinRadius
+    local origin = terrain.FindAreaPassable(center, 4086, 64 * guim, Human.pfclass)
 
-	local stA = GetPreciseTicks(1000000)
-	local pos = ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096,
-		filter_far_from_nest)
-	local timeA = GetPreciseTicks(1000000) - stA
+    local stA = GetPreciseTicks(1000000)
+    local pos = ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096,
+        filter_far_from_nest)
+    local timeA = GetPreciseTicks(1000000) - stA
 
-	DbgAddVector(origin, 15 * guim, red)
-	DbgAddVector(center, 10 * guim, blue)
-	DbgAddCircle(center, min_dist, blue)
-	DbgAddCircle(center, max_dist, yellow)
-	if pos then
-		DbgAddVector(pos, 10 * guim, green)
-		DbgAddSegment(origin, pos)
-	end
+    DbgAddVector(origin, 15 * guim, red)
+    DbgAddVector(center, 10 * guim, blue)
+    DbgAddCircle(center, min_dist, blue)
+    DbgAddCircle(center, max_dist, yellow)
+    if pos then
+        DbgAddVector(pos, 10 * guim, green)
+        DbgAddSegment(origin, pos)
+    end
 
-	print("pos", pos, "time", timeA / 1000.0)
+    print("pos", pos, "time", timeA / 1000.0)
 end

--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -1,19 +1,19 @@
 -------------------- MOD SETUP ---------------------
 local hour_duration = const.HourDuration
 
-MapVar("Global_nest_spawn_cd",0)
-MapVar("Nest_Notifications",1)
-MapVar("Nest_Species_Savegame_Stats",{})
-MapVar("Faction_aggression_threshold",0)
-MapVar("Nest_tutorial",false)
-MapVar("Nest_upgrade",false)
-MapVar("Per_species_nest_max",13)
-MapVar("Max_nests_allowed",20)
-MapVar('Nest_scouting_quadrants',{})
-MapVar('NA_Y_length',0)
-MapVar('NA_X_length',0)
-MapVar('NA_NestRoleZoom',3)
-MapVar('NA_NestRoleName',false)
+MapVar("Global_nest_spawn_cd", 0)
+MapVar("Nest_Notifications", 1)
+MapVar("Nest_Species_Savegame_Stats", {})
+MapVar("Faction_aggression_threshold", 0)
+MapVar("Nest_tutorial", false)
+MapVar("Nest_upgrade", false)
+MapVar("Per_species_nest_max", 13)
+MapVar("Max_nests_allowed", 20)
+MapVar('Nest_scouting_quadrants', {})
+MapVar('NA_Y_length', 0)
+MapVar('NA_X_length', 0)
+MapVar('NA_NestRoleZoom', 3)
+MapVar('NA_NestRoleName', false)
 
 function NA_Mod_Set(id)
 	id = id or CurrentModId
@@ -30,7 +30,7 @@ function NA_Mod_Set(id)
 	elseif nest_notif == 'Do not Alert me (<style TextNegative>Warning Dangerous</style>)' then
 		nest_level = 0
 	end
-	Nest_Notifications=nest_level
+	Nest_Notifications = nest_level
 	local per_species = options.max_nest
 	Per_species_nest_max = per_species or 13
 	Max_nests_allowed = options.max_global_nests or 15
@@ -39,7 +39,7 @@ function NA_Mod_Set(id)
 		NA_NestRoleZoom = 3
 	elseif visual_selection == 'Far (~80 meters)' then
 		NA_NestRoleZoom = 2
-	elseif visual_selection =='Close (Same as Resource Piles) (~20 meters)' then
+	elseif visual_selection == 'Close (Same as Resource Piles) (~20 meters)' then
 		NA_NestRoleZoom = 1
 	elseif visual_selection == 'Always off' then
 		NA_NestRoleZoom = 0
@@ -50,8 +50,6 @@ function NA_Mod_Set(id)
 		NA_NestRoleName = false
 	end
 end
-
-
 
 function Setup_nest_mod()
 	CreateGameTimeThread(function()
@@ -66,24 +64,24 @@ function Setup_nest_mod()
 					spawnflag = true
 				end
 				Nest_Species_Savegame_Stats[v.id] = {}
-				Nest_Species_Savegame_Stats[v.id][v.id..'_nest_spawn_cd']=0
-				Nest_Species_Savegame_Stats[v.id][v.id..'_evo_cd']=0
-				Nest_Species_Savegame_Stats[v.id][v.id..'_stored_aggr']=0
-				Nest_Species_Savegame_Stats[v.id][v.id..'_aggro_events']=0
-				Nest_Species_Savegame_Stats[v.id]['spawnflag']=spawnflag
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
+				Nest_Species_Savegame_Stats[v.id]['spawnflag'] = spawnflag
 			end
 		end
 		if Nest_scouting_quadrants == {} then
 			CreateMapGrid()
 		end
-		Faction_aggression_threshold = Max(0,6 - Get_difficulty_offset())
+		Faction_aggression_threshold = Max(0, 6 - Get_difficulty_offset())
 		Msg("UpdateNestRoleVisuals")
 	end)
 end
 
 OnMsg.ApplyModOptions = NA_Mod_Set
 OnMsg.GameStarted = Setup_nest_mod -- first start
-OnMsg.LoadGame = Setup_nest_mod -- savegame load
+OnMsg.LoadGame = Setup_nest_mod    -- savegame load
 
 
 -- note we are switching cases, and no MapVar in use should start with a lowercase character
@@ -129,28 +127,28 @@ function SavegameFixups.NA_MapVarCleanup()
 		if v.nest_class then
 			if not Nest_Species_Savegame_Stats[v.id] then
 				Nest_Species_Savegame_Stats[v.id] = {}
-				Nest_Species_Savegame_Stats[v.id][v.id..'_nest_spawn_cd']=0
-				Nest_Species_Savegame_Stats[v.id][v.id..'_evo_cd']=0
-				Nest_Species_Savegame_Stats[v.id][v.id..'_stored_aggr']=0
-				Nest_Species_Savegame_Stats[v.id][v.id..'_aggro_events']=0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = 0
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = 0
 			end
-			if MapVarValues[v.id..'_nest_spawn_cd'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id..'_nest_spawn_cd'] = MapVarValues[v.id..'_nest_spawn_cd']
+			if MapVarValues[v.id .. '_nest_spawn_cd'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_nest_spawn_cd'] = MapVarValues[v.id .. '_nest_spawn_cd']
 				-- we are not resetting this MapVar because we will never use this MapVar
 				flag = true
 			end
-			if MapVarValues[v.id..'_evo_cd'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id..'_evo_cd'] = MapVarValues[v.id..'_evo_cd']
+			if MapVarValues[v.id .. '_evo_cd'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_evo_cd'] = MapVarValues[v.id .. '_evo_cd']
 				-- we are not resetting this MapVar because we will never use this MapVar
 				flag = true
 			end
-			if MapVarValues[v.id..'_stored_aggr'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id..'_stored_aggr'] = MapVarValues[v.id..'_stored_aggr']
+			if MapVarValues[v.id .. '_stored_aggr'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_stored_aggr'] = MapVarValues[v.id .. '_stored_aggr']
 				-- we are not resetting this MapVar because we will never use this MapVar
 				flag = true
 			end
-			if MapVarValues[v.id..'_aggro_events'] ~= 0 then
-				Nest_Species_Savegame_Stats[v.id][v.id..'_aggro_events'] = MapVarValues[v.id..'_aggro_events']
+			if MapVarValues[v.id .. '_aggro_events'] ~= 0 then
+				Nest_Species_Savegame_Stats[v.id][v.id .. '_aggro_events'] = MapVarValues[v.id .. '_aggro_events']
 				-- we are not resetting this MapVar because we will never use this MapVar
 				flag = true
 			end
@@ -160,7 +158,6 @@ function SavegameFixups.NA_MapVarCleanup()
 		Bkob_Log("NA had to clean up some vars!")
 	end
 end
-
 
 --------------- SAVEGAME FIXUPS ---------------
 -- brute force method.... not ideal
@@ -176,13 +173,12 @@ function SavegameFixups.NA_Disaster_clean()
 	end
 end
 
-
 function SavegameFixups.Nest_cap_clean()
 	Align_global_nest_cap()
 end
 
 function Align_global_nest_cap()
-	local nests = MapGet(true,"TerritorialNest")
+	local nests = MapGet(true, "TerritorialNest")
 	local cap = Max_nests_allowed
 	if not cap then
 		cap = 19
@@ -192,7 +188,7 @@ function Align_global_nest_cap()
 	if #nests > (cap) then
 		DebugPrint("Still need to delete!")
 		local types = ClassDescendantsList('TerritorialNest')
-		local min = DivRound(cap,#types) - 1
+		local min = DivRound(cap, #types) - 1
 		local needed_delete = #nests - cap
 		local saved = {}
 		local count = 0
@@ -200,7 +196,7 @@ function Align_global_nest_cap()
 			DebugPrint("looking at this nest: ")
 			DebugPrint(count)
 			count = count + 1
-			if saved[nest.class] and saved[nest.class] > min  and needed_delete > 0 then
+			if saved[nest.class] and saved[nest.class] > min and needed_delete > 0 then
 				DebugPrint("Deleting this nest!")
 				-- delete
 				local members = nest.nest_members
@@ -229,9 +225,8 @@ function Align_global_nest_cap()
 	end
 end
 
-
 ------------------------------ HELPER FUNCTIONS ------------------------------
-function Bkob_Log_NA(hard_string,var)
+function Bkob_Log_NA(hard_string, var)
 	DebugPrint(hard_string)
 	if var then
 		DebugPrint(var)
@@ -264,37 +259,37 @@ function find_nest_species(input)
 end
 
 function Get_difficulty_offset()
-    local difficulty_offset = 2
-    local difficulty = GetGameDifficulty()
-    if difficulty == 'Easy' then
-        difficulty_offset = 1
-    elseif difficulty == 'Medium' then
-        difficulty_offset = 2
-    elseif difficulty == 'Hard' then
-        difficulty_offset = 3
-    elseif difficulty == 'VeryHard' then
-        difficulty_offset = 4
-    elseif difficulty == 'Insane' then
-        difficulty_offset = 5
-    elseif difficulty == 'PXImpossible' then
-        difficulty_offset = 6
-    else
-        difficulty_offset = 7
-    end
-    return difficulty_offset
+	local difficulty_offset = 2
+	local difficulty = GetGameDifficulty()
+	if difficulty == 'Easy' then
+		difficulty_offset = 1
+	elseif difficulty == 'Medium' then
+		difficulty_offset = 2
+	elseif difficulty == 'Hard' then
+		difficulty_offset = 3
+	elseif difficulty == 'VeryHard' then
+		difficulty_offset = 4
+	elseif difficulty == 'Insane' then
+		difficulty_offset = 5
+	elseif difficulty == 'PXImpossible' then
+		difficulty_offset = 6
+	else
+		difficulty_offset = 7
+	end
+	return difficulty_offset
 end
 
 --assuming a string of the nest class
 function get_species_from_nest(nest_class)
 	local found = false
-	for _,v in ipairs(ClassDescendantsList('TerritorialNest')) do
+	for _, v in ipairs(ClassDescendantsList('TerritorialNest')) do
 		if v == nest_class then
 			found = true
 		end
 	end
 	if not found then return end
 	local entries = #Presets.NestingSpeciesPreset.Default
-	for i=1, entries do
+	for i = 1, entries do
 		local species = Presets.NestingSpeciesPreset.Default[i]
 		if species and species.unit_species then
 			if species.nest_class == nest_class then
@@ -307,29 +302,29 @@ end
 function Get_nest_species_by_region(region)
 	region = region or Region.id
 	DebugPrint("Getting nest class id by region\n")
-    if region == 'Desertum' then
-        return get_species_from_nest('ShriekerNest')
-    elseif region == 'Sobrius' then
-        return get_species_from_nest("ShriekerNest")
-    elseif region == 'Saltu' then
-        return get_species_from_nest('ScissorhandsNest')
+	if region == 'Desertum' then
+		return get_species_from_nest('ShriekerNest')
+	elseif region == 'Sobrius' then
+		return get_species_from_nest("ShriekerNest")
+	elseif region == 'Saltu' then
+		return get_species_from_nest('ScissorhandsNest')
 	else
 		return get_species_from_nest('ShriekerNest')
-    end
+	end
 end
 
 function Get_nest_entity_by_region(region)
 	region = region or Region.id
 	DebugPrint("Getting nest class id by region\n")
-    if region == 'Desertum' then
-        return ('ShriekerNest')
-    elseif region == 'Sobrius' then
-        return get_species_from_nest("ShriekerNest")
-    elseif region == 'Saltu' then
-        return get_species_from_nest('ScissorhandsNest')
+	if region == 'Desertum' then
+		return ('ShriekerNest')
+	elseif region == 'Sobrius' then
+		return get_species_from_nest("ShriekerNest")
+	elseif region == 'Saltu' then
+		return get_species_from_nest('ScissorhandsNest')
 	else
 		return get_species_from_nest('ShriekerNest')
-    end
+	end
 end
 
 function Is_DLC_Present()
@@ -345,8 +340,9 @@ function mark_spawned_nest(nest_type)
 	print(species_def)
 	local species_id = species_def.id
 	print(species_id)
-	if Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_id..'_nest_spawn_cd'] then
-		Nest_Species_Savegame_Stats[species_id][species_id..'_nest_spawn_cd'] = GameTime() + (MoonInstance.AttackCooldownMin * 3)
+	if Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] then
+		Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] = GameTime() +
+			(MoonInstance.AttackCooldownMin * 3)
 	else
 		DebugPrint("Nesting species does not have an entry in map vars for their nest spawn cd! Alert mod author!")
 	end
@@ -355,9 +351,9 @@ end
 function NA_log_nest_evolved(nest)
 	local notif_level = Nest_Notifications or 1
 	if notif_level == 2 then
-		ForceActivateStoryBit('nests_evolving',self,true)
+		ForceActivateStoryBit('nests_evolving', self, true)
 	elseif notif_level == 1 then
-		AddGameNotification("nests_evolving", nil, nil, {nest})
+		AddGameNotification("nests_evolving", nil, nil, { nest })
 	end
 end
 
@@ -368,24 +364,24 @@ function NA_tutorial()
 end
 
 function Get_center_of_survivors()
-    local surv = GetValidSurvivorsOnMap()
-    local sum_x = 0
-    local sum_y = 0
-    local count = 0
-    local x = 0
-    local y = 0
-    for _,v in ipairs(surv) do
-        x,y,_ = v:GetVisualPosXYZ()
-        sum_x = sum_x + x
-        sum_y = sum_y + y
-        count = count + 1
-    end
-    if count == 0 then
-        -- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
-        return GetMapBox():Center()
-    end
-    local center = point(DivRound(sum_x,count),DivRound(sum_y,count))
-    return center
+	local surv = GetValidSurvivorsOnMap()
+	local sum_x = 0
+	local sum_y = 0
+	local count = 0
+	local x = 0
+	local y = 0
+	for _, v in ipairs(surv) do
+		x, y, _ = v:GetVisualPosXYZ()
+		sum_x = sum_x + x
+		sum_y = sum_y + y
+		count = count + 1
+	end
+	if count == 0 then
+		-- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
+		return GetMapBox():Center()
+	end
+	local center = point(DivRound(sum_x, count), DivRound(sum_y, count))
+	return center
 end
 
 function NA_QA(full_log)
@@ -396,9 +392,9 @@ function NA_QA(full_log)
 	full_log = full_log or false
 	EE_debug = full_log
 	print("Testing regions default nests")
-	print(Get_nest_entity_by_region('Desertum')=='nesting_shriekers')
-	print(Get_nest_entity_by_region('Sobrius')=='nesting_shriekers')
-	print(Get_nest_entity_by_region('Saltu')=='nesting_scissorhands')
+	print(Get_nest_entity_by_region('Desertum') == 'nesting_shriekers')
+	print(Get_nest_entity_by_region('Sobrius') == 'nesting_shriekers')
+	print(Get_nest_entity_by_region('Saltu') == 'nesting_scissorhands')
 	--assert(Get_nest_by_region('Desertum')=='nesting_shriekers')
 	--assert(Get_nest_by_region('Sobrius')=='nesting_shriekers')
 	--assert(Get_nest_by_region('Saltu')=='nesting_scissorhands')
@@ -412,12 +408,12 @@ function NA_QA(full_log)
 			ForceActivateStoryBit(v.spawner_storybit, nil, "immediate", nil, true)
 		end
 		CreateRealTimeThread(function(nestclass)
-			print("Testing nest: "..nestclass)
+			print("Testing nest: " .. nestclass)
 			Sleep(5000)
-			local nest_on_map = MapGetFirst(true,nestclass)
-			local EP_nums = {100, 800, 1200, 5000, 15000, 30000, 75000, 140000,300000}
+			local nest_on_map = MapGetFirst(true, nestclass)
+			local EP_nums = { 100, 800, 1200, 5000, 15000, 30000, 75000, 140000, 300000 }
 			local def = g_Classes[nestclass]
-			local attack_at = GameTime() + (2*hour_duration)
+			local attack_at = GameTime() + (2 * hour_duration)
 			local attacked = false
 			local deleted = false
 			local og_hatch = def.hatchling_class
@@ -430,23 +426,23 @@ function NA_QA(full_log)
 				nest.elder_class = og_elder
 			end
 			nest_on_map:expand()
-			for i=1, 10 do
+			for i = 1, 10 do
 				nest_on_map:consume_closest_node()
 			end
 			nest_on_map:SwitchState("sleepy")
-			print("State should be sleepy: "..nest_on_map.state)
+			print("State should be sleepy: " .. nest_on_map.state)
 			nest_on_map:SwitchState("awake")
-			print("State should be awake: "..nest_on_map.state)
+			print("State should be awake: " .. nest_on_map.state)
 			nest_on_map:SwitchState("asleep")
-			print("State should be asleep: "..nest_on_map.state)
-			for _,int in ipairs(EP_nums) do
+			print("State should be asleep: " .. nest_on_map.state)
+			for _, int in ipairs(EP_nums) do
 				print("Testing with EP: ")
 				print(int)
 				EventProgress = int
 				local correct_elder = elder_chain:get_correct_evo(int)
 				nest_on_map:change_nest_herd()
 				local possible = #correct_elder
-				table.insert_unique(correct_elder,nest_on_map.elder_class)
+				table.insert_unique(correct_elder, nest_on_map.elder_class)
 				if possible ~= #correct_elder then
 					print("Something went wrong evolving!")
 				end
@@ -459,14 +455,14 @@ function NA_QA(full_log)
 	end
 	print("Testing resources!")
 	local res_table = get_nest_res_table()
-	for _,res in ipairs(table.keys(res_table)) do
+	for _, res in ipairs(table.keys(res_table)) do
 		print(res)
-		for _,species_entry in ipairs(res_table[res]) do
-			print("This should aggro: "..species_entry.species)
+		for _, species_entry in ipairs(res_table[res]) do
+			print("This should aggro: " .. species_entry.species)
 			local to_send = {}
-			to_send[res]=species_entry.chance
+			to_send[res] = species_entry.chance
 			print(to_send)
-			for i=1,20 do
+			for i = 1, 20 do
 				Resource_aggression_check(to_send)
 			end
 		end
@@ -476,7 +472,7 @@ end
 
 function Get_species_nests()
 	local ret = {}
-	for i=1, #Presets.NestingSpeciesPreset.Default do
+	for i = 1, #Presets.NestingSpeciesPreset.Default do
 		local nest_def = Presets.NestingSpeciesPreset.Default[i]
 		if nest_def and nest_def.nest_class then
 			ret[#ret + 1] = nest_def.nest_class
@@ -491,7 +487,7 @@ function UnitInvader:GetNestClass()
 end
 
 function UnitInvader:Get_Nesting_Species()
-	for i=1, #Presets.NestingSpeciesPreset.Default do
+	for i = 1, #Presets.NestingSpeciesPreset.Default do
 		if Presets.NestingSpeciesPreset.Default[i] then
 			local nestS = Presets.NestingSpeciesPreset.Default[i]
 			if self.SpeciesGroup == nestS.unit_species then return nestS.id end
@@ -528,8 +524,8 @@ quadrants[1] = {
 --]]
 function CreateMapGrid()
 	local minx, miny, maxx, maxy = GetPlayBox():xyxy()
-	NA_X_length = MulDivRound(maxx - minx,1,5)
-	NA_Y_length = MulDivRound(maxy - miny,1,5)
+	NA_X_length = MulDivRound(maxx - minx, 1, 5)
+	NA_Y_length = MulDivRound(maxy - miny, 1, 5)
 
 	local species = Presets.NestingSpeciesPreset.Default
 	for _, v in ipairs(species) do
@@ -553,17 +549,17 @@ function CreateMapGrid()
 end
 
 function DebugQuadrant(no)
-	print("Quadrant: "..no)
+	print("Quadrant: " .. no)
 	local this_quad = Nest_scouting_quadrants[no]
-	for _,species in ipairs(table.keys(this_quad)) do
+	for _, species in ipairs(table.keys(this_quad)) do
 		if this_quad[species]['last_scout'] ~= 0 then
-			print("Has been explored by species: "..species)
-			print("On day: "..this_quad[species]['last_scout'])
-			print("And had recorded "..#this_quad[species]['map_objs'].."  of other species")
+			print("Has been explored by species: " .. species)
+			print("On day: " .. this_quad[species]['last_scout'])
+			print("And had recorded " .. #this_quad[species]['map_objs'] .. "  of other species")
 			print("Other species detected: ")
 			print(table.keys(this_quad[species]['other_species']))
 		else
-			print("Has not been explored by species: "..species)
+			print("Has not been explored by species: " .. species)
 		end
 	end
 end
@@ -588,19 +584,19 @@ function Get_box_from_quadrant(quadrant_number)
 	--print("Making box for quadrant: ",quadrant_number,'\n')
 	local start_x, _, _, start_y = GetPlayBox():xyxy()
 	--print('\nX start',start_x,'Y start',start_y,'\n')
- 	local quad_obj = Uncollapse_quad(quadrant_number)
-	local box_y_end = start_y - ((quad_obj.y-1) * NA_Y_length)
+	local quad_obj = Uncollapse_quad(quadrant_number)
+	local box_y_end = start_y - ((quad_obj.y - 1) * NA_Y_length)
 	local box_y_start = box_y_end - NA_Y_length
 	--print("y quad: ",quad_obj.y,'\n')
 	--print("starts at ",box_y_start," and stops at ",box_y_end,'\n')
-	local box_x_start = start_x + ((quad_obj.x-1) * NA_X_length)
+	local box_x_start = start_x + ((quad_obj.x - 1) * NA_X_length)
 	local box_x_end = box_x_start + NA_X_length
 	--print("x quad: ",quad_obj.x,'\n')
 	--print("starts at ",box_x_start," and stops at ",box_x_end,'\n')
 	return box(box_x_start, box_y_start, 0, box_x_end, box_y_end, 0)
 end
 
-function Cheat_find_all_in_quadrant(quad_no,classname)
+function Cheat_find_all_in_quadrant(quad_no, classname)
 	classname = classname or 'TerritorialNest'
 	local box = Get_box_from_quadrant(quad_no)
 	if not box then
@@ -612,30 +608,30 @@ end
 
 function compare_quad_maths(entity)
 	CreateMapGrid()
-	print("Unit is at ",entity:GetPosXYZ())
+	print("Unit is at ", entity:GetPosXYZ())
 	print('\n')
-	local quad_no = Get_quadrant_from_obj(entity,true)
+	local quad_no = Get_quadrant_from_obj(entity, true)
 	local quad_box = Get_box_from_quadrant(quad_no)
 	print("Quad box is: \n")
 	print(quad_box)
 	print("Entity is at this position:")
 	print(entity:GetPosXYZ())
 	print("Is this entity inside the quadrants box that it reports to be in?")
-	print(is_inside_of(quad_box,entity))
+	print(is_inside_of(quad_box, entity))
 end
 
 function Player_presence_in_quadrant(quad_no)
 	local box = Get_box_from_quadrant(quad_no)
 	if not box then return false end
-	local players_stuff = MapCount(box,function(thing)
+	local players_stuff = MapCount(box, function(thing)
 		return IsValid(thing) and thing.player
 	end)
-	print("There are ",players_stuff,' in this quadrant!\n')
+	print("There are ", players_stuff, ' in this quadrant!\n')
 	return players_stuff > 0
 end
 
 -- This is expected to be a map object
-function Get_quadrant_from_obj(entity,int_flag)
+function Get_quadrant_from_obj(entity, int_flag)
 	if NA_X_length == 0 or NA_Y_length == 0 then
 		CreateMapGrid()
 	end
@@ -643,7 +639,7 @@ function Get_quadrant_from_obj(entity,int_flag)
 	--print("\nStarting to count x coords at ",minx,'\n')
 	--print("Starting to count y coords at ",maxy,'but going down!\n')
 	int_flag = int_flag or false
-	local x,y,z = entity:GetPosXYZ()
+	local x, y, z = entity:GetPosXYZ()
 	local quad_x
 	local quad_y
 	--print("Unit is at this x position: ",x,'\n')
@@ -655,11 +651,11 @@ function Get_quadrant_from_obj(entity,int_flag)
 	for i = 1, 5, 1 do
 		if not quad_y then
 			local lowest_y = maxy - (i * NA_Y_length)
-			local highest_y = maxy - ((i-1) * NA_Y_length)
-			print("Checking this y quadrant, ",i,'\n')
-			print('Which starts at y: ',lowest_y, ' and ends at ',highest_y,'\n')
+			local highest_y = maxy - ((i - 1) * NA_Y_length)
+			print("Checking this y quadrant, ", i, '\n')
+			print('Which starts at y: ', lowest_y, ' and ends at ', highest_y, '\n')
 			if y < highest_y and y > lowest_y then
-				print("Which is more than this quadrant border: ",y,'\n')
+				print("Which is more than this quadrant border: ", y, '\n')
 				quad_y = i
 			end
 		end
@@ -685,11 +681,11 @@ function Get_quadrant_from_obj(entity,int_flag)
 	end
 	if int_flag then
 		local times_5 = quad_y - 1
-		print("Returning quadrant no: ",times_5 * 5 + quad_x,'\n')
+		print("Returning quadrant no: ", times_5 * 5 + quad_x, '\n')
 		return times_5 * 5 + quad_x
 	else
-		print("Returning quadrant obj: ",{x = quad_x, y = quad_y},'\n')
-		return {x = quad_x, y = quad_y}
+		print("Returning quadrant obj: ", { x = quad_x, y = quad_y }, '\n')
+		return { x = quad_x, y = quad_y }
 	end
 end
 
@@ -700,36 +696,35 @@ function Collapse_quad(quad_obj)
 end
 
 function Uncollapse_quad(quad_no)
-	local y = MulDivTrunc(quad_no-1, 1, 5)
+	local y = MulDivTrunc(quad_no - 1, 1, 5)
 	local x = quad_no - (y * 5)
 	y = y + 1
-	return {x = x, y = y}
+	return { x = x, y = y }
 end
 
 function Get_adjacent_quads(quad_int)
 	local quads = {}
 	if quad_int - 1 > 0 then
-		quads[#quads+1]= quad_int-1
+		quads[#quads + 1] = quad_int - 1
 	end
-	if quad_int + 1 <= 25  and quad_int % 5 ~= 0 then
-		quads[#quads+1]= quad_int+1
+	if quad_int + 1 <= 25 and quad_int % 5 ~= 0 then
+		quads[#quads + 1] = quad_int + 1
 	end
 	if quad_int + 5 <= 25 then
-		quads[#quads+1]= quad_int+5
+		quads[#quads + 1] = quad_int + 5
 	end
 	if quad_int - 5 > 0 then
-		quads[#quads+1]= quad_int-5
+		quads[#quads + 1] = quad_int - 5
 	end
 	return quads
 end
 
-function Reset_quadrant(quad_no,species)
+function Reset_quadrant(quad_no, species)
 	Nest_scouting_quadrants[quad_no][species].last_scout = GameTime()
 	Nest_scouting_quadrants[quad_no][species].player_detected = false
 	Nest_scouting_quadrants[quad_no][species].map_objs = {}
 	Nest_scouting_quadrants[quad_no][species].other_species = {}
 end
-
 
 -- Removed this function from debug mode to test scouting / overrides needed for behaviors
 function UnitInvader:DbgPrintInvaderBehaviours()
@@ -749,13 +744,13 @@ function UnitInvader:DbgPrintInvaderBehaviours()
 		local str = "aggressive"
 		local against = {}
 		for _, group in ipairs(self.forced_aggression_groups) do
-			table.insert(against, "(grp)"..group)
+			table.insert(against, "(grp)" .. group)
 		end
 		for _, label in ipairs(self.forced_aggression_labels) do
-			table.insert(against, "(lbl)"..label)
+			table.insert(against, "(lbl)" .. label)
 		end
 		for _, class in ipairs(self.forced_aggression_classes) do
-			table.insert(against, "(cls)"..class)
+			table.insert(against, "(cls)" .. class)
 		end
 		if next(against) then
 			str = str .. " against " .. table.concat(against, ", ")
@@ -784,7 +779,7 @@ function UnitInvader:DbgPrintInvaderBehaviours()
 		print("new behavior detected!")
 		current = "passive pathing"
 		current_until = self.path_until
-	-- inject new checks above this stay_awake_until, as this is the catchall from teh base bevahior bool
+		-- inject new checks above this stay_awake_until, as this is the catchall from teh base bevahior bool
 	elseif self.combat_passive_until then
 		if now < self.combat_passive_until then
 			current = "passive"
@@ -801,7 +796,6 @@ function UnitInvader:DbgPrintInvaderBehaviours()
 		else
 			table.insert(previous, "berserk")
 		end
-
 	else
 		current = "(possibly) idle"
 		current_until = max_int
@@ -813,7 +807,8 @@ function UnitInvader:DbgPrintInvaderBehaviours()
 		end
 	end
 	if current then
-		local until_str = (current_until == max_int) and "forever" or ("for " .. tostring(current_until / (const.HourDuration*1.0)) .. " more hours")
+		local until_str = (current_until == max_int) and "forever" or
+			("for " .. tostring(current_until / (const.HourDuration * 1.0)) .. " more hours")
 		print("current behaviour:", current, until_str)
 	end
 	if next(self.invader_behaviours) then
@@ -826,9 +821,9 @@ end
 
 function TestConnectivityRandomTile(center)
 	DbgClear()
-	
+
 	center = center or SelectedObj or GameStartPos
-	
+
 	local nests = MapGet("map", "TerritorialNest")
 	local function filter_far_from_nest(x, y)
 		-- check for distance to shrieker nests
@@ -841,21 +836,23 @@ function TestConnectivityRandomTile(center)
 	end
 	local x, y
 	local seed = InteractionRand(nil, "LandHuman")
-	local max_dist, min_dist = const.Gameplay.SurvivorSpawnNearBaseMaxRadius, const.Gameplay.SurvivorSpawnNearBaseMinRadius
-	local origin = terrain.FindAreaPassable(center, 4086, 64*guim, Human.pfclass)
-	
+	local max_dist, min_dist = const.Gameplay.SurvivorSpawnNearBaseMaxRadius,
+		const.Gameplay.SurvivorSpawnNearBaseMinRadius
+	local origin = terrain.FindAreaPassable(center, 4086, 64 * guim, Human.pfclass)
+
 	local stA = GetPreciseTicks(1000000)
-	local pos = ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096, filter_far_from_nest)
+	local pos = ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096,
+		filter_far_from_nest)
 	local timeA = GetPreciseTicks(1000000) - stA
-	
-	DbgAddVector(origin, 15*guim, red)
-	DbgAddVector(center, 10*guim, blue)
+
+	DbgAddVector(origin, 15 * guim, red)
+	DbgAddVector(center, 10 * guim, blue)
 	DbgAddCircle(center, min_dist, blue)
 	DbgAddCircle(center, max_dist, yellow)
 	if pos then
-		DbgAddVector(pos, 10*guim, green)
+		DbgAddVector(pos, 10 * guim, green)
 		DbgAddSegment(origin, pos)
 	end
-	
+
 	print("pos", pos, "time", timeA / 1000.0)
 end

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -4,31 +4,32 @@ local hours_per_day = day_duration / hour_duration
 
 
 function Juno_Cancer(force)
-	local nests = {}
-	if force then
-		nests = MapGet(true,'TerritorialNest',function(nest)
-		if nest.class ~= 'JunoNest' then return true end end)
-	else
-		nests = MapGet(true,'TerritorialNest',function(nest)
-			if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
-				return true
-			end
-		end)
-	end
-	if #nests > 0 then
-		local roll = AsyncRand(#nests)
-		local to_convert = nests[roll]
-		Convert_nest_into(to_convert,'nesting_juno')
-	elseif force then
-	end
+    local nests = {}
+    if force then
+        nests = MapGet(true, 'TerritorialNest', function(nest)
+            if nest.class ~= 'JunoNest' then return true end
+        end)
+    else
+        nests = MapGet(true, 'TerritorialNest', function(nest)
+            if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
+                return true
+            end
+        end)
+    end
+    if #nests > 0 then
+        local roll = AsyncRand(#nests)
+        local to_convert = nests[roll]
+        Convert_nest_into(to_convert, 'nesting_juno')
+    elseif force then
+    end
 end
 
 function SpawnNestInsideMap(marker, seed, nest_type, danger_lvl)
-	DebugPrint("Spawning a nest\n")
-	if marker and terrain.IsWater(marker) then
-		return
-	end
-	-- danger level does nothing right now, not part of MVP
+    DebugPrint("Spawning a nest\n")
+    if marker and terrain.IsWater(marker) then
+        return
+    end
+    -- danger level does nothing right now, not part of MVP
     danger_lvl = danger_lvl or 1
     seed = seed or InteractionRand(nil, "DailySpawn")
     local tags = {}
@@ -40,132 +41,132 @@ function SpawnNestInsideMap(marker, seed, nest_type, danger_lvl)
     elseif nest_type == 'ScissorhandsNest' then
         tags = { scissorhands_nest = true }
     else
-		--("Using backup, whatever nest type is the tag!")
-		--(nest_type)
+        --("Using backup, whatever nest type is the tag!")
+        --(nest_type)
         tags[nest_type] = true -- future proof for PX, the nest_type input will be the needed tag
     end
-	--(tags)
-	SuspendPassEdits("SpawndNest")
-	seed = seed or InteractionRand(nil, "DailySpawn")
-	local nest
-	--(seed)
-	--()
-	local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
-		tags_all = tags,
-	})
-	if not err then
-		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-		if nest_marker then
-			nest = nest_marker:SpawnNest(true)
-		else
-			assert(false, "Prefab without a nest marker: " .. name)
-		end
-	else
-		assert(false, "Prefab error: " .. err)
-	end
-	ResumePassEdits("SpawndNest")
-	return nest
+    --(tags)
+    SuspendPassEdits("SpawndNest")
+    seed = seed or InteractionRand(nil, "DailySpawn")
+    local nest
+    --(seed)
+    --()
+    local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
+        tags_all = tags,
+    })
+    if not err then
+        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+        if nest_marker then
+            nest = nest_marker:SpawnNest(true)
+        else
+            assert(false, "Prefab without a nest marker: " .. name)
+        end
+    else
+        assert(false, "Prefab error: " .. err)
+    end
+    ResumePassEdits("SpawndNest")
+    return nest
 end
 
 function PlacePrefabLogic:GetPrefabLoc(seed, params)
-	seed = seed or InteractionRand(nil, "PlacePrefab")
-	local name, pos, angle, prefab, idx
-	--("Params")
-	--(params)
-	local prefabs = self:GetPrefabs(params)
-	--("Initial get of #prefabs")
-	--(#prefabs)
-	local r = 4
-	local fresh_prefabs
-	while #prefabs == 0 and r > 0 do
-		--("RETRYING BECAUSE I FAILED TO FIND")
-		prefabs = self:GetPrefabs(params)
-		local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
-		--("non-self prefab get count")
-		--(#fresh_prefabs)
-		--("self get of #prefabs")
-		--(#prefabs)
-		r = r - 1
-		if #fresh_prefabs > #prefabs then
-			prefabs = fresh_prefabs
-		end
-	end
-	local retry
-	while true do
-		local idx
-		if #prefabs > 1 then
-			prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
-		else
-			prefab = prefabs[1]
-		end
-		----(prefab)
-		assert(prefab)
-		if not prefab then
-			return
-		end
-		pos = params and params.pos
-		if not pos then
-			pos = self:GetVisualPos()
-			if not self.FixAtCenter then
-				local reserved_radius
-				if params and params.avoid_reserved_locations and self.reserved_locations then
-					reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
-				end
-				local radius = prefab.max_radius * const.TypeTileSize
-				local free_dist = self.MaxPrefabRadius - radius
-				if free_dist > 0 then
-					local center = pos
-					pos = false
-					local retries = params and params.avoid_reserved_retries or 16
-					for i=1,retries do
-						local ra, rr
-						ra, seed = BraidRandom(seed, 360*60)
-						rr, seed = BraidRandom(seed, free_dist)
-						local pos_i = RotateRadius(rr, ra, center)
-						if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
-							pos = pos_i
-							break
-						end
-					end
-				elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
-					pos = false
-				end
-			end
-		end
-		if pos then
-			name = PrefabMarkers[prefab]
-			angle = params and params.angle
-			if not angle then
-				angle = self:GetAngle()
-				local rand_angle = self.RandAngle
-				if rand_angle > 0 then
-					local desired_angle = params and params.desired_angle
-					if desired_angle then
-						local angle_diff = AngleDiff(desired_angle, angle)
-						if abs(angle_diff) <= rand_angle then
-							angle = desired_angle
-						else
-							local min_angle, max_angle = angle - rand_angle, angle + rand_angle
-							if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
-								angle = min_angle
-							else
-								angle = max_angle
-							end
-						end
-					else
-						local da
-						da, seed = BraidRandom(seed, -rand_angle, rand_angle)
-						angle = angle + da
-					end
-				end
-			end
-			return name, pos, angle, prefab, seed
-		end
-		if #prefabs == 1 then
-			return
-		end
-		table.remove_rotate(prefabs, idx)
-	end
+    seed = seed or InteractionRand(nil, "PlacePrefab")
+    local name, pos, angle, prefab, idx
+    --("Params")
+    --(params)
+    local prefabs = self:GetPrefabs(params)
+    --("Initial get of #prefabs")
+    --(#prefabs)
+    local r = 4
+    local fresh_prefabs
+    while #prefabs == 0 and r > 0 do
+        --("RETRYING BECAUSE I FAILED TO FIND")
+        prefabs = self:GetPrefabs(params)
+        local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
+        --("non-self prefab get count")
+        --(#fresh_prefabs)
+        --("self get of #prefabs")
+        --(#prefabs)
+        r = r - 1
+        if #fresh_prefabs > #prefabs then
+            prefabs = fresh_prefabs
+        end
+    end
+    local retry
+    while true do
+        local idx
+        if #prefabs > 1 then
+            prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
+        else
+            prefab = prefabs[1]
+        end
+        ----(prefab)
+        assert(prefab)
+        if not prefab then
+            return
+        end
+        pos = params and params.pos
+        if not pos then
+            pos = self:GetVisualPos()
+            if not self.FixAtCenter then
+                local reserved_radius
+                if params and params.avoid_reserved_locations and self.reserved_locations then
+                    reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
+                end
+                local radius = prefab.max_radius * const.TypeTileSize
+                local free_dist = self.MaxPrefabRadius - radius
+                if free_dist > 0 then
+                    local center = pos
+                    pos = false
+                    local retries = params and params.avoid_reserved_retries or 16
+                    for i = 1, retries do
+                        local ra, rr
+                        ra, seed = BraidRandom(seed, 360 * 60)
+                        rr, seed = BraidRandom(seed, free_dist)
+                        local pos_i = RotateRadius(rr, ra, center)
+                        if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
+                            pos = pos_i
+                            break
+                        end
+                    end
+                elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
+                    pos = false
+                end
+            end
+        end
+        if pos then
+            name = PrefabMarkers[prefab]
+            angle = params and params.angle
+            if not angle then
+                angle = self:GetAngle()
+                local rand_angle = self.RandAngle
+                if rand_angle > 0 then
+                    local desired_angle = params and params.desired_angle
+                    if desired_angle then
+                        local angle_diff = AngleDiff(desired_angle, angle)
+                        if abs(angle_diff) <= rand_angle then
+                            angle = desired_angle
+                        else
+                            local min_angle, max_angle = angle - rand_angle, angle + rand_angle
+                            if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
+                                angle = min_angle
+                            else
+                                angle = max_angle
+                            end
+                        end
+                    else
+                        local da
+                        da, seed = BraidRandom(seed, -rand_angle, rand_angle)
+                        angle = angle + da
+                    end
+                end
+            end
+            return name, pos, angle, prefab, seed
+        end
+        if #prefabs == 1 then
+            return
+        end
+        table.remove_rotate(prefabs, idx)
+    end
 end
 
 RecursiveCallMethods.RegisterTarget = "call"
@@ -173,74 +174,74 @@ RecursiveCallMethods.RegisterTarget = "call"
 DefineClass.EnhancedTerritorialNest = {
 
     properties = {
-        { category = "Nest", id = "state",                name = "State of nest", editor = "choice", template = true, items = { "asleep", "sleepy", "awake", "allied"}, default = 'asleep', modifiable = true, help = "state of the nest"},
-        { category = "Nest", id = "attack_time",          name = "Nest Attack Time", editor = "number", default = max_int, modifiable = true, help = "When a nest will attack next if not asleep."},
-        { category = "Nest", id = "attack_delay",          name = "Nest Attack Delay", editor = "number", default = max_int, modifiable = true, help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)"},
-        { category = "Nest", id = "attacks_done",         name = "Nest Attack Count", editor = "number", default = 0, modifiable = true, help = "Number of attacks this nest has sent total"},
-        { category = "Nest", id = "attacks_to_evo",       name = "attacks needed to force evolution", editor = "number", default = 4, modifiable = true, help = "How much EP is needed to evolve the nest denizens"},
-        { category = "Nest", id = "proximity",            name = "Nests proximity to players stuff", editor = "number", default = 1, modifiable = true, help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates"},
-        { category = "Nest", id = "ui_attack_percent",    name = "How close the attack time is to occuring", editor = "number", scale = "%", default = 0, modifiable = true, help = ""},
-        { category = "Nest", id = "ui_evo",               name = "How close this nest is too evolving it's herd", editor = "number", scale = "%", default = 0, modifiable = true, help = ""},
-		{ category = "Nest", id = "base_strength",        name = "Base % str of an attack this will send", editor = "number", scale = "%", default = 30, modifiable = true, help = ""},
-		{ category = "Nest", id = "consume_time",        name = "When nest will eat the next node", editor = "number", default = 0, modifiable = true, help = "This is routinely updated based on each individual nest"},
-	},
+        { category = "Nest", id = "state",             name = "State of nest",                                 editor = "choice", template = true,   items = { "asleep", "sleepy", "awake", "allied" }, default = 'asleep',                                                                                                      modifiable = true, help = "state of the nest" },
+        { category = "Nest", id = "attack_time",       name = "Nest Attack Time",                              editor = "number", default = max_int, modifiable = true,                                help = "When a nest will attack next if not asleep." },
+        { category = "Nest", id = "attack_delay",      name = "Nest Attack Delay",                             editor = "number", default = max_int, modifiable = true,                                help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)" },
+        { category = "Nest", id = "attacks_done",      name = "Nest Attack Count",                             editor = "number", default = 0,       modifiable = true,                                help = "Number of attacks this nest has sent total" },
+        { category = "Nest", id = "attacks_to_evo",    name = "attacks needed to force evolution",             editor = "number", default = 4,       modifiable = true,                                help = "How much EP is needed to evolve the nest denizens" },
+        { category = "Nest", id = "proximity",         name = "Nests proximity to players stuff",              editor = "number", default = 1,       modifiable = true,                                help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates" },
+        { category = "Nest", id = "ui_attack_percent", name = "How close the attack time is to occuring",      editor = "number", scale = "%",       default = 0,                                      modifiable = true,                                                                                                        help = "" },
+        { category = "Nest", id = "ui_evo",            name = "How close this nest is too evolving it's herd", editor = "number", scale = "%",       default = 0,                                      modifiable = true,                                                                                                        help = "" },
+        { category = "Nest", id = "base_strength",     name = "Base % str of an attack this will send",        editor = "number", scale = "%",       default = 30,                                     modifiable = true,                                                                                                        help = "" },
+        { category = "Nest", id = "consume_time",      name = "When nest will eat the next node",              editor = "number", default = 0,       modifiable = true,                                help = "This is routinely updated based on each individual nest" },
+    },
     state = 'asleep',
-	attack_time = max_int,
-	attack_delay = max_int,
-	attacks_done = 0,
-	attacks_to_evo = 4,
-	base_strength = 20,
-	consume_time = max_int,
+    attack_time = max_int,
+    attack_delay = max_int,
+    attacks_done = 0,
+    attacks_to_evo = 4,
+    base_strength = 20,
+    consume_time = max_int,
     proximity = 1,
     ui_attack_percent = 0,
     ui_evo = 0,
-	sleep_check = 0,
-	awoken_at = 0,
-	attacked_by_player = false,
-	other_species_attacks = {},
+    sleep_check = 0,
+    awoken_at = 0,
+    attacked_by_player = false,
+    other_species_attacks = {},
 }
 
 function EnhancedTerritorialNest:Align_cgroup_members()
-	for _,v in ipairs(self.nest_members) do
-		v.CombatGroup = self.CombatGroup
-	end
+    for _, v in ipairs(self.nest_members) do
+        v.CombatGroup = self.CombatGroup
+    end
 end
 
 function NestDelayedInit(nest)
-	nest:UpdateNextAttackTime()
-	nest:get_proximity()
-	--nest:force_inert_if_capped()
-	nest.quadrant = Get_quadrant_from_obj(nest,true)
-	nest.spawned_on = GameTime()
+    nest:UpdateNextAttackTime()
+    nest:get_proximity()
+    --nest:force_inert_if_capped()
+    nest.quadrant = Get_quadrant_from_obj(nest, true)
+    nest.spawned_on = GameTime()
 end
 
 --~Presets.UnitSpeciesGroup.Default[Presets.NestingSpeciesPreset.Default[get_species_from_nest(SelectedObj.class)].unit_species]
 function EnhancedTerritorialNest:Init()
-	self.attack_time = max_int
-	self.consume_time = max_int
-	self.nest_species = get_species_from_nest(self.class)
-	local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
-	local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
-	local desired_cgroup = full_species_details.primary_combat_group
-	if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups,self.CombatGroup) then
-		self.CombatGroup = desired_cgroup
-		self:Align_cgroup_members()
-	end
-	-- wait a day then reset the above
+    self.attack_time = max_int
+    self.consume_time = max_int
+    self.nest_species = get_species_from_nest(self.class)
+    local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
+    local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
+    local desired_cgroup = full_species_details.primary_combat_group
+    if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups, self.CombatGroup) then
+        self.CombatGroup = desired_cgroup
+        self:Align_cgroup_members()
+    end
+    -- wait a day then reset the above
     CreateGameTimeThread(function(this_nest)
-		Sleep(day_duration)
-		NestDelayedInit(this_nest)
-	end,self)
+        Sleep(day_duration)
+        NestDelayedInit(this_nest)
+    end, self)
 end
 
 function EnhancedTerritorialNest:get_next_consume_time()
-	local wait_for = AsyncRand(hour_duration * 24,hour_duration * 36)
-	self.consume_time = GameTime() + wait_for
+    local wait_for = AsyncRand(hour_duration * 24, hour_duration * 36)
+    self.consume_time = GameTime() + wait_for
 end
 
 --This technically just increases the nest members, because the base game uses the nests herd to set the controlled territory
 function EnhancedTerritorialNest:expand()
-	DebugPrint("Nest Expanding it's territory!\n")
+    DebugPrint("Nest Expanding it's territory!\n")
     local expand_by = 6
     local nodes = 0
     local max_growths = 5
@@ -248,8 +249,9 @@ function EnhancedTerritorialNest:expand()
     while nodes < 30 and grows < max_growths do
         --(nodes)
         --("expanded the distance ",grows,' times')
-        nodes = MapCount(self,(self.territorial_range+(grows*expand_by))*guim,function(thing)
-            if not IsKindOf(thing,'NestSpore') then return true end end)
+        nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
+            if not IsKindOf(thing, 'NestSpore') then return true end
+        end)
         grows = grows + 1
         --("At this increased radius, there are ",nodes,' valid nodes to consume')
     end
@@ -259,85 +261,86 @@ function EnhancedTerritorialNest:expand()
     self.adults_max_count = self.adults_max_count + grows
 end
 
-function Convert_nest_into(nest_to_convert,other_species,delete_old_members)
-	if not Presets.NestingSpeciesPreset.Default[other_species] then return end
-	local species = Presets.NestingSpeciesPreset.Default[other_species]
-	local o_species_tags = species.PrefabTags
-	local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
-	local spore_building_def = my_current.spore_buildings
-	local spores = MapGet(nest_to_convert,nest_to_convert.max_range,spore_building_def)
-	if delete_old_members then
-		for _,member in ipairs(nest_to_convert.nest_members) do
-			member:SetNest(false)
-			DoneObject(member)
-		end
-	end
-	for _,spore in ipairs(spores) do
-		DoneObject(spore)
-	end
-	local def = g_Classes['FallingDebrisMarker']
-	local old_marker = MapFindNearest(nest_to_convert,true,'TerritorialNestMarker')
-	DoneObject(nest_to_convert)
-	local pos = old_marker:GetPos()
-	local new_marker = def:new()
-	new_marker:SetPosAngle(pos)
-	DoneObject(old_marker)
+function Convert_nest_into(nest_to_convert, other_species, delete_old_members)
+    if not Presets.NestingSpeciesPreset.Default[other_species] then return end
+    local species = Presets.NestingSpeciesPreset.Default[other_species]
+    local o_species_tags = species.PrefabTags
+    local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
+    local spore_building_def = my_current.spore_buildings
+    local spores = MapGet(nest_to_convert, nest_to_convert.max_range, spore_building_def)
+    if delete_old_members then
+        for _, member in ipairs(nest_to_convert.nest_members) do
+            member:SetNest(false)
+            DoneObject(member)
+        end
+    end
+    for _, spore in ipairs(spores) do
+        DoneObject(spore)
+    end
+    local def = g_Classes['FallingDebrisMarker']
+    local old_marker = MapFindNearest(nest_to_convert, true, 'TerritorialNestMarker')
+    DoneObject(nest_to_convert)
+    local pos = old_marker:GetPos()
+    local new_marker = def:new()
+    new_marker:SetPosAngle(pos)
+    DoneObject(old_marker)
 
-	SuspendPassEdits("SpawndNest")
-	local seed = InteractionRand(nil, "DailySpawn")
-	local nest
-	--(seed)
-	--()
-	local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
-		tags_all = o_species_tags,
-	})
-	if not err then
-		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-		if nest_marker then
-			nest = nest_marker:SpawnNest(true)
-		else
-			assert(false, "Prefab without a nest marker: " .. name)
-		end
-	else
-		assert(false, "Prefab error: " .. err)
-	end
-	ResumePassEdits("SpawndNest")
-	AddGameNotification("JunoNestSpawned", nil, nil, {nest})
-	return nest
-	--SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
+    SuspendPassEdits("SpawndNest")
+    local seed = InteractionRand(nil, "DailySpawn")
+    local nest
+    --(seed)
+    --()
+    local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
+        tags_all = o_species_tags,
+    })
+    if not err then
+        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+        if nest_marker then
+            nest = nest_marker:SpawnNest(true)
+        else
+            assert(false, "Prefab without a nest marker: " .. name)
+        end
+    else
+        assert(false, "Prefab error: " .. err)
+    end
+    ResumePassEdits("SpawndNest")
+    AddGameNotification("JunoNestSpawned", nil, nil, { nest })
+    return nest
+    --SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
 end
 
 function EnhancedTerritorialNest:give_ep_to_struct(ep)
     if not ep then return end
-	Bkob_Log_NA("Nest storing EP in support structures\n")
-	local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
-	Bkob_Log_NA(spore_building_def.class)
-	Bkob_Log_NA(self.territorial_range)
-	local spores_near = MapGet(self,self.territorial_range,spore_building_def.class)
-    Bkob_Log_NA("There are this many spore buildings near me: ",#spores_near)
-	local progress_each = DivRound(ep,#spores_near)
+    Bkob_Log_NA("Nest storing EP in support structures\n")
+    local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
+    Bkob_Log_NA(spore_building_def.class)
+    Bkob_Log_NA(self.territorial_range)
+    local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
+    Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
+    local progress_each = DivRound(ep, #spores_near)
     local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]
     local spore_res_prog = spore_res.progress
-    local units_to_give = Max(1,DivRound(progress_each,spore_res_prog))
-    Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ",units_to_give)
-    for _,spore in ipairs(spores_near) do
-            spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
+    local units_to_give = Max(1, DivRound(progress_each, spore_res_prog))
+    Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ", units_to_give)
+    for _, spore in ipairs(spores_near) do
+        spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
     end
 end
 
 function EnhancedTerritorialNest:consume_closest_node()
-	DebugPrint("Nest consuming nearest node\n")
-	self.consume_time = max_int
-    local closest_res = MapFindNearest(self,self,self.territorial_range,"EntityClass",function(thing)
-    if (IsKindOf(thing,'MineableRock') or IsKindOf(thing,'Plant')) and not (IsKindOf(thing,'NestSpore')) then return true end end)
-	Bkob_Log_NA(closest_res)
+    DebugPrint("Nest consuming nearest node\n")
+    self.consume_time = max_int
+    local closest_res = MapFindNearest(self, self, self.territorial_range, "EntityClass", function(thing)
+        if (IsKindOf(thing, 'MineableRock') or IsKindOf(thing, 'Plant')) and not (IsKindOf(thing, 'NestSpore')) then return true end
+    end)
+    Bkob_Log_NA(closest_res)
     if not closest_res then
         self:expand()
-		return --we expand instead of consuming
+        return --we expand instead of consuming
     end
     local res
     local amount
-    if IsKindOf(closest_res,'Plant') then
+    if IsKindOf(closest_res, 'Plant') then
         local res_array = closest_res:GetCutResources() or closest_res:GetHarvestResources()
         res = res_array[1]['resource']
         amount = res_array[1]['amount']
@@ -345,18 +348,18 @@ function EnhancedTerritorialNest:consume_closest_node()
         res = closest_res.MineResource
         amount = closest_res.MineAmount
     end
-    local node_res_units = DivRound(amount,const.ResourceScale)
+    local node_res_units = DivRound(amount, const.ResourceScale)
     local ep_scale = 1000
-    local progress = DivRound(Resources[res].progress*node_res_units,10)
-    Bkob_Log_NA("Nest is eating a ",closest_res.class)
-    Bkob_Log_NA('Node has ',node_res_units, ' of ',res, ' in it! which is ',progress,' EP')
-    local EP_to_give = DivRound(progress,4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
-    Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ",EP_to_give)
+    local progress = DivRound(Resources[res].progress * node_res_units, 10)
+    Bkob_Log_NA("Nest is eating a ", closest_res.class)
+    Bkob_Log_NA('Node has ', node_res_units, ' of ', res, ' in it! which is ', progress, ' EP')
+    local EP_to_give = DivRound(progress, 4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
+    Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ", EP_to_give)
     DoneObject(closest_res)
     self:give_ep_to_struct(EP_to_give)
-	local attack_cd = self.attack_delay
-	self.attack_time = self.attack_time - DivRound(attack_cd,100)
-	self:get_next_consume_time()
+    local attack_cd = self.attack_delay
+    self.attack_time = self.attack_time - DivRound(attack_cd, 100)
+    self:get_next_consume_time()
 end
 
 function EnhancedTerritorialNest:GetStoryBitPopupImage()
@@ -364,10 +367,10 @@ function EnhancedTerritorialNest:GetStoryBitPopupImage()
         return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
     elseif self.class == 'ScissorhandsNest' then
         return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
-	elseif self.class == 'ConsortiumNest' then
-		return 'ConsortiumNestVariant.PNG'
-	else
-		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
+    elseif self.class == 'ConsortiumNest' then
+        return 'ConsortiumNestVariant.PNG'
+    else
+        return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
     end
 end
 
@@ -377,47 +380,47 @@ end
 -- nest:Dist2D(me) < MulDivRound(3 * distance_to_beat,1,2) is my current way to detect if a nest is "in between" the player and this nest
 
 function EnhancedTerritorialNest:get_proximity()
-	local center = AveragePoint2D(GetValidSurvivorsOnMap())
-	local dist_to_center = self:GetDist2D(center)
+    local center = AveragePoint2D(GetValidSurvivorsOnMap())
+    local dist_to_center = self:GetDist2D(center)
     local rate = 150 * guim -- 150 meters per thresholdz
-    local prox = DivRound(dist_to_center,rate)
-	prox = Max(1,Min(5,prox)) -- closest nests have a prox of 1
-	self.proximity = prox
-	return prox
+    local prox = DivRound(dist_to_center, rate)
+    prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
+    self.proximity = prox
+    return prox
 end
 
 function EnhancedTerritorialNest:Getui_evo()
-	DebugPrint("Getting the UI % how close to an evo the nest is\n")
-    local option_1 = DivRound(self.attacks_done * 100,self.attacks_to_evo)
-    local option_2 = check_count_and_upgrade(self.elder_class,{},100)
+    DebugPrint("Getting the UI % how close to an evo the nest is\n")
+    local option_1 = DivRound(self.attacks_done * 100, self.attacks_to_evo)
+    local option_2 = check_count_and_upgrade(self.elder_class, {}, 100)
     if option_2 ~= self.elder_class then
         return 100 -- will show 100% if the EP is already high enough to trigger a "passive" evo
     else
-        return Max(1,option_1)
+        return Max(1, option_1)
     end
 end
 
 function EnhancedTerritorialNest:Getui_attack_strength()
-	--local max_possible = per_species_nest_max*10
-	if self.state == 'asleep' then
-		return 10
-	else
-		return self:calculate_attack_strength('player')
-	end
+    --local max_possible = per_species_nest_max*10
+    if self.state == 'asleep' then
+        return 10
+    else
+        return self:calculate_attack_strength('player')
+    end
 end
 
 function EnhancedTerritorialNest:Getui_attack_cap()
-	local player_attack = self:calculate_attack_strength('player')
-	local current_cap = self:get_attack_cap()
-	return DivRound(player_attack*100,current_cap)
+    local player_attack = self:calculate_attack_strength('player')
+    local current_cap = self:get_attack_cap()
+    return DivRound(player_attack * 100, current_cap)
 end
 
 function EnhancedTerritorialNest:Getui_attack_percent()
-	DebugPrint("Getting the UI % of how close an attack from the nest is\n")
-	local time_till_attack = self.attack_time - GameTime()
-	local num = self.attack_delay-time_till_attack
-	local percent=DivRound(num*100,self.attack_delay)
-	return Max(1,percent)
+    DebugPrint("Getting the UI % of how close an attack from the nest is\n")
+    local time_till_attack = self.attack_time - GameTime()
+    local num = self.attack_delay - time_till_attack
+    local percent = DivRound(num * 100, self.attack_delay)
+    return Max(1, percent)
 end
 
 function EnhancedTerritorialNest:IsAsleep()
@@ -433,83 +436,83 @@ function EnhancedTerritorialNest:IsSleepy()
 end
 
 function EnhancedTerritorialNest:change_nest_herd(force_evo)
-	Bkob_Log("Nest calculating if it needs to upgrade\n")
-	Bkob_Log("Forced Evo: ",force_evo)
+    Bkob_Log("Nest calculating if it needs to upgrade\n")
+    Bkob_Log("Forced Evo: ", force_evo)
     local elder = self.elder_class
-	local upgraded_flag = false
-	local evo,_,__
-	if force_evo then
-		evo = Find_evolution(g_Classes[elder])
-	else
-		local AdditionalClassList = {}
-		AdditionalClassList[#AdditionalClassList+1] = {self.adult_class,150}
-		AdditionalClassList[#AdditionalClassList+1] = {self.hatchling_class,50}
-	    evo, _, __ = check_count_and_upgrade(elder,AdditionalClassList,100)
-	end
+    local upgraded_flag = false
+    local evo, _, __
+    if force_evo then
+        evo = Find_evolution(g_Classes[elder])
+    else
+        local AdditionalClassList = {}
+        AdditionalClassList[#AdditionalClassList + 1] = { self.adult_class, 150 }
+        AdditionalClassList[#AdditionalClassList + 1] = { self.hatchling_class, 50 }
+        evo, _, __ = check_count_and_upgrade(elder, AdditionalClassList, 100)
+    end
     if evo == elder and self.adult_class == self.hatchling_class and self.adult_class == self.elder_class then
-		return upgraded_flag
-	end
-	-- base nests will just chain their units down
-	upgraded_flag = true
-	self.hatchling_class = self.adult_class
-	self.adult_class = self.elder_class
-	self.elder_class = evo
-	-- remove any newly-invalid creatures from nest_creatures
-	local removed = false
-	for _, unit in ipairs(self.nest_members) do
-		local class = unit.class
-		if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
-			self:RemoveNestMember(unit)
-			-- This will force spawn a new set of higher tier nests. 
-			-- If Nests are left unnattended they can get quite large groups defending it
-		end
-	end
-	if removed then
-		self:UpdateNextSpawnTime()
-	end
+        return upgraded_flag
+    end
+    -- base nests will just chain their units down
+    upgraded_flag = true
+    self.hatchling_class = self.adult_class
+    self.adult_class = self.elder_class
+    self.elder_class = evo
+    -- remove any newly-invalid creatures from nest_creatures
+    local removed = false
+    for _, unit in ipairs(self.nest_members) do
+        local class = unit.class
+        if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
+            self:RemoveNestMember(unit)
+            -- This will force spawn a new set of higher tier nests.
+            -- If Nests are left unnattended they can get quite large groups defending it
+        end
+    end
+    if removed then
+        self:UpdateNextSpawnTime()
+    end
     if upgraded_flag then
-		-- just to make sure we know how close the player is now that they have more stuff
-		self:get_proximity()
-		NA_log_nest_evolved(self)
+        -- just to make sure we know how close the player is now that they have more stuff
+        self:get_proximity()
+        NA_log_nest_evolved(self)
         self.attacks_done = 0
         self.attacks_to_evo = self.attacks_to_evo + 1
     end
-	return upgraded_flag
+    return upgraded_flag
 end
 
 function EnhancedTerritorialNest:can_be_aggressive(who)
-	if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
-		return true
-	elseif who == 'player' and self.attacked_by_player then
-		return true
-	elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
-		return true
-	else
-		return false
-	end
+    if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
+        return true
+    elseif who == 'player' and self.attacked_by_player then
+        return true
+    elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
+        return true
+    else
+        return false
+    end
 end
 
 function EnhancedTerritorialNest:RegisterTarget(unit, time)
-	if unit.player then
-		self.attacked_by_player = true
-	elseif unit.nest then
-		unit.nest.attacked_by_player = true
-	end
+    if unit.player then
+        self.attacked_by_player = true
+    elseif unit.nest then
+        unit.nest.attacked_by_player = true
+    end
     local tags = unit['UnitTags']
     if tags and self.state == 'asleep' and tags['Human'] then
-		DebugPrint("Nest registering a human attacker!\n")
+        DebugPrint("Nest registering a human attacker!\n")
         self:SwitchState('sleepy')
     end
-	if unit.nest then
-		DebugPrint("Nest registering another nest attacker!\n")
-		if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
-			self:SwitchState('sleepy')
-		end
-	end
+    if unit.nest then
+        DebugPrint("Nest registering another nest attacker!\n")
+        if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
+            self:SwitchState('sleepy')
+        end
+    end
 end
 
 function EnhancedTerritorialNest:set_new_max_hp()
-	DebugPrint("Nest raising max HP\n")
+    DebugPrint("Nest raising max HP\n")
     local base_hp = 100000
     local diff = Get_difficulty_offset()
     local max_possible_hp = base_hp * 100 * diff
@@ -517,7 +520,7 @@ function EnhancedTerritorialNest:set_new_max_hp()
         self.MaxHealth = max_possible_hp
         self.health_regen = 5
     elseif self.state == 'sleepy' then
-        self.MaxHealth = DivRound(max_possible_hp,2)
+        self.MaxHealth = DivRound(max_possible_hp, 2)
         self.health_regen = 1
     elseif self.state == 'asleep' then
         self.health_regen = 0
@@ -526,26 +529,26 @@ function EnhancedTerritorialNest:set_new_max_hp()
 end
 
 function EnhancedTerritorialNest:SwitchState(new_state)
-	DebugPrint("Nest switching it's internal state!\n")
+    DebugPrint("Nest switching it's internal state!\n")
     new_state = new_state or nil
-	local notif_level = Nest_Notifications
+    local notif_level = Nest_Notifications
     if not new_state or new_state == self.state then
         return
-	end
+    end
     if new_state == 'sleepy' and self.state == 'asleep' then
-		self.sleep_check = GameTime() + const.Scale.months
-		if notif_level == 2 then
-			ForceActivateStoryBit('asleep_too_sleepy',self,true)
-		elseif notif_level == 1 then
-			AddGameNotification("waking_up", nil, nil, {self})
-		end
-	elseif new_state == "asleep" and not (self.state == "awake") then
-		if notif_level == 2 then
-			-- woken up
-			ForceActivateStoryBit('back_to_sleep',self,true)
-		elseif notif_level == 1 then
-			AddGameNotification("back_to_sleep", nil, nil, {self})
-		end
+        self.sleep_check = GameTime() + const.Scale.months
+        if notif_level == 2 then
+            ForceActivateStoryBit('asleep_too_sleepy', self, true)
+        elseif notif_level == 1 then
+            AddGameNotification("waking_up", nil, nil, { self })
+        end
+    elseif new_state == "asleep" and not (self.state == "awake") then
+        if notif_level == 2 then
+            -- woken up
+            ForceActivateStoryBit('back_to_sleep', self, true)
+        elseif notif_level == 1 then
+            AddGameNotification("back_to_sleep", nil, nil, { self })
+        end
     end
     self.state = new_state
     self:UpdateNextAttackTime()
@@ -553,172 +556,173 @@ function EnhancedTerritorialNest:SwitchState(new_state)
 end
 
 function EnhancedTerritorialNest:get_attack_cap()
-	local base = 50
-    local awake_same_nests = MapCount(true,"TerritorialNest",function(other_nest,this_nest)
-		if IsKindOf(other_nest,this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
-			return true
-		end
-	end,self)
-	local nest_based_cap = awake_same_nests * 10
-	local year = const.Scale.years
-	local time_based_cap = MulDivTrunc(1,GameTime(),year)*50+50
-	if base > time_based_cap and base > nest_based_cap then
-		return base
-	elseif time_based_cap > nest_based_cap then
-		return time_based_cap
-	else
-		return nest_based_cap
-	end
-	return base
+    local base = 50
+    local awake_same_nests = MapCount(true, "TerritorialNest", function(other_nest, this_nest)
+        if IsKindOf(other_nest, this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
+            return true
+        end
+    end, self)
+    local nest_based_cap = awake_same_nests * 10
+    local year = const.Scale.years
+    local time_based_cap = MulDivTrunc(1, GameTime(), year) * 50 + 50
+    if base > time_based_cap and base > nest_based_cap then
+        return base
+    elseif time_based_cap > nest_based_cap then
+        return time_based_cap
+    else
+        return nest_based_cap
+    end
+    return base
 end
 
 function EnhancedTerritorialNest:calculate_interspecies_war_strength(who)
-	DebugPrint("Calculating interspecies war strength\n")
-	local nest_EP = 0
-	for _,defender in ipairs(who.nest_members) do
-		nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
-	end
-	local rand = 75 + AsyncRand(75)
-	return nest_EP + rand
+    DebugPrint("Calculating interspecies war strength\n")
+    local nest_EP = 0
+    for _, defender in ipairs(who.nest_members) do
+        nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
+    end
+    local rand = 75 + AsyncRand(75)
+    return nest_EP + rand
 end
 
 function EnhancedTerritorialNest:calculate_attack_strength(who)
-	DebugPrint("Nest calculating it's attack score\n")
-	if who == 'player' then
-		local max_attack_strength_allowed = self:get_attack_cap()
-		local base_strength = self.base_strength or 20
-		local diff_increase
-		if Get_difficulty_offset() > 5 then
-			diff_increase = 10
-		else
-			diff_increase = 0
-		end
-		local species = get_species_from_nest(self.class)
-		local banked = 0
-		local species_banked_aggr = species..'_banked_aggr'
-		if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
-			banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
-		else
-			DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
-			Nest_Species_Savegame_Stats[self.nest_species] = {}
-			Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
-		end
-		local subsequent_attacks = self.attacks_done * 10
-		local prox_loss = self.proximity * 10
-		local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
-		-- Make sure we don't go below base or above cap
-		local filtered_strength = Max(base_strength,Min(max_attack_strength_allowed,unfiltered_strength))
-		DebugPrint("Desired attack strength: ")
-		DebugPrint(unfiltered_strength)
-		DebugPrint("\nActual attack strength:")
-		DebugPrint(filtered_strength)
-		DebugPrint("\n")
-		return filtered_strength
-	elseif IsKindOf(who,'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
-			return self:calculate_interspecies_war_strength(who)
-	else
-		return 10
-	end
+    DebugPrint("Nest calculating it's attack score\n")
+    if who == 'player' then
+        local max_attack_strength_allowed = self:get_attack_cap()
+        local base_strength = self.base_strength or 20
+        local diff_increase
+        if Get_difficulty_offset() > 5 then
+            diff_increase = 10
+        else
+            diff_increase = 0
+        end
+        local species = get_species_from_nest(self.class)
+        local banked = 0
+        local species_banked_aggr = species .. '_banked_aggr'
+        if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
+            banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
+        else
+            DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
+            Nest_Species_Savegame_Stats[self.nest_species] = {}
+            Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
+        end
+        local subsequent_attacks = self.attacks_done * 10
+        local prox_loss = self.proximity * 10
+        local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
+        -- Make sure we don't go below base or above cap
+        local filtered_strength = Max(base_strength, Min(max_attack_strength_allowed, unfiltered_strength))
+        DebugPrint("Desired attack strength: ")
+        DebugPrint(unfiltered_strength)
+        DebugPrint("\nActual attack strength:")
+        DebugPrint(filtered_strength)
+        DebugPrint("\n")
+        return filtered_strength
+    elseif IsKindOf(who, 'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
+        return self:calculate_interspecies_war_strength(who)
+    else
+        return 10
+    end
 end
 
 function nest_find_spawn_fake(spawndef_instance, spawn_class, target)
-	local def = spawn_class and g_Classes[spawn_class]
-	local pfclass = def.pfclass
-	local range = spawndef_instance.nest.max_range
-	local target_retry = 7
-	local x,y
-	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-	local playbox = GetPlayBox()
-	local nest_entity_radius = spawndef_instance.nest:GetRadius()
-	for i=1,target_retry do
-		x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
-		local temp_pos = point(x,y)
-		local playbox_check = playbox:Dist2(temp_pos) > 1
-		local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-		if playbox_check or under_nest then
-			x = nil
-			target_retry = target_retry - 1
-			range = range * 2
-		else
-			local possible_pos = point(x,y)
-			return possible_pos
-		end
-	end
-	::continue::
-	dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest,7))
+    local def = spawn_class and g_Classes[spawn_class]
+    local pfclass = def.pfclass
+    local range = spawndef_instance.nest.max_range
+    local target_retry = 7
+    local x, y
+    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+    local playbox = GetPlayBox()
+    local nest_entity_radius = spawndef_instance.nest:GetRadius()
+    for i = 1, target_retry do
+        x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
+        local temp_pos = point(x, y)
+        local playbox_check = playbox:Dist2(temp_pos) > 1
+        local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+        if playbox_check or under_nest then
+            x = nil
+            target_retry = target_retry - 1
+            range = range * 2
+        else
+            local possible_pos = point(x, y)
+            return possible_pos
+        end
+    end
+    ::continue::
+    dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest, 7))
 end
 
 function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
-	--print("Finding spawn point near a nest!")
-	local playbox = GetPlayBox()
-	if not target then
-		--print("Didn't get a target to spawn near!")
-		target = spawndef_instance:ResolveTarget()
-	end
-	local def = spawn_class and g_Classes[spawn_class]
-	local pfclass = def.pfclass
-	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-	if not pos then print("no pos found!") end
-	local nest_entity_radius = spawndef_instance.nest:GetRadius()
-	local x,y
-	local retry = 10
-	local range = spawndef_instance.nest.max_range
-	local target_radius = 30*guim
-	while not x and retry > 0 do
-		local spot_closest_to_target =  terrain.FindPassable(target, pfclass, target_radius)
-		if not spot_closest_to_target then
-			target_radius = target_radius * 2
-		else
-			x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
-			local temp_pos = point(x,y)
-			local playbox_check = playbox:Dist2(temp_pos) > 1
-			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-			if playbox_check or under_nest then
-				x = nil
-				retry = retry - 1
-				range = range * 2
-			else
-				local possible_pos = point(x,y)
-				if ConnectivityCheck(possible_pos,spot_closest_to_target,pfclass) then
-					--print("Found a point!")
-					return possible_pos
-				else
-					retry = retry - 1
-					range = range * 2
-				end
-			end
-		end
-	return nil
-	end
+    --print("Finding spawn point near a nest!")
+    local playbox = GetPlayBox()
+    if not target then
+        --print("Didn't get a target to spawn near!")
+        target = spawndef_instance:ResolveTarget()
+    end
+    local def = spawn_class and g_Classes[spawn_class]
+    local pfclass = def.pfclass
+    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+    if not pos then print("no pos found!") end
+    local nest_entity_radius = spawndef_instance.nest:GetRadius()
+    local x, y
+    local retry = 10
+    local range = spawndef_instance.nest.max_range
+    local target_radius = 30 * guim
+    while not x and retry > 0 do
+        local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
+        if not spot_closest_to_target then
+            target_radius = target_radius * 2
+        else
+            x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
+            local temp_pos = point(x, y)
+            local playbox_check = playbox:Dist2(temp_pos) > 1
+            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+            if playbox_check or under_nest then
+                x = nil
+                retry = retry - 1
+                range = range * 2
+            else
+                local possible_pos = point(x, y)
+                if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
+                    --print("Found a point!")
+                    return possible_pos
+                else
+                    retry = retry - 1
+                    range = range * 2
+                end
+            end
+        end
+        return nil
+    end
 end
 
-local post_spawn_animal = function(self,obj,target,context)
-		obj.CombatHostile = true
-		Msg("SpawnedAnimalThreat", obj)
-		give_nest_speed_effect(obj,self.nest.proximity)
-	end
-
-local post_spawn_robot = function(self,obj,target,context)
-		obj:SetInvader(true)
-		Msg("SpawnedAnimalThreat", obj)
-		give_nest_speed_effect(obj,self.nest.proximity)
-	end
-
-function give_nest_speed_effect(ob,prox)
-	local robot_flag = false
-	local times = prox or 1
-	if IsKindOf(ob,'Robot') then
-		robot_flag = true
-	end
-	while times > 0 do
-		if robot_flag then
-			ob:AddRobotCondition('nest_attack_speed_robot','mod')
-		else
-			ob:AddHealthCondition('nest_attack_speed','mod')
-		end
-		times = times - 1
-	end
+local post_spawn_animal = function(self, obj, target, context)
+    obj.CombatHostile = true
+    Msg("SpawnedAnimalThreat", obj)
+    give_nest_speed_effect(obj, self.nest.proximity)
 end
+
+local post_spawn_robot = function(self, obj, target, context)
+    obj:SetInvader(true)
+    Msg("SpawnedAnimalThreat", obj)
+    give_nest_speed_effect(obj, self.nest.proximity)
+end
+
+function give_nest_speed_effect(ob, prox)
+    local robot_flag = false
+    local times = prox or 1
+    if IsKindOf(ob, 'Robot') then
+        robot_flag = true
+    end
+    while times > 0 do
+        if robot_flag then
+            ob:AddRobotCondition('nest_attack_speed_robot', 'mod')
+        else
+            ob:AddHealthCondition('nest_attack_speed', 'mod')
+        end
+        times = times - 1
+    end
+end
+
 --[[
 quadrants = {1={},2={}}
 ......
@@ -747,67 +751,67 @@ quadrants[1] = {
 --]]
 
 function EnhancedTerritorialNest:IsQuadrantScouted(quad_no)
-	local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
-	if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
-		return false
-	else
-		return true
-	end
+    local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
+    if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
+        return false
+    else
+        return true
+    end
 end
 
-function EnhancedTerritorialNest:MarkScouted(other_species,time)
-	rawset(self, other_species, time)
+function EnhancedTerritorialNest:MarkScouted(other_species, time)
+    rawset(self, other_species, time)
 end
 
-function ReportScoutingResults(quad_no,species,objects_to_report,player_found,nest)
-	Reset_quadrant(quad_no,species)
-	if nest.quadrant_scouting then
-		nest.quadrant_scouting = false
-	end
-	local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
-	if player_found then 
-		scout_quad_logs['player_presence'] = true
-		DebugPrint("Player presence detected in this quadrant!\n")
-		if nest:IsAsleep() then
-			nest:SwitchState('sleepy')
-		end
-	end
-	scout_quad_logs.last_scout = GameTime()
-	scout_quad_logs['map_objs'] = objects_to_report
-	for _,obj in ipairs(objects_to_report) do
-		if IsKindOf(obj,"TerritorialNest") and obj.nest_species ~= species then
-			if scout_quad_logs[that_species] then
-				scout_quad_logs[that_species][#scout_quad_logs[that_species]+1] = nest
-				nest:MarkScouted(self.nest_species,GameTime())
-			else
-				scout_quad_logs[that_species] = {}
-				scout_quad_logs[that_species][1] = nest
-			end
-		end
-		scout_quad_logs['map_objs'][#scout_quad_logs['map_objs']+1] = nest
-	end
+function ReportScoutingResults(quad_no, species, objects_to_report, player_found, nest)
+    Reset_quadrant(quad_no, species)
+    if nest.quadrant_scouting then
+        nest.quadrant_scouting = false
+    end
+    local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
+    if player_found then
+        scout_quad_logs['player_presence'] = true
+        DebugPrint("Player presence detected in this quadrant!\n")
+        if nest:IsAsleep() then
+            nest:SwitchState('sleepy')
+        end
+    end
+    scout_quad_logs.last_scout = GameTime()
+    scout_quad_logs['map_objs'] = objects_to_report
+    for _, obj in ipairs(objects_to_report) do
+        if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
+            if scout_quad_logs[that_species] then
+                scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
+                nest:MarkScouted(self.nest_species, GameTime())
+            else
+                scout_quad_logs[that_species] = {}
+                scout_quad_logs[that_species][1] = nest
+            end
+        end
+        scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
+    end
 end
 
 -- TODO instead of cheat learning about the quadrant, send out a nesting unit to scout
 function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
-	DebugPrint("Nest is releasing a scouting unit!!\n")
-	local spawn_def = SpawnDefs['Nest_scout_passive']
-	--used by invader to know what quadrant is to be scouted
-	-- And to track if the scout ever returned
-	if self.quadrant_scouting then
-		DebugPrint("Whelp, looks like my last scout is MIA...")
-	end
-	self.quadrant_scouting = quad_no
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.adult_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.hatchling_class,50}
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t,{},100)
-	--[[
+    DebugPrint("Nest is releasing a scouting unit!!\n")
+    local spawn_def = SpawnDefs['Nest_scout_passive']
+    --used by invader to know what quadrant is to be scouted
+    -- And to track if the scout ever returned
+    if self.quadrant_scouting then
+        DebugPrint("Whelp, looks like my last scout is MIA...")
+    end
+    self.quadrant_scouting = quad_no
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.adult_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
+    --[[
 	if not Nest_scouting_quadrants[quad_no] then
 		CreateMapGrid()
 	end
@@ -820,450 +824,496 @@ function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
 end
 
 function MegaScout(nest)
-	for i=1,25 do
-		nest:Scout_Specific_Quad(i)
-	end
+    for i = 1, 25 do
+        nest:Scout_Specific_Quad(i)
+    end
 end
 
 -- Currently this will just cheat
 -- I want to build out scouting behavior to allow the player to interact with a species learning about the map
 function EnhancedTerritorialNest:scout_nearest_quad()
-	DebugPrint("\nScouting closest usncouted quad!\n")
-	if not self.quadrant then
-		self.quadrant = Get_quadrant_from_obj(self,true)
-	end
-	if not self.nest_species then
-		self.nest_species = get_species_from_nest(self.class)
-	end
-	if not Nest_scouting_quadrants[1] then
-		CreateMapGrid()
-	end
-	local to_scout
-	local shouldnt_scout = {}
-	if not Nest_scouting_quadrants[self.quadrant] then
-		CreateMapGrid()
-	end
-	local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-	if not my_species_quad_logs then
-		CreateMapGrid()
-		my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-	end
-	if my_species_quad_logs.last_scout == 0 then
-		to_scout = self.quadrant
-	elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
-		to_scout = self.quadrant
-		goto continue
-	end
-	shouldnt_scout[#shouldnt_scout+1] = self.quadrant
-	for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
-	--ignoring diagonals because..... its hard
-		for _,no in ipairs(shouldnt_scout) do
-			for _,q in ipairs(Get_adjacent_quads(no)) do
-				if not table.find(shouldnt_scout,q) then
-					if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
-						to_scout = q
-						goto continue
-					elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
-						shouldnt_scout[#shouldnt_scout+1] = q
-					else
-						--print("Whelp, guess Im going to scout quadrant",q,"now!\n")
-						to_scout = q
-						goto continue
-					end
-				end
-			end
-		end
-	end
-	::continue::
-	if not to_scout then
-		DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
-		return
-	else
-		DebugPrint("I am scouting this quadrant:",to_scout,'\n')
-	end
-	self:Scout_Specific_Quad(to_scout)
+    DebugPrint("\nScouting closest usncouted quad!\n")
+    if not self.quadrant then
+        self.quadrant = Get_quadrant_from_obj(self, true)
+    end
+    if not self.nest_species then
+        self.nest_species = get_species_from_nest(self.class)
+    end
+    if not Nest_scouting_quadrants[1] then
+        CreateMapGrid()
+    end
+    local to_scout
+    local shouldnt_scout = {}
+    if not Nest_scouting_quadrants[self.quadrant] then
+        CreateMapGrid()
+    end
+    local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+    if not my_species_quad_logs then
+        CreateMapGrid()
+        my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+    end
+    if my_species_quad_logs.last_scout == 0 then
+        to_scout = self.quadrant
+    elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
+        to_scout = self.quadrant
+        goto continue
+    end
+    shouldnt_scout[#shouldnt_scout + 1] = self.quadrant
+    for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
+        --ignoring diagonals because..... its hard
+        for _, no in ipairs(shouldnt_scout) do
+            for _, q in ipairs(Get_adjacent_quads(no)) do
+                if not table.find(shouldnt_scout, q) then
+                    if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
+                        to_scout = q
+                        goto continue
+                    elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
+                        shouldnt_scout[#shouldnt_scout + 1] = q
+                    else
+                        --print("Whelp, guess Im going to scout quadrant",q,"now!\n")
+                        to_scout = q
+                        goto continue
+                    end
+                end
+            end
+        end
+    end
+    ::continue::
+    if not to_scout then
+        DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
+        return
+    else
+        DebugPrint("I am scouting this quadrant:", to_scout, '\n')
+    end
+    self:Scout_Specific_Quad(to_scout)
 end
 
 function EnhancedTerritorialNest:nest_attack_player()
-	DebugPrint("Nest is attacking the player directly!\n")
-	local spawn_def = SpawnDefs['nest_attack']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.elder_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.adult_class,150}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.hatchling_class,50}
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	local atk_str = self:calculate_attack_strength('player')
-	spawn_def:ActivateSpawn(t,{},atk_str)
+    DebugPrint("Nest is attacking the player directly!\n")
+    local spawn_def = SpawnDefs['nest_attack']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.elder_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    local atk_str = self:calculate_attack_strength('player')
+    spawn_def:ActivateSpawn(t, {}, atk_str)
 end
 
 function EnhancedTerritorialNest:nest_attack_non_player(enemy_nest)
-	DebugPrint("Nest is attacking a non player target near it!\n")
-	local spawn_def = SpawnDefs['nest_attack']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.elder_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.adult_class,150}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.hatchling_class,50}
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	print("ACTIVATING SPAWN!")
-	spawn_def:ActivateSpawn(t,{},self:calculate_attack_strength(enemy_nest))
+    DebugPrint("Nest is attacking a non player target near it!\n")
+    local spawn_def = SpawnDefs['nest_attack']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.elder_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    print("ACTIVATING SPAWN!")
+    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength(enemy_nest))
 end
 
 function EnhancedTerritorialNest:nest_support_closest(ally_nest)
-	DebugPrint("Nest is sending support to the closest nest!\n")
-	local spawn_def = SpawnDefs['Support_same_species_passive']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.adult_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.hatchling_class,50}
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t,{},100)
+    DebugPrint("Nest is sending support to the closest nest!\n")
+    local spawn_def = SpawnDefs['Support_same_species_passive']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.adult_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    -- Support the specific in-sector ally chosen by GetSupportTarget: target IT so the reinforcement
+    -- spawns near the ally (and does not march across the player's base). Fall back to the SpawnDef's
+    -- own target resolution when called without an explicit ally.
+    local t = ally_nest or spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:overflow_spawn()
-	DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
-	local spawn_def = SpawnDefs['nest_overflow']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.elder_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.adult_class,150}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.hatchling_class,50}
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t,{},self:calculate_attack_strength())
+    DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
+    local spawn_def = SpawnDefs['nest_overflow']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.elder_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength())
 end
 
 function EnhancedTerritorialNest:GetUnscoutedQuadrantsWithin(range)
-	range = range or 5
-	local unscouted = {}
-	local processed_quads = {}
-	local distance = 1
-	unscouted[distance]= {}
-	--print("I am in quadrant", self.quadrant,'\n')
-	if self:IsQuadrantScouted(self.quadrant) then
-		local distance_entry = unscouted[distance]
-		distance_entry[#distance_entry+1] = self.quadrant
-	end
-	processed_quads[#processed_quads+1] = self.quadrant
-	local temp_processed = {}
-	for i = 1, range do
-		distance = distance + 1
-		-- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
-		unscouted[distance]= table.copy(unscouted[distance-1])
-		--print("Now checking quadrants at distance ",distance-1,'\n')
-		local distance_entry = unscouted[distance]
-		for _, qu in ipairs(processed_quads) do
-			local adjacent = Get_adjacent_quads(qu)
-			--print("Looking through these: ", adjacent,'\n')
-			for _,qua in ipairs(adjacent) do
-				if not table.find(processed_quads,qua) and not table.find(temp_processed,qua) then
-					temp_processed[#temp_processed+1] = qua
-					local scouted = self:IsQuadrantScouted(qua)
-					if not scouted then
-						distance_entry[#distance_entry+1] = qua
-					end
-				end
-			end
-		end
-		--print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
-		--print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
-		for _,v in ipairs(temp_processed) do
-			processed_quads[#processed_quads+1] = v
-		end
-		temp_processed = {}
-	end
-	return unscouted
+    range = range or 5
+    local unscouted = {}
+    local processed_quads = {}
+    local distance = 1
+    unscouted[distance] = {}
+    --print("I am in quadrant", self.quadrant,'\n')
+    if self:IsQuadrantScouted(self.quadrant) then
+        local distance_entry = unscouted[distance]
+        distance_entry[#distance_entry + 1] = self.quadrant
+    end
+    processed_quads[#processed_quads + 1] = self.quadrant
+    local temp_processed = {}
+    for i = 1, range do
+        distance = distance + 1
+        -- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
+        unscouted[distance] = table.copy(unscouted[distance - 1])
+        --print("Now checking quadrants at distance ",distance-1,'\n')
+        local distance_entry = unscouted[distance]
+        for _, qu in ipairs(processed_quads) do
+            local adjacent = Get_adjacent_quads(qu)
+            --print("Looking through these: ", adjacent,'\n')
+            for _, qua in ipairs(adjacent) do
+                if not table.find(processed_quads, qua) and not table.find(temp_processed, qua) then
+                    temp_processed[#temp_processed + 1] = qua
+                    local scouted = self:IsQuadrantScouted(qua)
+                    if not scouted then
+                        distance_entry[#distance_entry + 1] = qua
+                    end
+                end
+            end
+        end
+        --print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
+        --print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
+        for _, v in ipairs(temp_processed) do
+            processed_quads[#processed_quads + 1] = v
+        end
+        temp_processed = {}
+    end
+    return unscouted
 end
 
 function EnhancedTerritorialNest:IsPlayerKnown()
-	local my_species = get_species_from_nest(self.class)
-	for _, quad in ipairs(Nest_scouting_quadrants) do
-		if quad[my_species].player_presence then
-			return true
-		end
-	end
-	return false
+    local my_species = get_species_from_nest(self.class)
+    for _, quad in ipairs(Nest_scouting_quadrants) do
+        if quad[my_species].player_presence then
+            return true
+        end
+    end
+    return false
 end
 
 function EnhancedTerritorialNest:IsCloserToPlayer(other_nest)
-	local compare_point = Get_center_of_survivors()
-	local my_distance = self:GetDist2D(compare_point)
-	local other_distance = other_nest:GetDist2D(compare_point)
-	return my_distance < other_distance
+    local compare_point = Get_center_of_survivors()
+    local my_distance = self:GetDist2D(compare_point)
+    local other_distance = other_nest:GetDist2D(compare_point)
+    return my_distance < other_distance
 end
 
 function EnhancedTerritorialNest:IsClosestToPlayer()
-	--local my_species = get_species_from_nest(self.class)
-	local compare_point = Get_center_of_survivors()
-	--print("Center of survivors is: ",compare_point,'\n')
-	local my_distance = self:GetDist2D(compare_point)
-	--print("I am this far away from it: ",my_distance,'\n')
-	local nest_dist = {}
-	MapForEach("map",self.class,function(nest,compare_point,me)
-		if nest ~= me then
-			nest_dist[#nest_dist+1] = {nest=nest, dist=nest:GetDist2D(compare_point)}
-		end
-	end,compare_point,self)
-	local closest = self
-	--print(nest_dist,'\n')
-	for _,v in ipairs(nest_dist) do
-		if v.dist < my_distance then
-			closest = v.nest
-		end
-	end
-	return closest == self
+    --local my_species = get_species_from_nest(self.class)
+    local compare_point = Get_center_of_survivors()
+    --print("Center of survivors is: ",compare_point,'\n')
+    local my_distance = self:GetDist2D(compare_point)
+    --print("I am this far away from it: ",my_distance,'\n')
+    local nest_dist = {}
+    MapForEach("map", self.class, function(nest, compare_point, me)
+        if nest ~= me then
+            nest_dist[#nest_dist + 1] = { nest = nest, dist = nest:GetDist2D(compare_point) }
+        end
+    end, compare_point, self)
+    local closest = self
+    --print(nest_dist,'\n')
+    for _, v in ipairs(nest_dist) do
+        if v.dist < my_distance then
+            closest = v.nest
+        end
+    end
+    return closest == self
+end
+
+-- A nest attacks the player only when it is the most-forward of its species; a nest behind a same-species ally sends
+-- support to that ally instead. "Behind" = the ally is closer to the survivor centre AND within an angular sector of
+-- this nest's own bearing from that centre. The angular gate is what stops support being sent to a nest ~180 degrees
+-- opposite (on the far side of the player), which is what would march units through the player's base. Returns the ally
+-- nest to support, or false if this nest is the front line.
+function EnhancedTerritorialNest:GetSupportTarget()
+    local center = Get_center_of_survivors()
+    local my_dist = self:GetDist2D(center)
+    local my_bearing = CalcOrientation(center, self:GetPos())
+    local sector = 60 * 60 -- +-60 degrees (HG angles are in 1/60-degree units) -> a 120-degree forward arc
+    local best, best_dist
+    MapForEach("map", self.class, function(nest, me)
+        if nest == me then return end
+        local n_dist = nest:GetDist2D(center)
+        if n_dist >= my_dist then return end                                                     -- only nests ahead of me (closer to the survivors)
+        if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
+        if not best or n_dist < best_dist then
+            best, best_dist = nest, n_dist
+        end
+    end, self)
+    return best or false
 end
 
 function EnhancedTerritorialNest:GetNearbyEnemiesNonPlayer(range)
-	local valid_targets = MapGet(self,range,"TerritorialNest",function(nest,me)
-		if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species 
-		and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
-			return true
-		end
-	end,self)
-	local closest = {}
-	for _,target in iapairs(valid_targets) do
-		if table.find(closest,target.nest_species) then
-			closest[target.nest_species]= target
-		else
-			closest[target.nest_species] = {}
-			closest[target.nest_species][1] = target
-		end
-	end
-	range = range or 5
-	local enemy_selection = {}
-	local processed_quads = {}
-	local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-	for _, species in my_quad.other_species do
-		table.insert_unique(enemy_selection,species)
-	end
-	processed_quads[#processed_quads+1] = self.quadrant
-	local temp_processed = {}
-	for i = 1, range do
-		for _,no in ipairs(processed_quads) do
-			for _,q in ipairs(Get_adjacent_quads(no)) do
-				local this_quad = Nest_scouting_quadrants[q][self.nest_species]
-				if not table.find(processed_quads,q) and not table.find(temp_processed,q) then
-					temp_processed[#temp_processed+1] = q
-					for _, species in this_quad.other_species do
-						table.insert_unique(enemy_selection,species)
-					end
-				end
-			end
-		end
-		for _,v in ipairs(temp_processed) do
-			processed_quads[#processed_quads+1] = v
-		end
-		temp_processed = {}
-	end
-	return enemy_selection
+    local valid_targets = MapGet(self, range, "TerritorialNest", function(nest, me)
+        if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species
+            and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
+            return true
+        end
+    end, self)
+    local closest = {}
+    for _, target in ipairs(valid_targets) do
+        if table.find(closest, target.nest_species) then
+            closest[target.nest_species] = target
+        else
+            closest[target.nest_species] = {}
+            closest[target.nest_species][1] = target
+        end
+    end
+    range = range or 5
+    local enemy_selection = {}
+    local processed_quads = {}
+    local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+    for _, species in pairs(my_quad.other_species) do
+        table.insert_unique(enemy_selection, species)
+    end
+    processed_quads[#processed_quads + 1] = self.quadrant
+    local temp_processed = {}
+    for i = 1, range do
+        for _, no in ipairs(processed_quads) do
+            for _, q in ipairs(Get_adjacent_quads(no)) do
+                local this_quad = Nest_scouting_quadrants[q][self.nest_species]
+                if not table.find(processed_quads, q) and not table.find(temp_processed, q) then
+                    temp_processed[#temp_processed + 1] = q
+                    for _, species in pairs(this_quad.other_species) do
+                        table.insert_unique(enemy_selection, species)
+                    end
+                end
+            end
+        end
+        for _, v in ipairs(temp_processed) do
+            processed_quads[#processed_quads + 1] = v
+        end
+        temp_processed = {}
+    end
+    return enemy_selection
 end
 
 function EnhancedTerritorialNest:ClosestSleepyNest(range)
-	range = range or max_int
-	local closest_sleepy = MapFindMin(self,range,"TerritorialNest",function(nest,me,range)
-		if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
-			return me:GetDist2D(nest)
-		end
-	end,self,range)
-	if closest_sleepy then
-		return closest_sleepy
-	else
-		return false
-	end
+    range = range or max_int
+    local closest_sleepy = MapFindMin(self, range, "TerritorialNest", function(nest, me, range)
+        if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
+            return me:GetDist2D(nest)
+        end
+    end, self, range)
+    if closest_sleepy then
+        return closest_sleepy
+    else
+        return false
+    end
 end
 
 function EnhancedTerritorialNest:support_arrived(allied_unit)
-	--print("A unit supporting me has arrived!")
-	local my_strongest_tier = 0
-	if self.state == 'asleep' then
-		--print("This is going to try and wake me up!")
-		if not self.wake_up_alarms then
-			self.wake_up_alarms = 0
-		end
-		self.wake_up_alarms = self.wake_up_alarms + 1
-		local awake = MapCount(true,"TerritorialNest",function(nest,me)
-			if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
-				return true
-			end
-		end,self)
-		-- make it so that each nest needs more units to wake it up
-		local threshold = 1
-		if Faction_aggression_threshold > threshold then
-			threshold = Faction_aggression_threshold
-		end
-		-- This means the first nest only needs a single wake up event
-		local threshold = threshold * awake
-		if self.wake_up_alarms > threshold then
-			--print("It did wake me up!")
-			self:SwitchState('awake')
-		else
-			--print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
-		end
-		goto continue
-	end
-	local hatchling_tier = EE_get_tier(self.hatchling_class)
-	local adult_tier = EE_get_tier(self.adult_class)
-	local elder_tier = EE_get_tier(self.elder_class)
-	local my_best = Max(hatchling_tier,adult_tier,elder_tier)
-	for _,defender in ipairs(self.nest_members) do
-		local d_tier = EE_get_tier(defender.class)
-		if d_tier > my_best then
-			my_best = d_tier
-		end
-	end
-	--print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
-	local compare
-	if allied_unit.class then
-		compare = allied_unit.class
-	else
-		compare = allied_unit.id
-	end
-	--print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
-	if EE_get_tier(compare) > my_best then
-		--print("It is!")
-		self.attacks_done = self.attacks_done + 1
-		if self.attacks_done > self.attacks_to_evo then
-			--print("And it triggered an evolution!")
-			self:change_nest_herd(true)
-		end
-		goto continue
-	else
-		--print("It was not")
-	end
-	--print("Storing this units EP cost in the nearby structrues and reducing attack time!")
-	local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
-	self:give_ep_to_struct(EP_of_unit)
-	local attack_cd = self.attack_delay
-	-- each unit will reduce the attack cd by 5%
-	self.attack_time = self.attack_time - (5*DivRound(attack_cd,100))
-	::continue::
+    --print("A unit supporting me has arrived!")
+    local my_strongest_tier = 0
+    if self.state == 'asleep' then
+        --print("This is going to try and wake me up!")
+        if not self.wake_up_alarms then
+            self.wake_up_alarms = 0
+        end
+        self.wake_up_alarms = self.wake_up_alarms + 1
+        local awake = MapCount(true, "TerritorialNest", function(nest, me)
+            if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
+                return true
+            end
+        end, self)
+        -- make it so that each nest needs more units to wake it up
+        local threshold = 1
+        if Faction_aggression_threshold > threshold then
+            threshold = Faction_aggression_threshold
+        end
+        -- This means the first nest only needs a single wake up event
+        local threshold = threshold * awake
+        if self.wake_up_alarms > threshold then
+            --print("It did wake me up!")
+            self:SwitchState('awake')
+        else
+            --print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
+        end
+        goto continue
+    end
+    local hatchling_tier = EE_get_tier(self.hatchling_class)
+    local adult_tier = EE_get_tier(self.adult_class)
+    local elder_tier = EE_get_tier(self.elder_class)
+    local my_best = Max(hatchling_tier, adult_tier, elder_tier)
+    for _, defender in ipairs(self.nest_members) do
+        local d_tier = EE_get_tier(defender.class)
+        if d_tier > my_best then
+            my_best = d_tier
+        end
+    end
+    --print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
+    local compare
+    if allied_unit.class then
+        compare = allied_unit.class
+    else
+        compare = allied_unit.id
+    end
+    --print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
+    if EE_get_tier(compare) > my_best then
+        --print("It is!")
+        self.attacks_done = self.attacks_done + 1
+        if self.attacks_done > self.attacks_to_evo then
+            --print("And it triggered an evolution!")
+            self:change_nest_herd(true)
+        end
+        goto continue
+    else
+        --print("It was not")
+    end
+    --print("Storing this units EP cost in the nearby structrues and reducing attack time!")
+    local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
+    self:give_ep_to_struct(EP_of_unit)
+    local attack_cd = self.attack_delay
+    -- each unit will reduce the attack cd by 5%
+    self.attack_time = self.attack_time - (5 * DivRound(attack_cd, 100))
+    ::continue::
 end
 
 function EnhancedTerritorialNest:mega_consume()
-	DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
-	local multiplier = Get_difficulty_offset()
-	for i=1, 3 * multiplier do
-		self:consume_closest_node()
-	end
+    DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
+    local multiplier = Get_difficulty_offset()
+    for i = 1, 3 * multiplier do
+        self:consume_closest_node()
+    end
 end
 
 function EnhancedTerritorialNest:alert_neighbor(allied_sleepy_nest)
-	DebugPrint("Nest is sending support to the closest nest!\n")
-	local spawn_def = SpawnDefs['Nest_wakeup_alarm']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.adult_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList+1] = {self.hatchling_class,50}
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t,{},100)
+    DebugPrint("Nest is sending support to the closest nest!\n")
+    local spawn_def = SpawnDefs['Nest_wakeup_alarm']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.adult_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:growth_event()
-	DebugPrint("Nest has grown enough to do something!\n")
+    DebugPrint("Nest has grown enough to do something!\n")
     self:UpdateNextAttackTime()
     self:change_nest_herd()
-	local spawn_def
-	local spawn_def_selection = {}
-	if self.state == 'sleepy' then
-		spawn_def_selection[#spawn_def_selection+1] = {weight=100,fun=self.overflow_spawn}
-		spawn_def_selection[#spawn_def_selection+1] = {weight=15,fun=self.scout_nearest_quad}
-		spawn_def = table.weighted_rand(spawn_def_selection,"weight")
-		spawn_def.fun(self)
-		return
-	end
-	local unscouted = self:GetUnscoutedQuadrantsWithin()
-	local my_quad_scouted = #unscouted[1] > 1
-	local unscouted_nearby = unscouted[3]
-	if not my_quad_scouted then
-		spawn_def_selection[#spawn_def_selection+1] = {weight=200,fun=self.scout_quad,input=unscouted[1][1]}
-	elseif #unscouted_nearby > 0 then
-		local to_scout = table.weighted_rand(unscouted_nearby,function(entry) return 100 end)
-		spawn_def_selection[#spawn_def_selection+1] = {weight=(100*unscouted_nearby),fun=self.scout_quad,input=to_scout}
-	elseif unscouted[#unscouted] > 0 then
-		local to_scout = table.weighted_rand(unscouted[#unscouted],function(entry) return 100 end)
-		spawn_def_selection[#spawn_def_selection+1] = {weight=15,fun=self.scout_quad,input=to_scout}
-	end
-	local attack_range = MulDivRound(NA_X_length+NA_Y_length,2)*3
-	local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
-	if #nearby_enemies > 0 then
-		for _,enemy in ipairs(nearby_enemies) do
-			local weight = 100
-			if enemy.state == 'asleep' then
-				weight = weight * 2
-			end
-			spawn_def_selection[#spawn_def_selection+1] = {weight=weight,fun=self.nest_attack_non_player,input=enemy}
-		end
-	end
-	-- note this means if a nest is awaken by another species, it will still be aggressive towards the player
-	if self:IsPlayerKnown() and not self:Asleep() and self:can_be_aggressive() then
-		local closest = self:GetNestToSupport()
-		if closest then
-			spawn_def_selection[#spawn_def_selection+1] = {weight=150,fun=self.nest_support_closest,input=closest}
-		else
-			spawn_def_selection[#spawn_def_selection+1] = {weight=300,fun=self.nest_attack_player}
-		end
-	else
-		local scouting
-		if unscouted[#unscouted] > 0 then
-			scouting = table.weighted_rand(unscouted[#unscouted],function(entry) return 100 end)
-		else
-			-- we force scout the quadrant with the oldest scouted time as a major major backup
-			for i = 1, #Nest_scouting_quadrants do
-				if Nest_scouting_quadrants[i][self.nest_species].last_scout then
-					scouting = i
-					break
-				end
-				scouting = unscouted[1][1]
-			end
-		end
-		-- if the player is not known, we ALWAYS want to scout and find them
-		spawn_def_selection[#spawn_def_selection+1] = {weight=50,fun=self.scout_quad,input=scouting}
-	end
-	-- if there is a nest within ~3 quadrant lengths
-	local wake_up_range = MulDivRound(NA_X_length+NA_Y_length,2)*3
-	local sleepy =self:ClosestSleepyNest(wake_up_range)
-	if sleepy then
-		spawn_def_selection[#spawn_def_selection+1] = {weight=100,fun=self.alert_neighbor,input=sleepy}
-	end
-	-- always leave the options to just vomit enemies in the nearby area
-	-- and consume a lot of nearby biomass
-	spawn_def_selection[#spawn_def_selection+1] = {weight=10,fun=self.overflow_spawn}
-	spawn_def_selection[#spawn_def_selection+1] = {weight=50,fun=self.mega_consume}
-	spawn_def = table.weighted_rand(spawn_def_selection,"weight")
-	if spawn_def.input then
-		spawn_def.fun(self,spawn_def.input)
-	else
-		spawn_def.fun(self)
-	end
+    local spawn_def
+    local spawn_def_selection = {}
+    if self.state == 'sleepy' then
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.overflow_spawn }
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.scout_nearest_quad }
+        spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+        spawn_def.fun(self)
+        return
+    end
+    -- ensure quadrant + scouting grid exist before reading them (growth_event lacked the guard
+    -- that scout_nearest_quad has; on a fresh map the grid is uninitialised -> nil-index crash)
+    if not self.quadrant then
+        self.quadrant = Get_quadrant_from_obj(self, true)
+    end
+    if not self.nest_species then
+        self.nest_species = get_species_from_nest(self.class)
+    end
+    if not Nest_scouting_quadrants[self.quadrant] then
+        CreateMapGrid()
+    end
+    local unscouted = self:GetUnscoutedQuadrantsWithin()
+    local my_quad_scouted = #unscouted[1] > 0
+    local unscouted_nearby = unscouted[3]
+    if not my_quad_scouted then
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 200, fun = self.Scout_Specific_Quad, input = self
+        .quadrant }
+    elseif #unscouted_nearby > 0 then
+        local to_scout = table.weighted_rand(unscouted_nearby, function(entry) return 100 end)
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = (100 * #unscouted_nearby), fun = self
+        .Scout_Specific_Quad, input = to_scout }
+    elseif #unscouted[#unscouted] > 0 then
+        local to_scout = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.Scout_Specific_Quad, input = to_scout }
+    end
+    local attack_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+    local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
+    if #nearby_enemies > 0 then
+        for _, enemy in ipairs(nearby_enemies) do
+            local weight = 100
+            if enemy.state == 'asleep' then
+                weight = weight * 2
+            end
+            spawn_def_selection[#spawn_def_selection + 1] = { weight = weight, fun = self.nest_attack_non_player, input =
+            enemy }
+        end
+    end
+    -- note this means if a nest is awaken by another species, it will still be aggressive towards the player
+    if self:IsPlayerKnown() and not self:IsAsleep() and self:can_be_aggressive() then
+        -- Per Ark Builder (now with the angular check he hadn't finished): attack the player only if
+        -- this nest is the front line of its species; if a same-species ally is ahead of us toward
+        -- the survivors AND in roughly our own direction, support it instead. The angular gate stops
+        -- support being sent to a ~180-degree-opposite nest (which would cross the player's base).
+        local support_target = self:GetSupportTarget()
+        if support_target then
+            spawn_def_selection[#spawn_def_selection + 1] = { weight = 150, fun = self.nest_support_closest, input =
+            support_target }
+        else
+            spawn_def_selection[#spawn_def_selection + 1] = { weight = 300, fun = self.nest_attack_player }
+        end
+    else
+        local scouting
+        if #unscouted[#unscouted] > 0 then
+            scouting = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+        else
+            -- we force scout the quadrant with the oldest scouted time as a major major backup
+            for i = 1, #Nest_scouting_quadrants do
+                if Nest_scouting_quadrants[i][self.nest_species].last_scout then
+                    scouting = i
+                    break
+                end
+                scouting = unscouted[1][1]
+            end
+        end
+        -- if the player is not known, we ALWAYS want to scout and find them
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.Scout_Specific_Quad, input = scouting }
+    end
+    -- if there is a nest within ~3 quadrant lengths
+    local wake_up_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+    local sleepy = self:ClosestSleepyNest(wake_up_range)
+    if sleepy then
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.alert_neighbor, input = sleepy }
+    end
+    -- always leave the options to just vomit enemies in the nearby area
+    -- and consume a lot of nearby biomass
+    spawn_def_selection[#spawn_def_selection + 1] = { weight = 10, fun = self.overflow_spawn }
+    spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.mega_consume }
+    spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+    if spawn_def.input then
+        spawn_def.fun(self, spawn_def.input)
+    else
+        spawn_def.fun(self)
+    end
 end
 
 function EnhancedTerritorialNest:UpdateNextAttackTime()
-	DebugPrint("Nest updating when to attack next\n")
+    DebugPrint("Nest updating when to attack next\n")
     local diff = Get_difficulty_offset() - 3
-	self.attack_delay = MoonInstance.AttackCooldownMin + AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
+    self.attack_delay = MoonInstance.AttackCooldownMin +
+    AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
     if self.state == 'asleep' then self.attack_delay = self.attack_delay * 2 end
-    self.attack_time =  GameTime() + self.attack_delay --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
-	DebugPrint("Next attack time:\n")
-	DebugPrint(self.attack_time)
-	DebugPrint("\nGame Time:\n")
-	DebugPrint(GameTime())
-	DebugPrint("\n")
+    self.attack_time = GameTime() + self.attack_delay  --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
+    DebugPrint("Next attack time:\n")
+    DebugPrint(self.attack_time)
+    DebugPrint("\nGame Time:\n")
+    DebugPrint(GameTime())
+    DebugPrint("\n")
 end
 
 function EnhancedTerritorialNest:TooTiredCheck()
@@ -1271,251 +1321,252 @@ function EnhancedTerritorialNest:TooTiredCheck()
 end
 
 function EnhancedTerritorialNest:OnObjUpdate(time, update_interval)
-	local health = self.Health
-	if health <= 0 then return end
+    local health = self.Health
+    if health <= 0 then return end
     if self.attack_time < GameTime() and health > 0 and not self:IsDestroyed() then
-		DebugPrint("Nest is activating!\n")
-		self:growth_event()
-		-- grow_event contains logic to determine what this event really "does"
+        DebugPrint("Nest is activating!\n")
+        self:growth_event()
+        -- grow_event contains logic to determine what this event really "does"
     end
-	if self.consume_time < GameTime() then
+    if self.consume_time < GameTime() then
         self:consume_closest_node()
-	end
-	if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
-		if self:TooTiredCheck() then
-			self:SwitchState('asleep')
-		else
-			self.sleep_check = GameTime() + const.Scale.months
-		end
-	end
+    end
+    if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
+        if self:TooTiredCheck() then
+            self:SwitchState('asleep')
+        else
+            self.sleep_check = GameTime() + const.Scale.months
+        end
+    end
 end
 
 function TerritorialNest:Done()
-	local members = self.nest_members
-	for i = #members, 1, -1 do
-		members[i]:SetNest(false)
-	end
-	DeleteThread(self.engagement_range_thread)
-	self.engagement_range_thread = nil
-	self:RemoveFromLabels(Game)
-	self.attack_time = max_int
+    local members = self.nest_members
+    for i = #members, 1, -1 do
+        members[i]:SetNest(false)
+    end
+    DeleteThread(self.engagement_range_thread)
+    self.engagement_range_thread = nil
+    self:RemoveFromLabels(Game)
+    self.attack_time = max_int
 end
 
 function UnitNesting:OnObjUpdate()
-	local nest = self.nest
-	if not IsValid(nest) then
-		return
-	end
-	local effect = self.NestEffect or ""
-	if effect == "" then
-		return
-	end
-	local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
-	if nest_nearby == self.nest_nearby then
-		return
-	end
-	self:give_nest_effect()
+    local nest = self.nest
+    if not IsValid(nest) then
+        return
+    end
+    local effect = self.NestEffect or ""
+    if effect == "" then
+        return
+    end
+    local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
+    if nest_nearby == self.nest_nearby then
+        return
+    end
+    self:give_nest_effect()
 end
 
 function UnitNesting:ReportScoutingResult()
-	quadrant = invader.target_quadrant
-	local day = GameTime()
-	local species = invader.location.nest_species
-	local list_of_found = self.observed_objects
-	nest_scouting_quadrants[quadrant][species]['last_scout'] = day
-	-- Override the last scouting report
-	nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
-	nest_scouting_quadrants[quadrant][species]['other_species'] = {}
-	for _,b in ipairs(list_of_found) do
-		local handle = b['handle'] or false
-		if handle then
-			nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs']+1] = handle
-			local species = get_species_from_nest(b.class)
-			if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
-				nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
-			end
-			nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species']+1] = handle
-		end
-	end
+    quadrant = invader.target_quadrant
+    local day = GameTime()
+    local species = invader.location.nest_species
+    local list_of_found = self.observed_objects
+    nest_scouting_quadrants[quadrant][species]['last_scout'] = day
+    -- Override the last scouting report
+    nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
+    nest_scouting_quadrants[quadrant][species]['other_species'] = {}
+    for _, b in ipairs(list_of_found) do
+        local handle = b['handle'] or false
+        if handle then
+            nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs'] + 1] =
+            handle
+            local species = get_species_from_nest(b.class)
+            if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
+                nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
+            end
+            nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species'] + 1] =
+            handle
+        end
+    end
 end
 
 -- override of base game function to give nest effect in case things go wrong
 function TerritorialNest:AddNestMember(member)
-	table.insert(self.nest_members, member)
-	if member.CombatGroup ~= self.CombatGroup then
-		member.CombatGroup = self.CombatGroup
-	end
-	-- mark guardian members as such (they stay close to the nest and protect it if attacked)
-	self:TrySetNestGuardian(member)
-	member:give_nest_effect()
+    table.insert(self.nest_members, member)
+    if member.CombatGroup ~= self.CombatGroup then
+        member.CombatGroup = self.CombatGroup
+    end
+    -- mark guardian members as such (they stay close to the nest and protect it if attacked)
+    self:TrySetNestGuardian(member)
+    member:give_nest_effect()
 end
 
 function UnitNesting:give_nest_effect()
-	if not self.nest then return end
-	local nest = self.nest
-	local give = self:IsCloser(nest, nest.territorial_range)
-	if give then
-		if IsKindOf(self,"Robot") then
-			self:AddRobotCondition('FamiliarGroundRobo','mod')
-		else
-			self:AddHealthCondition(self.NestEffect or "", "nest")
-		end
-	elseif IsKindOf(self,"Robot") then
-		self:RemoveRobotCondition('FamiliarGroundRobo','mod')
-	else
-		self:RemoveHealthConditions(self.NestEffect or "", "nest")
-
-	end
+    if not self.nest then return end
+    local nest = self.nest
+    local give = self:IsCloser(nest, nest.territorial_range)
+    if give then
+        if IsKindOf(self, "Robot") then
+            self:AddRobotCondition('FamiliarGroundRobo', 'mod')
+        else
+            self:AddHealthCondition(self.NestEffect or "", "nest")
+        end
+    elseif IsKindOf(self, "Robot") then
+        self:RemoveRobotCondition('FamiliarGroundRobo', 'mod')
+    else
+        self:RemoveHealthConditions(self.NestEffect or "", "nest")
+    end
 end
 
 function UnitNesting:UpdateAttachedUI()
-	if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
-	RemoveAttachedUIToObject(self, 'NestRolePermanent')
-	RemoveAttachedUIToObject(self, 'NestRoleClose')
-	RemoveAttachedUIToObject(self, 'NestRoleFar')
-	local template
-	if NA_NestRoleZoom == 3 then
-		template = 'NestRolePermanent'
-	elseif NA_NestRoleZoom == 2 then
-		template = 'NestRoleFar'
-	elseif NA_NestRoleZoom == 1 then
-		 template = 'NestRoleClose'
-	end
-	if template then
-		AddAttachedUIToObject(self, template, 'Task', self)
-	end
+    if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
+    RemoveAttachedUIToObject(self, 'NestRolePermanent')
+    RemoveAttachedUIToObject(self, 'NestRoleClose')
+    RemoveAttachedUIToObject(self, 'NestRoleFar')
+    local template
+    if NA_NestRoleZoom == 3 then
+        template = 'NestRolePermanent'
+    elseif NA_NestRoleZoom == 2 then
+        template = 'NestRoleFar'
+    elseif NA_NestRoleZoom == 1 then
+        template = 'NestRoleClose'
+    end
+    if template then
+        AddAttachedUIToObject(self, template, 'Task', self)
+    end
 end
 
 function UnitNesting:GetUIRole()
-	if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
-	if self.hide_UI_on_empty and amount <= 0 then return "" end
-	local name = ''
-	if NA_NestRoleName then
-		name = self:GetHUDName(self)
-	end
-	local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
-	local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
-	local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
-	local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-	local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
-	local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-	if self.found_player then
-		return T{"<image "..scout_found_player.." 1800><name>",name=name}
-	elseif self.scouting then
-		return T{"<image "..scout.." 1800><name>",name=name}
-	elseif self.pathing_to then
-		return T{"<image "..support.." 1800><name>",name=name}
-	elseif self.nest then
-		local image = defender
-		return T{"<image "..image.." 1800><name>",name=name}
-	end
+    if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
+    if self.hide_UI_on_empty and amount <= 0 then return "" end
+    local name = ''
+    if NA_NestRoleName then
+        name = self:GetHUDName(self)
+    end
+    local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
+    local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
+    local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
+    local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+    local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
+    local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+    if self.found_player then
+        return T { "<image " .. scout_found_player .. " 1800><name>", name = name }
+    elseif self.scouting then
+        return T { "<image " .. scout .. " 1800><name>", name = name }
+    elseif self.pathing_to then
+        return T { "<image " .. support .. " 1800><name>", name = name }
+    elseif self.nest then
+        local image = defender
+        return T { "<image " .. image .. " 1800><name>", name = name }
+    end
 end
 
 local OG_ShouldShowHUDName = UnitAnimal.ShouldShowHUDName
 function UnitAnimal:ShouldShowHUDName()
-	local base = OG_ShouldShowHUDName(self)
-	if self:CheckForNewBehaviors() or self.nest then return true else return base end
-	--return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
+    local base = OG_ShouldShowHUDName(self)
+    if self:CheckForNewBehaviors() or self.nest then return true else return base end
+    --return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
 end
 
 function UnitNesting:SetNest(nest)
-	nest = nest or false
-	if nest == self.nest then return end
-	local old_nest = self.nest
-	if IsValid(old_nest) then
-		old_nest:RemoveNestMember(self)
-	end
-	self.nest = nest or nil
-	if IsValid(nest) then
-		nest:AddNestMember(self)
-		--self:AddHUDName()
-	end
+    nest = nest or false
+    if nest == self.nest then return end
+    local old_nest = self.nest
+    if IsValid(old_nest) then
+        old_nest:RemoveNestMember(self)
+    end
+    self.nest = nest or nil
+    if IsValid(nest) then
+        nest:AddNestMember(self)
+        --self:AddHUDName()
+    end
 end
 
-function is_inside_of(box,pos)
-	if box:GetDist2D(pos) == 0 then
-		return true
-	else
-		return false
-	end
+function is_inside_of(box, pos)
+    if box:GetDist2D(pos) == 0 then
+        return true
+    else
+        return false
+    end
 end
 
 function TerritorialNest:SpawnAround(class, range, instant, burrowed)
-	local def = class and g_Classes[class]
-	if not def then return end
-	if burrowed and not def.CanBurrowInNest then return end
-	local playbox = GetPlayBox()
-	local pfclass = def.pfclass
-	local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
-	local nest_entity_radius = self:GetRadius()
-	local x,y
-	local retry = 10
-	-- overriding range given because that is usually just 10 meters...
-	range = self.max_range
-	while not x and retry > 0 do
-		x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
-		if x then
-			local temp_pos = point(x,y)
-			local playbox_check = playbox:Dist2(temp_pos) > 1
-			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-			if playbox_check or under_nest then
-				x = nil
-				retry = retry - 1
-			else
-				retry = -1
-			end
-		end
-	end
-	if not x then return end
-	if IsKindOf(def,'Robot') then
+    local def = class and g_Classes[class]
+    if not def then return end
+    if burrowed and not def.CanBurrowInNest then return end
+    local playbox = GetPlayBox()
+    local pfclass = def.pfclass
+    local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
+    local nest_entity_radius = self:GetRadius()
+    local x, y
+    local retry = 10
+    -- overriding range given because that is usually just 10 meters...
+    range = self.max_range
+    while not x and retry > 0 do
+        x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
+        if x then
+            local temp_pos = point(x, y)
+            local playbox_check = playbox:Dist2(temp_pos) > 1
+            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+            if playbox_check or under_nest then
+                x = nil
+                retry = retry - 1
+            else
+                retry = -1
+            end
+        end
+    end
+    if not x then return end
+    if IsKindOf(def, 'Robot') then
         local spawn_def = SpawnDefs['single_spawn_around_loc']
-		local instance = {}
-		instance.location = self
-		instance.radius = range
-		instance.PostSpawn = function(self,obj,target,context)
-			obj:SetNest(self.location)
-			obj:SetInvader(true)
-		end
-		instance.FindSpawnLoc = function(self, spawn_class, target,context)
-			return point(x,y)
-		end
-		instance.SpawnClass = class
-		spawn_def = spawn_def:CreateInstance(instance)
-		local t = spawn_def:ResolveTarget()
-		spawn_def:ActivateSpawn(t,{},100)
-		return true
-	else
-		local obj
-		obj = def:new()
-		obj:SetNest(self)
-		obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360*60, "SpawnNestMember"))
-		if not instant then
-			obj.init_with_command = "CmdSpawn"
-		end
-		return obj
-	end
-	-- in case we have changed what combat groups this nest is
-	obj.CombatGroup = self.CombatGroup
-	return false
+        local instance = {}
+        instance.location = self
+        instance.radius = range
+        instance.PostSpawn = function(self, obj, target, context)
+            obj:SetNest(self.location)
+            obj:SetInvader(true)
+        end
+        instance.FindSpawnLoc = function(self, spawn_class, target, context)
+            return point(x, y)
+        end
+        instance.SpawnClass = class
+        spawn_def = spawn_def:CreateInstance(instance)
+        local t = spawn_def:ResolveTarget()
+        spawn_def:ActivateSpawn(t, {}, 100)
+        return true
+    else
+        local obj
+        obj = def:new()
+        obj:SetNest(self)
+        obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360 * 60, "SpawnNestMember"))
+        if not instant then
+            obj.init_with_command = "CmdSpawn"
+        end
+        return obj
+    end
+    -- in case we have changed what combat groups this nest is
+    obj.CombatGroup = self.CombatGroup
+    return false
 end
 
-function TerritorialNest:Spawn_robot_nestling(x,y,class)
-	local spawn_def = SpawnDefs['Single_Robots']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.pos = point(x,y)
-	instance.SpawnClass = class
-	instance.FindSpawnLoc = function(self, spawn_class, target,context)
-		return self.pos
-	end
-	--[[instance.PostSpawn = function(self,obj,target,context)
+function TerritorialNest:Spawn_robot_nestling(x, y, class)
+    local spawn_def = SpawnDefs['Single_Robots']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.pos = point(x, y)
+    instance.SpawnClass = class
+    instance.FindSpawnLoc = function(self, spawn_class, target, context)
+        return self.pos
+    end
+    --[[instance.PostSpawn = function(self,obj,target,context)
 		obj:SetInvader(true)
 		obj:SetNest(self.nest)
 	end--]]
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t,{},100)
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 AppendClass.TerritorialNest = {
@@ -1525,96 +1576,96 @@ AppendClass.TerritorialNest = {
 -- meta class grouping all spore buildings for easier searching
 -- We do not append ConsortiumSporeDeposit because we define it in the other file with this as a parent already
 DefineClass.NestSpore = {
-	properties = {}
+    properties = {}
 }
 
 AppendClass.ShriekerSporeDeposit = {
-	__parents = { "NestSpore" }
+    __parents = { "NestSpore" }
 }
 
 AppendClass.ScissorhandSporeDeposit = {
-	__parents = { "NestSpore" }
+    __parents = { "NestSpore" }
 }
 
-function count_effects_by_id(target,effect_id)
-	local count = 0
-	for _, effect in ipairs(target.status_effects or empty_table) do
-		if effect.id == effect_id then
-			count = count +1
-		end
-	end
-	return count
+function count_effects_by_id(target, effect_id)
+    local count = 0
+    for _, effect in ipairs(target.status_effects or empty_table) do
+        if effect.id == effect_id then
+            count = count + 1
+        end
+    end
+    return count
 end
 
 function decay_speed(target)
-	local effect_id = 'nest_attack_speed'
-	--[[if IsKindOf(target,'Robot') then
+    local effect_id = 'nest_attack_speed'
+    --[[if IsKindOf(target,'Robot') then
 		effect_id = 'nest_attack_speed_robot'
 		target:RemoveRobotConditions(effect_id, "ReplaceOldest")
 	end--]]
-	local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
-	local distance_to = target:GetDist2D(survivors)
-	local prox = MulDivRound(distance_to,1,150*guim)
-	local count = count_effects_by_id(target,effect_id)
-	while count > prox do
-		if IsKindOf(target,'Robot') then
-			target:RemoveRobotConditions(effect_id, "ReplaceOldest")
-			count = count_effects_by_id(target,effect_id)
-		else
-			target:RemoveHealthConditions(effect_id, "ReplaceOldest")
-			count = count_effects_by_id(target,effect_id)
-		end
-	end
+    local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
+    local distance_to = target:GetDist2D(survivors)
+    local prox = MulDivRound(distance_to, 1, 150 * guim)
+    local count = count_effects_by_id(target, effect_id)
+    while count > prox do
+        if IsKindOf(target, 'Robot') then
+            target:RemoveRobotConditions(effect_id, "ReplaceOldest")
+            count = count_effects_by_id(target, effect_id)
+        else
+            target:RemoveHealthConditions(effect_id, "ReplaceOldest")
+            count = count_effects_by_id(target, effect_id)
+        end
+    end
 end
 
 function add_delay_to_nests()
-	MapForEach(true,"TerritorialNest", function(nest)
-		if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
-			nest:UpdateNextAttackTime()
-		end
-	end)
+    MapForEach(true, "TerritorialNest", function(nest)
+        if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
+            nest:UpdateNextAttackTime()
+        end
+    end)
 end
 
 function clean_up_robots()
-	MapForEach(true,"Robot", function(robot)
-		if not robot.Invader and not robot.command_center then
-			DoneObject(robot)
-		end
-	end)
-	MapForEach(true,"ConsortiumNest", function(nest)
-		local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
-		nest:UpdateTerritoryTerrain(true, count)
-		for i = 1, count do
-			if not nest:SpawnNestMember(true) then
-				break
-			end
-		end
-	end)
+    MapForEach(true, "Robot", function(robot)
+        if not robot.Invader and not robot.command_center then
+            DoneObject(robot)
+        end
+    end)
+    MapForEach(true, "ConsortiumNest", function(nest)
+        local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
+        nest:UpdateTerritoryTerrain(true, count)
+        for i = 1, count do
+            if not nest:SpawnNestMember(true) then
+                break
+            end
+        end
+    end)
 end
 
 function delete_robots()
-	MapDelete("map", "HeavyHostileRobot_LVL1", function(robot,playbox)
-		return is_inside_of(playbox,robot)
-	end,GetPlayBox())
+    MapDelete("map", "HeavyHostileRobot_LVL1", function(robot, playbox)
+        return is_inside_of(playbox, robot)
+    end, GetPlayBox())
 end
 
 function SavegameFixups.EnhancedNestFixes()
-	add_delay_to_nests()
-	clean_up_robots()
-	delete_robots()
+    add_delay_to_nests()
+    clean_up_robots()
+    delete_robots()
 end
 
 function OnMsg.PostLoadGame()
-	delete_robots()
+    delete_robots()
 end
 
 function OnMsg.UpdateNestRoleVisuals()
-	MapForEach('map', 'UnitNesting', function(nest_member)
-		nest_member:UpdateAttachedUI()
-	end)
+    MapForEach('map', 'UnitNesting', function(nest_member)
+        nest_member:UpdateAttachedUI()
+    end)
 end
 
---[[ Debugging ovverride 
+--[[ Debugging ovverride
 function CreateFloatingText(target, text, style, spot, stagger_spawn, params, game_time)
 	print(text)
 	return CreateCustomFloatingText(nil, target, text, style, spot, stagger_spawn, params, game_time)

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -4,374 +4,374 @@ local hours_per_day = day_duration / hour_duration
 
 
 function Juno_Cancer(force)
-	local nests = {}
-	if force then
-		nests = MapGet(true, 'TerritorialNest', function(nest)
-			if nest.class ~= 'JunoNest' then return true end
-		end)
-	else
-		nests = MapGet(true, 'TerritorialNest', function(nest)
-			if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
-				return true
-			end
-		end)
-	end
-	if #nests > 0 then
-		local roll = AsyncRand(#nests)
-		local to_convert = nests[roll]
-		Convert_nest_into(to_convert, 'nesting_juno')
-	elseif force then
-	end
+    local nests = {}
+    if force then
+        nests = MapGet(true, 'TerritorialNest', function(nest)
+            if nest.class ~= 'JunoNest' then return true end
+        end)
+    else
+        nests = MapGet(true, 'TerritorialNest', function(nest)
+            if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
+                return true
+            end
+        end)
+    end
+    if #nests > 0 then
+        local roll = AsyncRand(#nests)
+        local to_convert = nests[roll]
+        Convert_nest_into(to_convert, 'nesting_juno')
+    elseif force then
+    end
 end
 
 function SpawnNestInsideMap(marker, seed, nest_type, danger_lvl)
-	DebugPrint("Spawning a nest\n")
-	if marker and terrain.IsWater(marker) then
-		return
-	end
-	-- danger level does nothing right now, not part of MVP
-	danger_lvl = danger_lvl or 1
-	seed = seed or InteractionRand(nil, "DailySpawn")
-	local tags = {}
-	nest_type = nest_type or Get_nest_by_region()
-	if not nest_type then
-		return
-	elseif nest_type == 'ShriekerNest' then
-		tags = { shrieker_fall = true }
-	elseif nest_type == 'ScissorhandsNest' then
-		tags = { scissorhands_nest = true }
-	else
-		--("Using backup, whatever nest type is the tag!")
-		--(nest_type)
-		tags[nest_type] = true -- future proof for PX, the nest_type input will be the needed tag
-	end
-	--(tags)
-	SuspendPassEdits("SpawndNest")
-	seed = seed or InteractionRand(nil, "DailySpawn")
-	local nest
-	--(seed)
-	--()
-	local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
-		tags_all = tags,
-	})
-	if not err then
-		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-		if nest_marker then
-			nest = nest_marker:SpawnNest(true)
-		else
-			assert(false, "Prefab without a nest marker: " .. name)
-		end
-	else
-		assert(false, "Prefab error: " .. err)
-	end
-	ResumePassEdits("SpawndNest")
-	return nest
+    DebugPrint("Spawning a nest\n")
+    if marker and terrain.IsWater(marker) then
+        return
+    end
+    -- danger level does nothing right now, not part of MVP
+    danger_lvl = danger_lvl or 1
+    seed = seed or InteractionRand(nil, "DailySpawn")
+    local tags = {}
+    nest_type = nest_type or Get_nest_by_region()
+    if not nest_type then
+        return
+    elseif nest_type == 'ShriekerNest' then
+        tags = { shrieker_fall = true }
+    elseif nest_type == 'ScissorhandsNest' then
+        tags = { scissorhands_nest = true }
+    else
+        --("Using backup, whatever nest type is the tag!")
+        --(nest_type)
+        tags[nest_type] = true -- future proof for PX, the nest_type input will be the needed tag
+    end
+    --(tags)
+    SuspendPassEdits("SpawndNest")
+    seed = seed or InteractionRand(nil, "DailySpawn")
+    local nest
+    --(seed)
+    --()
+    local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
+        tags_all = tags,
+    })
+    if not err then
+        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+        if nest_marker then
+            nest = nest_marker:SpawnNest(true)
+        else
+            assert(false, "Prefab without a nest marker: " .. name)
+        end
+    else
+        assert(false, "Prefab error: " .. err)
+    end
+    ResumePassEdits("SpawndNest")
+    return nest
 end
 
 function PlacePrefabLogic:GetPrefabLoc(seed, params)
-	seed = seed or InteractionRand(nil, "PlacePrefab")
-	local name, pos, angle, prefab, idx
-	--("Params")
-	--(params)
-	local prefabs = self:GetPrefabs(params)
-	--("Initial get of #prefabs")
-	--(#prefabs)
-	local r = 4
-	local fresh_prefabs
-	while #prefabs == 0 and r > 0 do
-		--("RETRYING BECAUSE I FAILED TO FIND")
-		prefabs = self:GetPrefabs(params)
-		local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
-		--("non-self prefab get count")
-		--(#fresh_prefabs)
-		--("self get of #prefabs")
-		--(#prefabs)
-		r = r - 1
-		if #fresh_prefabs > #prefabs then
-			prefabs = fresh_prefabs
-		end
-	end
-	local retry
-	while true do
-		local idx
-		if #prefabs > 1 then
-			prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
-		else
-			prefab = prefabs[1]
-		end
-		----(prefab)
-		assert(prefab)
-		if not prefab then
-			return
-		end
-		pos = params and params.pos
-		if not pos then
-			pos = self:GetVisualPos()
-			if not self.FixAtCenter then
-				local reserved_radius
-				if params and params.avoid_reserved_locations and self.reserved_locations then
-					reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
-				end
-				local radius = prefab.max_radius * const.TypeTileSize
-				local free_dist = self.MaxPrefabRadius - radius
-				if free_dist > 0 then
-					local center = pos
-					pos = false
-					local retries = params and params.avoid_reserved_retries or 16
-					for i = 1, retries do
-						local ra, rr
-						ra, seed = BraidRandom(seed, 360 * 60)
-						rr, seed = BraidRandom(seed, free_dist)
-						local pos_i = RotateRadius(rr, ra, center)
-						if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
-							pos = pos_i
-							break
-						end
-					end
-				elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
-					pos = false
-				end
-			end
-		end
-		if pos then
-			name = PrefabMarkers[prefab]
-			angle = params and params.angle
-			if not angle then
-				angle = self:GetAngle()
-				local rand_angle = self.RandAngle
-				if rand_angle > 0 then
-					local desired_angle = params and params.desired_angle
-					if desired_angle then
-						local angle_diff = AngleDiff(desired_angle, angle)
-						if abs(angle_diff) <= rand_angle then
-							angle = desired_angle
-						else
-							local min_angle, max_angle = angle - rand_angle, angle + rand_angle
-							if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
-								angle = min_angle
-							else
-								angle = max_angle
-							end
-						end
-					else
-						local da
-						da, seed = BraidRandom(seed, -rand_angle, rand_angle)
-						angle = angle + da
-					end
-				end
-			end
-			return name, pos, angle, prefab, seed
-		end
-		if #prefabs == 1 then
-			return
-		end
-		table.remove_rotate(prefabs, idx)
-	end
+    seed = seed or InteractionRand(nil, "PlacePrefab")
+    local name, pos, angle, prefab, idx
+    --("Params")
+    --(params)
+    local prefabs = self:GetPrefabs(params)
+    --("Initial get of #prefabs")
+    --(#prefabs)
+    local r = 4
+    local fresh_prefabs
+    while #prefabs == 0 and r > 0 do
+        --("RETRYING BECAUSE I FAILED TO FIND")
+        prefabs = self:GetPrefabs(params)
+        local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
+        --("non-self prefab get count")
+        --(#fresh_prefabs)
+        --("self get of #prefabs")
+        --(#prefabs)
+        r = r - 1
+        if #fresh_prefabs > #prefabs then
+            prefabs = fresh_prefabs
+        end
+    end
+    local retry
+    while true do
+        local idx
+        if #prefabs > 1 then
+            prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
+        else
+            prefab = prefabs[1]
+        end
+        ----(prefab)
+        assert(prefab)
+        if not prefab then
+            return
+        end
+        pos = params and params.pos
+        if not pos then
+            pos = self:GetVisualPos()
+            if not self.FixAtCenter then
+                local reserved_radius
+                if params and params.avoid_reserved_locations and self.reserved_locations then
+                    reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
+                end
+                local radius = prefab.max_radius * const.TypeTileSize
+                local free_dist = self.MaxPrefabRadius - radius
+                if free_dist > 0 then
+                    local center = pos
+                    pos = false
+                    local retries = params and params.avoid_reserved_retries or 16
+                    for i = 1, retries do
+                        local ra, rr
+                        ra, seed = BraidRandom(seed, 360 * 60)
+                        rr, seed = BraidRandom(seed, free_dist)
+                        local pos_i = RotateRadius(rr, ra, center)
+                        if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
+                            pos = pos_i
+                            break
+                        end
+                    end
+                elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
+                    pos = false
+                end
+            end
+        end
+        if pos then
+            name = PrefabMarkers[prefab]
+            angle = params and params.angle
+            if not angle then
+                angle = self:GetAngle()
+                local rand_angle = self.RandAngle
+                if rand_angle > 0 then
+                    local desired_angle = params and params.desired_angle
+                    if desired_angle then
+                        local angle_diff = AngleDiff(desired_angle, angle)
+                        if abs(angle_diff) <= rand_angle then
+                            angle = desired_angle
+                        else
+                            local min_angle, max_angle = angle - rand_angle, angle + rand_angle
+                            if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
+                                angle = min_angle
+                            else
+                                angle = max_angle
+                            end
+                        end
+                    else
+                        local da
+                        da, seed = BraidRandom(seed, -rand_angle, rand_angle)
+                        angle = angle + da
+                    end
+                end
+            end
+            return name, pos, angle, prefab, seed
+        end
+        if #prefabs == 1 then
+            return
+        end
+        table.remove_rotate(prefabs, idx)
+    end
 end
 
 RecursiveCallMethods.RegisterTarget = "call"
 
 DefineClass.EnhancedTerritorialNest = {
 
-	properties = {
-		{ category = "Nest", id = "state",             name = "State of nest",                                 editor = "choice", template = true,   items = { "asleep", "sleepy", "awake", "allied" }, default = 'asleep',                                                                                                       modifiable = true, help = "state of the nest" },
-		{ category = "Nest", id = "attack_time",       name = "Nest Attack Time",                              editor = "number", default = max_int, modifiable = true,                                 help = "When a nest will attack next if not asleep." },
-		{ category = "Nest", id = "attack_delay",      name = "Nest Attack Delay",                             editor = "number", default = max_int, modifiable = true,                                 help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)" },
-		{ category = "Nest", id = "attacks_done",      name = "Nest Attack Count",                             editor = "number", default = 0,       modifiable = true,                                 help = "Number of attacks this nest has sent total" },
-		{ category = "Nest", id = "attacks_to_evo",    name = "attacks needed to force evolution",             editor = "number", default = 4,       modifiable = true,                                 help = "How much EP is needed to evolve the nest denizens" },
-		{ category = "Nest", id = "proximity",         name = "Nests proximity to players stuff",              editor = "number", default = 1,       modifiable = true,                                 help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates" },
-		{ category = "Nest", id = "ui_attack_percent", name = "How close the attack time is to occuring",      editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
-		{ category = "Nest", id = "ui_evo",            name = "How close this nest is too evolving it's herd", editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
-		{ category = "Nest", id = "base_strength",     name = "Base % str of an attack this will send",        editor = "number", scale = "%",       default = 30,                                      modifiable = true,                                                                                                        help = "" },
-		{ category = "Nest", id = "consume_time",      name = "When nest will eat the next node",              editor = "number", default = 0,       modifiable = true,                                 help = "This is routinely updated based on each individual nest" },
-	},
-	state = 'asleep',
-	attack_time = max_int,
-	attack_delay = max_int,
-	attacks_done = 0,
-	attacks_to_evo = 4,
-	base_strength = 20,
-	consume_time = max_int,
-	proximity = 1,
-	ui_attack_percent = 0,
-	ui_evo = 0,
-	sleep_check = 0,
-	awoken_at = 0,
-	attacked_by_player = false,
-	other_species_attacks = {},
+    properties = {
+        { category = "Nest", id = "state",             name = "State of nest",                                 editor = "choice", template = true,   items = { "asleep", "sleepy", "awake", "allied" }, default = 'asleep',                                                                                                       modifiable = true, help = "state of the nest" },
+        { category = "Nest", id = "attack_time",       name = "Nest Attack Time",                              editor = "number", default = max_int, modifiable = true,                                 help = "When a nest will attack next if not asleep." },
+        { category = "Nest", id = "attack_delay",      name = "Nest Attack Delay",                             editor = "number", default = max_int, modifiable = true,                                 help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)" },
+        { category = "Nest", id = "attacks_done",      name = "Nest Attack Count",                             editor = "number", default = 0,       modifiable = true,                                 help = "Number of attacks this nest has sent total" },
+        { category = "Nest", id = "attacks_to_evo",    name = "attacks needed to force evolution",             editor = "number", default = 4,       modifiable = true,                                 help = "How much EP is needed to evolve the nest denizens" },
+        { category = "Nest", id = "proximity",         name = "Nests proximity to players stuff",              editor = "number", default = 1,       modifiable = true,                                 help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates" },
+        { category = "Nest", id = "ui_attack_percent", name = "How close the attack time is to occuring",      editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
+        { category = "Nest", id = "ui_evo",            name = "How close this nest is too evolving it's herd", editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
+        { category = "Nest", id = "base_strength",     name = "Base % str of an attack this will send",        editor = "number", scale = "%",       default = 30,                                      modifiable = true,                                                                                                        help = "" },
+        { category = "Nest", id = "consume_time",      name = "When nest will eat the next node",              editor = "number", default = 0,       modifiable = true,                                 help = "This is routinely updated based on each individual nest" },
+    },
+    state = 'asleep',
+    attack_time = max_int,
+    attack_delay = max_int,
+    attacks_done = 0,
+    attacks_to_evo = 4,
+    base_strength = 20,
+    consume_time = max_int,
+    proximity = 1,
+    ui_attack_percent = 0,
+    ui_evo = 0,
+    sleep_check = 0,
+    awoken_at = 0,
+    attacked_by_player = false,
+    other_species_attacks = {},
 }
 
 function EnhancedTerritorialNest:Align_cgroup_members()
-	for _, v in ipairs(self.nest_members) do
-		v.CombatGroup = self.CombatGroup
-	end
+    for _, v in ipairs(self.nest_members) do
+        v.CombatGroup = self.CombatGroup
+    end
 end
 
 function NestDelayedInit(nest)
-	nest:UpdateNextAttackTime()
-	nest:get_proximity()
-	--nest:force_inert_if_capped()
-	nest.quadrant = Get_quadrant_from_obj(nest, true)
-	nest.spawned_on = GameTime()
+    nest:UpdateNextAttackTime()
+    nest:get_proximity()
+    --nest:force_inert_if_capped()
+    nest.quadrant = Get_quadrant_from_obj(nest, true)
+    nest.spawned_on = GameTime()
 end
 
 --~Presets.UnitSpeciesGroup.Default[Presets.NestingSpeciesPreset.Default[get_species_from_nest(SelectedObj.class)].unit_species]
 function EnhancedTerritorialNest:Init()
-	self.attack_time = max_int
-	self.consume_time = max_int
-	self.nest_species = get_species_from_nest(self.class)
-	local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
-	local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
-	local desired_cgroup = full_species_details.primary_combat_group
-	if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups, self.CombatGroup) then
-		self.CombatGroup = desired_cgroup
-		self:Align_cgroup_members()
-	end
-	-- wait a day then reset the above
-	CreateGameTimeThread(function(this_nest)
-		Sleep(day_duration)
-		NestDelayedInit(this_nest)
-	end, self)
+    self.attack_time = max_int
+    self.consume_time = max_int
+    self.nest_species = get_species_from_nest(self.class)
+    local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
+    local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
+    local desired_cgroup = full_species_details.primary_combat_group
+    if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups, self.CombatGroup) then
+        self.CombatGroup = desired_cgroup
+        self:Align_cgroup_members()
+    end
+    -- wait a day then reset the above
+    CreateGameTimeThread(function(this_nest)
+        Sleep(day_duration)
+        NestDelayedInit(this_nest)
+    end, self)
 end
 
 function EnhancedTerritorialNest:get_next_consume_time()
-	local wait_for = AsyncRand(hour_duration * 24, hour_duration * 36)
-	self.consume_time = GameTime() + wait_for
+    local wait_for = AsyncRand(hour_duration * 24, hour_duration * 36)
+    self.consume_time = GameTime() + wait_for
 end
 
 --This technically just increases the nest members, because the base game uses the nests herd to set the controlled territory
 function EnhancedTerritorialNest:expand()
-	DebugPrint("Nest Expanding it's territory!\n")
-	local expand_by = 6
-	local nodes = 0
-	local max_growths = 5
-	local grows = 0
-	while nodes < 30 and grows < max_growths do
-		--(nodes)
-		--("expanded the distance ",grows,' times')
-		nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
-			if not IsKindOf(thing, 'NestSpore') then return true end
-		end)
-		grows = grows + 1
-		--("At this increased radius, there are ",nodes,' valid nodes to consume')
-	end
-	--("There was enough nodes nearby to warrant an increase of",grows*expand_by,' meter radius')
-	self.elders_max_count = self.elders_max_count + grows
-	self.hatchlings_max_count = self.hatchlings_max_count + grows
-	self.adults_max_count = self.adults_max_count + grows
+    DebugPrint("Nest Expanding it's territory!\n")
+    local expand_by = 6
+    local nodes = 0
+    local max_growths = 5
+    local grows = 0
+    while nodes < 30 and grows < max_growths do
+        --(nodes)
+        --("expanded the distance ",grows,' times')
+        nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
+            if not IsKindOf(thing, 'NestSpore') then return true end
+        end)
+        grows = grows + 1
+        --("At this increased radius, there are ",nodes,' valid nodes to consume')
+    end
+    --("There was enough nodes nearby to warrant an increase of",grows*expand_by,' meter radius')
+    self.elders_max_count = self.elders_max_count + grows
+    self.hatchlings_max_count = self.hatchlings_max_count + grows
+    self.adults_max_count = self.adults_max_count + grows
 end
 
 function Convert_nest_into(nest_to_convert, other_species, delete_old_members)
-	if not Presets.NestingSpeciesPreset.Default[other_species] then return end
-	local species = Presets.NestingSpeciesPreset.Default[other_species]
-	local o_species_tags = species.PrefabTags
-	local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
-	local spore_building_def = my_current.spore_buildings
-	local spores = MapGet(nest_to_convert, nest_to_convert.max_range, spore_building_def)
-	if delete_old_members then
-		for _, member in ipairs(nest_to_convert.nest_members) do
-			member:SetNest(false)
-			DoneObject(member)
-		end
-	end
-	for _, spore in ipairs(spores) do
-		DoneObject(spore)
-	end
-	local def = g_Classes['FallingDebrisMarker']
-	local old_marker = MapFindNearest(nest_to_convert, true, 'TerritorialNestMarker')
-	DoneObject(nest_to_convert)
-	local pos = old_marker:GetPos()
-	local new_marker = def:new()
-	new_marker:SetPosAngle(pos)
-	DoneObject(old_marker)
+    if not Presets.NestingSpeciesPreset.Default[other_species] then return end
+    local species = Presets.NestingSpeciesPreset.Default[other_species]
+    local o_species_tags = species.PrefabTags
+    local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
+    local spore_building_def = my_current.spore_buildings
+    local spores = MapGet(nest_to_convert, nest_to_convert.max_range, spore_building_def)
+    if delete_old_members then
+        for _, member in ipairs(nest_to_convert.nest_members) do
+            member:SetNest(false)
+            DoneObject(member)
+        end
+    end
+    for _, spore in ipairs(spores) do
+        DoneObject(spore)
+    end
+    local def = g_Classes['FallingDebrisMarker']
+    local old_marker = MapFindNearest(nest_to_convert, true, 'TerritorialNestMarker')
+    DoneObject(nest_to_convert)
+    local pos = old_marker:GetPos()
+    local new_marker = def:new()
+    new_marker:SetPosAngle(pos)
+    DoneObject(old_marker)
 
-	SuspendPassEdits("SpawndNest")
-	local seed = InteractionRand(nil, "DailySpawn")
-	local nest
-	--(seed)
-	--()
-	local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
-		tags_all = o_species_tags,
-	})
-	if not err then
-		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-		if nest_marker then
-			nest = nest_marker:SpawnNest(true)
-		else
-			assert(false, "Prefab without a nest marker: " .. name)
-		end
-	else
-		assert(false, "Prefab error: " .. err)
-	end
-	ResumePassEdits("SpawndNest")
-	AddGameNotification("JunoNestSpawned", nil, nil, { nest })
-	return nest
-	--SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
+    SuspendPassEdits("SpawndNest")
+    local seed = InteractionRand(nil, "DailySpawn")
+    local nest
+    --(seed)
+    --()
+    local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
+        tags_all = o_species_tags,
+    })
+    if not err then
+        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+        if nest_marker then
+            nest = nest_marker:SpawnNest(true)
+        else
+            assert(false, "Prefab without a nest marker: " .. name)
+        end
+    else
+        assert(false, "Prefab error: " .. err)
+    end
+    ResumePassEdits("SpawndNest")
+    AddGameNotification("JunoNestSpawned", nil, nil, { nest })
+    return nest
+    --SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
 end
 
 function EnhancedTerritorialNest:give_ep_to_struct(ep)
-	if not ep then return end
-	Bkob_Log_NA("Nest storing EP in support structures\n")
-	local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
-	Bkob_Log_NA(spore_building_def.class)
-	Bkob_Log_NA(self.territorial_range)
-	local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
-	Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
-	local progress_each = DivRound(ep, #spores_near)
-	local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]
-	local spore_res_prog = spore_res.progress
-	local units_to_give = Max(1, DivRound(progress_each, spore_res_prog))
-	Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ", units_to_give)
-	for _, spore in ipairs(spores_near) do
-		spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
-	end
+    if not ep then return end
+    Bkob_Log_NA("Nest storing EP in support structures\n")
+    local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
+    Bkob_Log_NA(spore_building_def.class)
+    Bkob_Log_NA(self.territorial_range)
+    local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
+    Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
+    local progress_each = DivRound(ep, #spores_near)
+    local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]
+    local spore_res_prog = spore_res.progress
+    local units_to_give = Max(1, DivRound(progress_each, spore_res_prog))
+    Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ", units_to_give)
+    for _, spore in ipairs(spores_near) do
+        spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
+    end
 end
 
 function EnhancedTerritorialNest:consume_closest_node()
-	DebugPrint("Nest consuming nearest node\n")
-	self.consume_time = max_int
-	local closest_res = MapFindNearest(self, self, self.territorial_range, "EntityClass", function(thing)
-		if (IsKindOf(thing, 'MineableRock') or IsKindOf(thing, 'Plant')) and not (IsKindOf(thing, 'NestSpore')) then return true end
-	end)
-	Bkob_Log_NA(closest_res)
-	if not closest_res then
-		self:expand()
-		return --we expand instead of consuming
-	end
-	local res
-	local amount
-	if IsKindOf(closest_res, 'Plant') then
-		local res_array = closest_res:GetCutResources() or closest_res:GetHarvestResources()
-		res = res_array[1]['resource']
-		amount = res_array[1]['amount']
-	else
-		res = closest_res.MineResource
-		amount = closest_res.MineAmount
-	end
-	local node_res_units = DivRound(amount, const.ResourceScale)
-	local ep_scale = 1000
-	local progress = DivRound(Resources[res].progress * node_res_units, 10)
-	Bkob_Log_NA("Nest is eating a ", closest_res.class)
-	Bkob_Log_NA('Node has ', node_res_units, ' of ', res, ' in it! which is ', progress, ' EP')
-	local EP_to_give = DivRound(progress, 4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
-	Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ", EP_to_give)
-	DoneObject(closest_res)
-	self:give_ep_to_struct(EP_to_give)
-	local attack_cd = self.attack_delay
-	self.attack_time = self.attack_time - DivRound(attack_cd, 100)
-	self:get_next_consume_time()
+    DebugPrint("Nest consuming nearest node\n")
+    self.consume_time = max_int
+    local closest_res = MapFindNearest(self, self, self.territorial_range, "EntityClass", function(thing)
+        if (IsKindOf(thing, 'MineableRock') or IsKindOf(thing, 'Plant')) and not (IsKindOf(thing, 'NestSpore')) then return true end
+    end)
+    Bkob_Log_NA(closest_res)
+    if not closest_res then
+        self:expand()
+        return --we expand instead of consuming
+    end
+    local res
+    local amount
+    if IsKindOf(closest_res, 'Plant') then
+        local res_array = closest_res:GetCutResources() or closest_res:GetHarvestResources()
+        res = res_array[1]['resource']
+        amount = res_array[1]['amount']
+    else
+        res = closest_res.MineResource
+        amount = closest_res.MineAmount
+    end
+    local node_res_units = DivRound(amount, const.ResourceScale)
+    local ep_scale = 1000
+    local progress = DivRound(Resources[res].progress * node_res_units, 10)
+    Bkob_Log_NA("Nest is eating a ", closest_res.class)
+    Bkob_Log_NA('Node has ', node_res_units, ' of ', res, ' in it! which is ', progress, ' EP')
+    local EP_to_give = DivRound(progress, 4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
+    Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ", EP_to_give)
+    DoneObject(closest_res)
+    self:give_ep_to_struct(EP_to_give)
+    local attack_cd = self.attack_delay
+    self.attack_time = self.attack_time - DivRound(attack_cd, 100)
+    self:get_next_consume_time()
 end
 
 function EnhancedTerritorialNest:GetStoryBitPopupImage()
-	if self.class == 'ShriekerNest' then
-		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-	elseif self.class == 'ScissorhandsNest' then
-		return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
-	elseif self.class == 'ConsortiumNest' then
-		return 'ConsortiumNestVariant.PNG'
-	else
-		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-	end
+    if self.class == 'ShriekerNest' then
+        return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
+    elseif self.class == 'ScissorhandsNest' then
+        return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
+    elseif self.class == 'ConsortiumNest' then
+        return 'ConsortiumNestVariant.PNG'
+    else
+        return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
+    end
 end
 
 -- Closest does 2 things
@@ -380,347 +380,347 @@ end
 -- nest:Dist2D(me) < MulDivRound(3 * distance_to_beat,1,2) is my current way to detect if a nest is "in between" the player and this nest
 
 function EnhancedTerritorialNest:get_proximity()
-	local center = AveragePoint2D(GetValidSurvivorsOnMap())
-	local dist_to_center = self:GetDist2D(center)
-	local rate = 150 * guim     -- 150 meters per thresholdz
-	local prox = DivRound(dist_to_center, rate)
-	prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
-	self.proximity = prox
-	return prox
+    local center = AveragePoint2D(GetValidSurvivorsOnMap())
+    local dist_to_center = self:GetDist2D(center)
+    local rate = 150 * guim  -- 150 meters per thresholdz
+    local prox = DivRound(dist_to_center, rate)
+    prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
+    self.proximity = prox
+    return prox
 end
 
 function EnhancedTerritorialNest:Getui_evo()
-	DebugPrint("Getting the UI % how close to an evo the nest is\n")
-	local option_1 = DivRound(self.attacks_done * 100, self.attacks_to_evo)
-	local option_2 = check_count_and_upgrade(self.elder_class, {}, 100)
-	if option_2 ~= self.elder_class then
-		return 100 -- will show 100% if the EP is already high enough to trigger a "passive" evo
-	else
-		return Max(1, option_1)
-	end
+    DebugPrint("Getting the UI % how close to an evo the nest is\n")
+    local option_1 = DivRound(self.attacks_done * 100, self.attacks_to_evo)
+    local option_2 = check_count_and_upgrade(self.elder_class, {}, 100)
+    if option_2 ~= self.elder_class then
+        return 100 -- will show 100% if the EP is already high enough to trigger a "passive" evo
+    else
+        return Max(1, option_1)
+    end
 end
 
 function EnhancedTerritorialNest:Getui_attack_strength()
-	--local max_possible = per_species_nest_max*10
-	if self.state == 'asleep' then
-		return 10
-	else
-		return self:calculate_attack_strength('player')
-	end
+    --local max_possible = per_species_nest_max*10
+    if self.state == 'asleep' then
+        return 10
+    else
+        return self:calculate_attack_strength('player')
+    end
 end
 
 function EnhancedTerritorialNest:Getui_attack_cap()
-	local player_attack = self:calculate_attack_strength('player')
-	local current_cap = self:get_attack_cap()
-	return DivRound(player_attack * 100, current_cap)
+    local player_attack = self:calculate_attack_strength('player')
+    local current_cap = self:get_attack_cap()
+    return DivRound(player_attack * 100, current_cap)
 end
 
 function EnhancedTerritorialNest:Getui_attack_percent()
-	DebugPrint("Getting the UI % of how close an attack from the nest is\n")
-	local time_till_attack = self.attack_time - GameTime()
-	local num = self.attack_delay - time_till_attack
-	local percent = DivRound(num * 100, self.attack_delay)
-	return Max(1, percent)
+    DebugPrint("Getting the UI % of how close an attack from the nest is\n")
+    local time_till_attack = self.attack_time - GameTime()
+    local num = self.attack_delay - time_till_attack
+    local percent = DivRound(num * 100, self.attack_delay)
+    return Max(1, percent)
 end
 
 function EnhancedTerritorialNest:IsAsleep()
-	return self.state == 'asleep'
+    return self.state == 'asleep'
 end
 
 function EnhancedTerritorialNest:IsAwake()
-	return self.state == 'awake'
+    return self.state == 'awake'
 end
 
 function EnhancedTerritorialNest:IsSleepy()
-	return self.state == 'sleepy'
+    return self.state == 'sleepy'
 end
 
 function EnhancedTerritorialNest:change_nest_herd(force_evo)
-	Bkob_Log("Nest calculating if it needs to upgrade\n")
-	Bkob_Log("Forced Evo: ", force_evo)
-	local elder = self.elder_class
-	local upgraded_flag = false
-	local evo, _, __
-	if force_evo then
-		evo = Find_evolution(g_Classes[elder])
-	else
-		local AdditionalClassList = {}
-		AdditionalClassList[#AdditionalClassList + 1] = { self.adult_class, 150 }
-		AdditionalClassList[#AdditionalClassList + 1] = { self.hatchling_class, 50 }
-		evo, _, __ = check_count_and_upgrade(elder, AdditionalClassList, 100)
-	end
-	if evo == elder and self.adult_class == self.hatchling_class and self.adult_class == self.elder_class then
-		return upgraded_flag
-	end
-	-- base nests will just chain their units down
-	upgraded_flag = true
-	self.hatchling_class = self.adult_class
-	self.adult_class = self.elder_class
-	self.elder_class = evo
-	-- remove any newly-invalid creatures from nest_creatures
-	local removed = false
-	for _, unit in ipairs(self.nest_members) do
-		local class = unit.class
-		if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
-			self:RemoveNestMember(unit)
-			-- This will force spawn a new set of higher tier nests.
-			-- If Nests are left unnattended they can get quite large groups defending it
-		end
-	end
-	if removed then
-		self:UpdateNextSpawnTime()
-	end
-	if upgraded_flag then
-		-- just to make sure we know how close the player is now that they have more stuff
-		self:get_proximity()
-		NA_log_nest_evolved(self)
-		self.attacks_done = 0
-		self.attacks_to_evo = self.attacks_to_evo + 1
-	end
-	return upgraded_flag
+    Bkob_Log("Nest calculating if it needs to upgrade\n")
+    Bkob_Log("Forced Evo: ", force_evo)
+    local elder = self.elder_class
+    local upgraded_flag = false
+    local evo, _, __
+    if force_evo then
+        evo = Find_evolution(g_Classes[elder])
+    else
+        local AdditionalClassList = {}
+        AdditionalClassList[#AdditionalClassList + 1] = { self.adult_class, 150 }
+        AdditionalClassList[#AdditionalClassList + 1] = { self.hatchling_class, 50 }
+        evo, _, __ = check_count_and_upgrade(elder, AdditionalClassList, 100)
+    end
+    if evo == elder and self.adult_class == self.hatchling_class and self.adult_class == self.elder_class then
+        return upgraded_flag
+    end
+    -- base nests will just chain their units down
+    upgraded_flag = true
+    self.hatchling_class = self.adult_class
+    self.adult_class = self.elder_class
+    self.elder_class = evo
+    -- remove any newly-invalid creatures from nest_creatures
+    local removed = false
+    for _, unit in ipairs(self.nest_members) do
+        local class = unit.class
+        if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
+            self:RemoveNestMember(unit)
+            -- This will force spawn a new set of higher tier nests.
+            -- If Nests are left unnattended they can get quite large groups defending it
+        end
+    end
+    if removed then
+        self:UpdateNextSpawnTime()
+    end
+    if upgraded_flag then
+        -- just to make sure we know how close the player is now that they have more stuff
+        self:get_proximity()
+        NA_log_nest_evolved(self)
+        self.attacks_done = 0
+        self.attacks_to_evo = self.attacks_to_evo + 1
+    end
+    return upgraded_flag
 end
 
 function EnhancedTerritorialNest:can_be_aggressive(who)
-	if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
-		return true
-	elseif who == 'player' and self.attacked_by_player then
-		return true
-	elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
-		return true
-	else
-		return false
-	end
+    if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
+        return true
+    elseif who == 'player' and self.attacked_by_player then
+        return true
+    elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
+        return true
+    else
+        return false
+    end
 end
 
 function EnhancedTerritorialNest:RegisterTarget(unit, time)
-	if unit.player then
-		self.attacked_by_player = true
-	elseif unit.nest then
-		unit.nest.attacked_by_player = true
-	end
-	local tags = unit['UnitTags']
-	if tags and self.state == 'asleep' and tags['Human'] then
-		DebugPrint("Nest registering a human attacker!\n")
-		self:SwitchState('sleepy')
-	end
-	if unit.nest then
-		DebugPrint("Nest registering another nest attacker!\n")
-		if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
-			self:SwitchState('sleepy')
-		end
-	end
+    if unit.player then
+        self.attacked_by_player = true
+    elseif unit.nest then
+        unit.nest.attacked_by_player = true
+    end
+    local tags = unit['UnitTags']
+    if tags and self.state == 'asleep' and tags['Human'] then
+        DebugPrint("Nest registering a human attacker!\n")
+        self:SwitchState('sleepy')
+    end
+    if unit.nest then
+        DebugPrint("Nest registering another nest attacker!\n")
+        if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
+            self:SwitchState('sleepy')
+        end
+    end
 end
 
 function EnhancedTerritorialNest:set_new_max_hp()
-	DebugPrint("Nest raising max HP\n")
-	local base_hp = 100000
-	local diff = Get_difficulty_offset()
-	local max_possible_hp = base_hp * 100 * diff
-	if self.state == 'awake' then
-		self.MaxHealth = max_possible_hp
-		self.health_regen = 5
-	elseif self.state == 'sleepy' then
-		self.MaxHealth = DivRound(max_possible_hp, 2)
-		self.health_regen = 1
-	elseif self.state == 'asleep' then
-		self.health_regen = 0
-		self.MaxHealth = base_hp
-	end
+    DebugPrint("Nest raising max HP\n")
+    local base_hp = 100000
+    local diff = Get_difficulty_offset()
+    local max_possible_hp = base_hp * 100 * diff
+    if self.state == 'awake' then
+        self.MaxHealth = max_possible_hp
+        self.health_regen = 5
+    elseif self.state == 'sleepy' then
+        self.MaxHealth = DivRound(max_possible_hp, 2)
+        self.health_regen = 1
+    elseif self.state == 'asleep' then
+        self.health_regen = 0
+        self.MaxHealth = base_hp
+    end
 end
 
 function EnhancedTerritorialNest:SwitchState(new_state)
-	DebugPrint("Nest switching it's internal state!\n")
-	new_state = new_state or nil
-	local notif_level = Nest_Notifications
-	if not new_state or new_state == self.state then
-		return
-	end
-	if new_state == 'sleepy' and self.state == 'asleep' then
-		self.sleep_check = GameTime() + const.Scale.months
-		if notif_level == 2 then
-			ForceActivateStoryBit('asleep_too_sleepy', self, true)
-		elseif notif_level == 1 then
-			AddGameNotification("waking_up", nil, nil, { self })
-		end
-	elseif new_state == "asleep" and not (self.state == "awake") then
-		if notif_level == 2 then
-			-- woken up
-			ForceActivateStoryBit('back_to_sleep', self, true)
-		elseif notif_level == 1 then
-			AddGameNotification("back_to_sleep", nil, nil, { self })
-		end
-	end
-	self.state = new_state
-	self:UpdateNextAttackTime()
-	self:set_new_max_hp()
+    DebugPrint("Nest switching it's internal state!\n")
+    new_state = new_state or nil
+    local notif_level = Nest_Notifications
+    if not new_state or new_state == self.state then
+        return
+    end
+    if new_state == 'sleepy' and self.state == 'asleep' then
+        self.sleep_check = GameTime() + const.Scale.months
+        if notif_level == 2 then
+            ForceActivateStoryBit('asleep_too_sleepy', self, true)
+        elseif notif_level == 1 then
+            AddGameNotification("waking_up", nil, nil, { self })
+        end
+    elseif new_state == "asleep" and not (self.state == "awake") then
+        if notif_level == 2 then
+            -- woken up
+            ForceActivateStoryBit('back_to_sleep', self, true)
+        elseif notif_level == 1 then
+            AddGameNotification("back_to_sleep", nil, nil, { self })
+        end
+    end
+    self.state = new_state
+    self:UpdateNextAttackTime()
+    self:set_new_max_hp()
 end
 
 function EnhancedTerritorialNest:get_attack_cap()
-	local base = 50
-	local awake_same_nests = MapCount(true, "TerritorialNest", function(other_nest, this_nest)
-		if IsKindOf(other_nest, this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
-			return true
-		end
-	end, self)
-	local nest_based_cap = awake_same_nests * 10
-	local year = const.Scale.years
-	local time_based_cap = MulDivTrunc(1, GameTime(), year) * 50 + 50
-	if base > time_based_cap and base > nest_based_cap then
-		return base
-	elseif time_based_cap > nest_based_cap then
-		return time_based_cap
-	else
-		return nest_based_cap
-	end
-	return base
+    local base = 50
+    local awake_same_nests = MapCount(true, "TerritorialNest", function(other_nest, this_nest)
+        if IsKindOf(other_nest, this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
+            return true
+        end
+    end, self)
+    local nest_based_cap = awake_same_nests * 10
+    local year = const.Scale.years
+    local time_based_cap = MulDivTrunc(1, GameTime(), year) * 50 + 50
+    if base > time_based_cap and base > nest_based_cap then
+        return base
+    elseif time_based_cap > nest_based_cap then
+        return time_based_cap
+    else
+        return nest_based_cap
+    end
+    return base
 end
 
 function EnhancedTerritorialNest:calculate_interspecies_war_strength(who)
-	DebugPrint("Calculating interspecies war strength\n")
-	local nest_EP = 0
-	for _, defender in ipairs(who.nest_members) do
-		nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
-	end
-	local rand = 75 + AsyncRand(75)
-	return nest_EP + rand
+    DebugPrint("Calculating interspecies war strength\n")
+    local nest_EP = 0
+    for _, defender in ipairs(who.nest_members) do
+        nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
+    end
+    local rand = 75 + AsyncRand(75)
+    return nest_EP + rand
 end
 
 function EnhancedTerritorialNest:calculate_attack_strength(who)
-	DebugPrint("Nest calculating it's attack score\n")
-	if who == 'player' then
-		local max_attack_strength_allowed = self:get_attack_cap()
-		local base_strength = self.base_strength or 20
-		local diff_increase
-		if Get_difficulty_offset() > 5 then
-			diff_increase = 10
-		else
-			diff_increase = 0
-		end
-		local species = get_species_from_nest(self.class)
-		local banked = 0
-		local species_banked_aggr = species .. '_banked_aggr'
-		if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
-			banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
-		else
-			DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
-			Nest_Species_Savegame_Stats[self.nest_species] = {}
-			Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
-		end
-		local subsequent_attacks = self.attacks_done * 10
-		local prox_loss = self.proximity * 10
-		local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
-		-- Make sure we don't go below base or above cap
-		local filtered_strength = Max(base_strength, Min(max_attack_strength_allowed, unfiltered_strength))
-		DebugPrint("Desired attack strength: ")
-		DebugPrint(unfiltered_strength)
-		DebugPrint("\nActual attack strength:")
-		DebugPrint(filtered_strength)
-		DebugPrint("\n")
-		return filtered_strength
-	elseif IsKindOf(who, 'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
-		return self:calculate_interspecies_war_strength(who)
-	else
-		return 10
-	end
+    DebugPrint("Nest calculating it's attack score\n")
+    if who == 'player' then
+        local max_attack_strength_allowed = self:get_attack_cap()
+        local base_strength = self.base_strength or 20
+        local diff_increase
+        if Get_difficulty_offset() > 5 then
+            diff_increase = 10
+        else
+            diff_increase = 0
+        end
+        local species = get_species_from_nest(self.class)
+        local banked = 0
+        local species_banked_aggr = species .. '_banked_aggr'
+        if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
+            banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
+        else
+            DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
+            Nest_Species_Savegame_Stats[self.nest_species] = {}
+            Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
+        end
+        local subsequent_attacks = self.attacks_done * 10
+        local prox_loss = self.proximity * 10
+        local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
+        -- Make sure we don't go below base or above cap
+        local filtered_strength = Max(base_strength, Min(max_attack_strength_allowed, unfiltered_strength))
+        DebugPrint("Desired attack strength: ")
+        DebugPrint(unfiltered_strength)
+        DebugPrint("\nActual attack strength:")
+        DebugPrint(filtered_strength)
+        DebugPrint("\n")
+        return filtered_strength
+    elseif IsKindOf(who, 'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
+        return self:calculate_interspecies_war_strength(who)
+    else
+        return 10
+    end
 end
 
 function nest_find_spawn_fake(spawndef_instance, spawn_class, target)
-	local def = spawn_class and g_Classes[spawn_class]
-	local pfclass = def.pfclass
-	local range = spawndef_instance.nest.max_range
-	local target_retry = 7
-	local x, y
-	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-	local playbox = GetPlayBox()
-	local nest_entity_radius = spawndef_instance.nest:GetRadius()
-	for i = 1, target_retry do
-		x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
-		local temp_pos = point(x, y)
-		local playbox_check = playbox:Dist2(temp_pos) > 1
-		local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-		if playbox_check or under_nest then
-			x = nil
-			target_retry = target_retry - 1
-			range = range * 2
-		else
-			local possible_pos = point(x, y)
-			return possible_pos
-		end
-	end
-	::continue::
-	dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest, 7))
+    local def = spawn_class and g_Classes[spawn_class]
+    local pfclass = def.pfclass
+    local range = spawndef_instance.nest.max_range
+    local target_retry = 7
+    local x, y
+    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+    local playbox = GetPlayBox()
+    local nest_entity_radius = spawndef_instance.nest:GetRadius()
+    for i = 1, target_retry do
+        x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
+        local temp_pos = point(x, y)
+        local playbox_check = playbox:Dist2(temp_pos) > 1
+        local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+        if playbox_check or under_nest then
+            x = nil
+            target_retry = target_retry - 1
+            range = range * 2
+        else
+            local possible_pos = point(x, y)
+            return possible_pos
+        end
+    end
+    ::continue::
+    dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest, 7))
 end
 
 function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
-	--print("Finding spawn point near a nest!")
-	local playbox = GetPlayBox()
-	if not target then
-		--print("Didn't get a target to spawn near!")
-		target = spawndef_instance:ResolveTarget()
-	end
-	local def = spawn_class and g_Classes[spawn_class]
-	local pfclass = def.pfclass
-	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-	if not pos then print("no pos found!") end
-	local nest_entity_radius = spawndef_instance.nest:GetRadius()
-	local x, y
-	local retry = 10
-	local range = spawndef_instance.nest.max_range
-	local target_radius = 30 * guim
-	while not x and retry > 0 do
-		local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
-		if not spot_closest_to_target then
-			target_radius = target_radius * 2
-		else
-			x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
-			local temp_pos = point(x, y)
-			local playbox_check = playbox:Dist2(temp_pos) > 1
-			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-			if playbox_check or under_nest then
-				x = nil
-				retry = retry - 1
-				range = range * 2
-			else
-				local possible_pos = point(x, y)
-				if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
-					--print("Found a point!")
-					return possible_pos
-				else
-					retry = retry - 1
-					range = range * 2
-				end
-			end
-		end
-		return nil
-	end
+    --print("Finding spawn point near a nest!")
+    local playbox = GetPlayBox()
+    if not target then
+        --print("Didn't get a target to spawn near!")
+        target = spawndef_instance:ResolveTarget()
+    end
+    local def = spawn_class and g_Classes[spawn_class]
+    local pfclass = def.pfclass
+    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+    if not pos then print("no pos found!") end
+    local nest_entity_radius = spawndef_instance.nest:GetRadius()
+    local x, y
+    local retry = 10
+    local range = spawndef_instance.nest.max_range
+    local target_radius = 30 * guim
+    while not x and retry > 0 do
+        local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
+        if not spot_closest_to_target then
+            target_radius = target_radius * 2
+        else
+            x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
+            local temp_pos = point(x, y)
+            local playbox_check = playbox:Dist2(temp_pos) > 1
+            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+            if playbox_check or under_nest then
+                x = nil
+                retry = retry - 1
+                range = range * 2
+            else
+                local possible_pos = point(x, y)
+                if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
+                    --print("Found a point!")
+                    return possible_pos
+                else
+                    retry = retry - 1
+                    range = range * 2
+                end
+            end
+        end
+        return nil
+    end
 end
 
 local post_spawn_animal = function(self, obj, target, context)
-	obj.CombatHostile = true
-	Msg("SpawnedAnimalThreat", obj)
-	give_nest_speed_effect(obj, self.nest.proximity)
+    obj.CombatHostile = true
+    Msg("SpawnedAnimalThreat", obj)
+    give_nest_speed_effect(obj, self.nest.proximity)
 end
 
 local post_spawn_robot = function(self, obj, target, context)
-	obj:SetInvader(true)
-	Msg("SpawnedAnimalThreat", obj)
-	give_nest_speed_effect(obj, self.nest.proximity)
+    obj:SetInvader(true)
+    Msg("SpawnedAnimalThreat", obj)
+    give_nest_speed_effect(obj, self.nest.proximity)
 end
 
 function give_nest_speed_effect(ob, prox)
-	local robot_flag = false
-	local times = prox or 1
-	if IsKindOf(ob, 'Robot') then
-		robot_flag = true
-	end
-	while times > 0 do
-		if robot_flag then
-			ob:AddRobotCondition('nest_attack_speed_robot', 'mod')
-		else
-			ob:AddHealthCondition('nest_attack_speed', 'mod')
-		end
-		times = times - 1
-	end
+    local robot_flag = false
+    local times = prox or 1
+    if IsKindOf(ob, 'Robot') then
+        robot_flag = true
+    end
+    while times > 0 do
+        if robot_flag then
+            ob:AddRobotCondition('nest_attack_speed_robot', 'mod')
+        else
+            ob:AddHealthCondition('nest_attack_speed', 'mod')
+        end
+        times = times - 1
+    end
 end
 
 --[[
@@ -751,67 +751,67 @@ quadrants[1] = {
 --]]
 
 function EnhancedTerritorialNest:IsQuadrantScouted(quad_no)
-	local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
-	if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
-		return false
-	else
-		return true
-	end
+    local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
+    if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
+        return false
+    else
+        return true
+    end
 end
 
 function EnhancedTerritorialNest:MarkScouted(other_species, time)
-	rawset(self, other_species, time)
+    rawset(self, other_species, time)
 end
 
 function ReportScoutingResults(quad_no, species, objects_to_report, player_found, nest)
-	Reset_quadrant(quad_no, species)
-	if nest.quadrant_scouting then
-		nest.quadrant_scouting = false
-	end
-	local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
-	if player_found then
-		scout_quad_logs['player_presence'] = true
-		DebugPrint("Player presence detected in this quadrant!\n")
-		if nest:IsAsleep() then
-			nest:SwitchState('sleepy')
-		end
-	end
-	scout_quad_logs.last_scout = GameTime()
-	scout_quad_logs['map_objs'] = objects_to_report
-	for _, obj in ipairs(objects_to_report) do
-		if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
-			if scout_quad_logs[that_species] then
-				scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
-				nest:MarkScouted(self.nest_species, GameTime())
-			else
-				scout_quad_logs[that_species] = {}
-				scout_quad_logs[that_species][1] = nest
-			end
-		end
-		scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
-	end
+    Reset_quadrant(quad_no, species)
+    if nest.quadrant_scouting then
+        nest.quadrant_scouting = false
+    end
+    local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
+    if player_found then
+        scout_quad_logs['player_presence'] = true
+        DebugPrint("Player presence detected in this quadrant!\n")
+        if nest:IsAsleep() then
+            nest:SwitchState('sleepy')
+        end
+    end
+    scout_quad_logs.last_scout = GameTime()
+    scout_quad_logs['map_objs'] = objects_to_report
+    for _, obj in ipairs(objects_to_report) do
+        if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
+            if scout_quad_logs[that_species] then
+                scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
+                nest:MarkScouted(self.nest_species, GameTime())
+            else
+                scout_quad_logs[that_species] = {}
+                scout_quad_logs[that_species][1] = nest
+            end
+        end
+        scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
+    end
 end
 
 -- TODO instead of cheat learning about the quadrant, send out a nesting unit to scout
 function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
-	DebugPrint("Nest is releasing a scouting unit!!\n")
-	local spawn_def = SpawnDefs['Nest_scout_passive']
-	--used by invader to know what quadrant is to be scouted
-	-- And to track if the scout ever returned
-	if self.quadrant_scouting then
-		DebugPrint("Whelp, looks like my last scout is MIA...")
-	end
-	self.quadrant_scouting = quad_no
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.adult_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t, {}, 100)
-	--[[
+    DebugPrint("Nest is releasing a scouting unit!!\n")
+    local spawn_def = SpawnDefs['Nest_scout_passive']
+    --used by invader to know what quadrant is to be scouted
+    -- And to track if the scout ever returned
+    if self.quadrant_scouting then
+        DebugPrint("Whelp, looks like my last scout is MIA...")
+    end
+    self.quadrant_scouting = quad_no
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.adult_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
+    --[[
 	if not Nest_scouting_quadrants[quad_no] then
 		CreateMapGrid()
 	end
@@ -824,213 +824,213 @@ function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
 end
 
 function MegaScout(nest)
-	for i = 1, 25 do
-		nest:Scout_Specific_Quad(i)
-	end
+    for i = 1, 25 do
+        nest:Scout_Specific_Quad(i)
+    end
 end
 
 -- Currently this will just cheat
 -- I want to build out scouting behavior to allow the player to interact with a species learning about the map
 function EnhancedTerritorialNest:scout_nearest_quad()
-	DebugPrint("\nScouting closest usncouted quad!\n")
-	if not self.quadrant then
-		self.quadrant = Get_quadrant_from_obj(self, true)
-	end
-	if not self.nest_species then
-		self.nest_species = get_species_from_nest(self.class)
-	end
-	if not Nest_scouting_quadrants[1] then
-		CreateMapGrid()
-	end
-	local to_scout
-	local shouldnt_scout = {}
-	if not Nest_scouting_quadrants[self.quadrant] then
-		CreateMapGrid()
-	end
-	local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-	if not my_species_quad_logs then
-		CreateMapGrid()
-		my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-	end
-	if my_species_quad_logs.last_scout == 0 then
-		to_scout = self.quadrant
-	elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
-		to_scout = self.quadrant
-		goto continue
-	end
-	shouldnt_scout[#shouldnt_scout + 1] = self.quadrant
-	for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
-		--ignoring diagonals because..... its hard
-		for _, no in ipairs(shouldnt_scout) do
-			for _, q in ipairs(Get_adjacent_quads(no)) do
-				if not table.find(shouldnt_scout, q) then
-					if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
-						to_scout = q
-						goto continue
-					elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
-						shouldnt_scout[#shouldnt_scout + 1] = q
-					else
-						--print("Whelp, guess Im going to scout quadrant",q,"now!\n")
-						to_scout = q
-						goto continue
-					end
-				end
-			end
-		end
-	end
-	::continue::
-	if not to_scout then
-		DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
-		return
-	else
-		DebugPrint("I am scouting this quadrant:", to_scout, '\n')
-	end
-	self:Scout_Specific_Quad(to_scout)
+    DebugPrint("\nScouting closest usncouted quad!\n")
+    if not self.quadrant then
+        self.quadrant = Get_quadrant_from_obj(self, true)
+    end
+    if not self.nest_species then
+        self.nest_species = get_species_from_nest(self.class)
+    end
+    if not Nest_scouting_quadrants[1] then
+        CreateMapGrid()
+    end
+    local to_scout
+    local shouldnt_scout = {}
+    if not Nest_scouting_quadrants[self.quadrant] then
+        CreateMapGrid()
+    end
+    local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+    if not my_species_quad_logs then
+        CreateMapGrid()
+        my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+    end
+    if my_species_quad_logs.last_scout == 0 then
+        to_scout = self.quadrant
+    elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
+        to_scout = self.quadrant
+        goto continue
+    end
+    shouldnt_scout[#shouldnt_scout + 1] = self.quadrant
+    for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
+        --ignoring diagonals because..... its hard
+        for _, no in ipairs(shouldnt_scout) do
+            for _, q in ipairs(Get_adjacent_quads(no)) do
+                if not table.find(shouldnt_scout, q) then
+                    if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
+                        to_scout = q
+                        goto continue
+                    elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
+                        shouldnt_scout[#shouldnt_scout + 1] = q
+                    else
+                        --print("Whelp, guess Im going to scout quadrant",q,"now!\n")
+                        to_scout = q
+                        goto continue
+                    end
+                end
+            end
+        end
+    end
+    ::continue::
+    if not to_scout then
+        DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
+        return
+    else
+        DebugPrint("I am scouting this quadrant:", to_scout, '\n')
+    end
+    self:Scout_Specific_Quad(to_scout)
 end
 
 function EnhancedTerritorialNest:nest_attack_player()
-	DebugPrint("Nest is attacking the player directly!\n")
-	local spawn_def = SpawnDefs['nest_attack']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.elder_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	local atk_str = self:calculate_attack_strength('player')
-	spawn_def:ActivateSpawn(t, {}, atk_str)
+    DebugPrint("Nest is attacking the player directly!\n")
+    local spawn_def = SpawnDefs['nest_attack']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.elder_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    local atk_str = self:calculate_attack_strength('player')
+    spawn_def:ActivateSpawn(t, {}, atk_str)
 end
 
 function EnhancedTerritorialNest:nest_attack_non_player(enemy_nest)
-	DebugPrint("Nest is attacking a non player target near it!\n")
-	local spawn_def = SpawnDefs['nest_attack']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.elder_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	print("ACTIVATING SPAWN!")
-	spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength(enemy_nest))
+    DebugPrint("Nest is attacking a non player target near it!\n")
+    local spawn_def = SpawnDefs['nest_attack']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.elder_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    print("ACTIVATING SPAWN!")
+    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength(enemy_nest))
 end
 
 function EnhancedTerritorialNest:nest_support_closest(ally_nest)
-	DebugPrint("Nest is sending support to the closest nest!\n")
-	local spawn_def = SpawnDefs['Support_same_species_passive']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.adult_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-	spawn_def = spawn_def:CreateInstance(instance)
-	-- Support the specific in-sector ally chosen by GetSupportTarget: target IT so the reinforcement
-	-- spawns near the ally (and does not march across the player's base). Fall back to the SpawnDef's
-	-- own target resolution when called without an explicit ally.
-	local t = ally_nest or spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t, {}, 100)
+    DebugPrint("Nest is sending support to the closest nest!\n")
+    local spawn_def = SpawnDefs['Support_same_species_passive']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.adult_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    -- Support the specific in-sector ally chosen by GetSupportTarget: target IT so the reinforcement
+    -- spawns near the ally (and does not march across the player's base). Fall back to the SpawnDef's
+    -- own target resolution when called without an explicit ally.
+    local t = ally_nest or spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:overflow_spawn()
-	DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
-	local spawn_def = SpawnDefs['nest_overflow']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.elder_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength())
+    DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
+    local spawn_def = SpawnDefs['nest_overflow']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.elder_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength())
 end
 
 function EnhancedTerritorialNest:GetUnscoutedQuadrantsWithin(range)
-	range = range or 5
-	local unscouted = {}
-	local processed_quads = {}
-	local distance = 1
-	unscouted[distance] = {}
-	--print("I am in quadrant", self.quadrant,'\n')
-	if self:IsQuadrantScouted(self.quadrant) then
-		local distance_entry = unscouted[distance]
-		distance_entry[#distance_entry + 1] = self.quadrant
-	end
-	processed_quads[#processed_quads + 1] = self.quadrant
-	local temp_processed = {}
-	for i = 1, range do
-		distance = distance + 1
-		-- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
-		unscouted[distance] = table.copy(unscouted[distance - 1])
-		--print("Now checking quadrants at distance ",distance-1,'\n')
-		local distance_entry = unscouted[distance]
-		for _, qu in ipairs(processed_quads) do
-			local adjacent = Get_adjacent_quads(qu)
-			--print("Looking through these: ", adjacent,'\n')
-			for _, qua in ipairs(adjacent) do
-				if not table.find(processed_quads, qua) and not table.find(temp_processed, qua) then
-					temp_processed[#temp_processed + 1] = qua
-					local scouted = self:IsQuadrantScouted(qua)
-					if not scouted then
-						distance_entry[#distance_entry + 1] = qua
-					end
-				end
-			end
-		end
-		--print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
-		--print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
-		for _, v in ipairs(temp_processed) do
-			processed_quads[#processed_quads + 1] = v
-		end
-		temp_processed = {}
-	end
-	return unscouted
+    range = range or 5
+    local unscouted = {}
+    local processed_quads = {}
+    local distance = 1
+    unscouted[distance] = {}
+    --print("I am in quadrant", self.quadrant,'\n')
+    if self:IsQuadrantScouted(self.quadrant) then
+        local distance_entry = unscouted[distance]
+        distance_entry[#distance_entry + 1] = self.quadrant
+    end
+    processed_quads[#processed_quads + 1] = self.quadrant
+    local temp_processed = {}
+    for i = 1, range do
+        distance = distance + 1
+        -- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
+        unscouted[distance] = table.copy(unscouted[distance - 1])
+        --print("Now checking quadrants at distance ",distance-1,'\n')
+        local distance_entry = unscouted[distance]
+        for _, qu in ipairs(processed_quads) do
+            local adjacent = Get_adjacent_quads(qu)
+            --print("Looking through these: ", adjacent,'\n')
+            for _, qua in ipairs(adjacent) do
+                if not table.find(processed_quads, qua) and not table.find(temp_processed, qua) then
+                    temp_processed[#temp_processed + 1] = qua
+                    local scouted = self:IsQuadrantScouted(qua)
+                    if not scouted then
+                        distance_entry[#distance_entry + 1] = qua
+                    end
+                end
+            end
+        end
+        --print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
+        --print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
+        for _, v in ipairs(temp_processed) do
+            processed_quads[#processed_quads + 1] = v
+        end
+        temp_processed = {}
+    end
+    return unscouted
 end
 
 function EnhancedTerritorialNest:IsPlayerKnown()
-	local my_species = get_species_from_nest(self.class)
-	for _, quad in ipairs(Nest_scouting_quadrants) do
-		if quad[my_species].player_presence then
-			return true
-		end
-	end
-	return false
+    local my_species = get_species_from_nest(self.class)
+    for _, quad in ipairs(Nest_scouting_quadrants) do
+        if quad[my_species].player_presence then
+            return true
+        end
+    end
+    return false
 end
 
 function EnhancedTerritorialNest:IsCloserToPlayer(other_nest)
-	local compare_point = Get_center_of_survivors()
-	local my_distance = self:GetDist2D(compare_point)
-	local other_distance = other_nest:GetDist2D(compare_point)
-	return my_distance < other_distance
+    local compare_point = Get_center_of_survivors()
+    local my_distance = self:GetDist2D(compare_point)
+    local other_distance = other_nest:GetDist2D(compare_point)
+    return my_distance < other_distance
 end
 
 function EnhancedTerritorialNest:IsClosestToPlayer()
-	--local my_species = get_species_from_nest(self.class)
-	local compare_point = Get_center_of_survivors()
-	--print("Center of survivors is: ",compare_point,'\n')
-	local my_distance = self:GetDist2D(compare_point)
-	--print("I am this far away from it: ",my_distance,'\n')
-	local nest_dist = {}
-	MapForEach("map", self.class, function(nest, compare_point, me)
-		if nest ~= me then
-			nest_dist[#nest_dist + 1] = { nest = nest, dist = nest:GetDist2D(compare_point) }
-		end
-	end, compare_point, self)
-	local closest = self
-	--print(nest_dist,'\n')
-	for _, v in ipairs(nest_dist) do
-		if v.dist < my_distance then
-			closest = v.nest
-		end
-	end
-	return closest == self
+    --local my_species = get_species_from_nest(self.class)
+    local compare_point = Get_center_of_survivors()
+    --print("Center of survivors is: ",compare_point,'\n')
+    local my_distance = self:GetDist2D(compare_point)
+    --print("I am this far away from it: ",my_distance,'\n')
+    local nest_dist = {}
+    MapForEach("map", self.class, function(nest, compare_point, me)
+        if nest ~= me then
+            nest_dist[#nest_dist + 1] = { nest = nest, dist = nest:GetDist2D(compare_point) }
+        end
+    end, compare_point, self)
+    local closest = self
+    --print(nest_dist,'\n')
+    for _, v in ipairs(nest_dist) do
+        if v.dist < my_distance then
+            closest = v.nest
+        end
+    end
+    return closest == self
 end
 
 -- A nest attacks the player only when it is the most-forward of its species; a nest behind a same-species ally sends
@@ -1039,296 +1039,296 @@ end
 -- opposite (on the far side of the player), which is what would march units through the player's base. Returns the ally
 -- nest to support, or false if this nest is the front line.
 function EnhancedTerritorialNest:GetSupportTarget()
-	local center = Get_center_of_survivors()
-	local my_dist = self:GetDist2D(center)
-	local my_bearing = CalcOrientation(center, self:GetPos())
-	local sector = 60 * 60 -- +-60 degrees (HG angles are in 1/60-degree units) -> a 120-degree forward arc
-	local best, best_dist
-	MapForEach("map", self.class, function(nest, me)
-		if nest == me then return end
-		local n_dist = nest:GetDist2D(center)
-		if n_dist >= my_dist then return end                                                           -- only nests ahead of me (closer to the survivors)
-		if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
-		if not best or n_dist < best_dist then
-			best, best_dist = nest, n_dist
-		end
-	end, self)
-	return best or false
+    local center = Get_center_of_survivors()
+    local my_dist = self:GetDist2D(center)
+    local my_bearing = CalcOrientation(center, self:GetPos())
+    local sector = 60 * 60 -- +-60 degrees (HG angles are in 1/60-degree units) -> a 120-degree forward arc
+    local best, best_dist
+    MapForEach("map", self.class, function(nest, me)
+        if nest == me then return end
+        local n_dist = nest:GetDist2D(center)
+        if n_dist >= my_dist then return end                                                     -- only nests ahead of me (closer to the survivors)
+        if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
+        if not best or n_dist < best_dist then
+            best, best_dist = nest, n_dist
+        end
+    end, self)
+    return best or false
 end
 
 function EnhancedTerritorialNest:GetNearbyEnemiesNonPlayer(range)
-	local valid_targets = MapGet(self, range, "TerritorialNest", function(nest, me)
-		if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species
-			and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
-			return true
-		end
-	end, self)
-	local closest = {}
-	for _, target in ipairs(valid_targets) do
-		if table.find(closest, target.nest_species) then
-			closest[target.nest_species] = target
-		else
-			closest[target.nest_species] = {}
-			closest[target.nest_species][1] = target
-		end
-	end
-	range = range or 5
-	local enemy_selection = {}
-	local processed_quads = {}
-	local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-	for _, species in pairs(my_quad.other_species) do
-		table.insert_unique(enemy_selection, species)
-	end
-	processed_quads[#processed_quads + 1] = self.quadrant
-	local temp_processed = {}
-	for i = 1, range do
-		for _, no in ipairs(processed_quads) do
-			for _, q in ipairs(Get_adjacent_quads(no)) do
-				local this_quad = Nest_scouting_quadrants[q][self.nest_species]
-				if not table.find(processed_quads, q) and not table.find(temp_processed, q) then
-					temp_processed[#temp_processed + 1] = q
-					for _, species in pairs(this_quad.other_species) do
-						table.insert_unique(enemy_selection, species)
-					end
-				end
-			end
-		end
-		for _, v in ipairs(temp_processed) do
-			processed_quads[#processed_quads + 1] = v
-		end
-		temp_processed = {}
-	end
-	return enemy_selection
+    local valid_targets = MapGet(self, range, "TerritorialNest", function(nest, me)
+        if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species
+            and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
+            return true
+        end
+    end, self)
+    local closest = {}
+    for _, target in ipairs(valid_targets) do
+        if table.find(closest, target.nest_species) then
+            closest[target.nest_species] = target
+        else
+            closest[target.nest_species] = {}
+            closest[target.nest_species][1] = target
+        end
+    end
+    range = range or 5
+    local enemy_selection = {}
+    local processed_quads = {}
+    local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+    for _, species in pairs(my_quad.other_species) do
+        table.insert_unique(enemy_selection, species)
+    end
+    processed_quads[#processed_quads + 1] = self.quadrant
+    local temp_processed = {}
+    for i = 1, range do
+        for _, no in ipairs(processed_quads) do
+            for _, q in ipairs(Get_adjacent_quads(no)) do
+                local this_quad = Nest_scouting_quadrants[q][self.nest_species]
+                if not table.find(processed_quads, q) and not table.find(temp_processed, q) then
+                    temp_processed[#temp_processed + 1] = q
+                    for _, species in pairs(this_quad.other_species) do
+                        table.insert_unique(enemy_selection, species)
+                    end
+                end
+            end
+        end
+        for _, v in ipairs(temp_processed) do
+            processed_quads[#processed_quads + 1] = v
+        end
+        temp_processed = {}
+    end
+    return enemy_selection
 end
 
 function EnhancedTerritorialNest:ClosestSleepyNest(range)
-	range = range or max_int
-	local closest_sleepy = MapFindMin(self, range, "TerritorialNest", function(nest, me, range)
-		if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
-			return me:GetDist2D(nest)
-		end
-	end, self, range)
-	if closest_sleepy then
-		return closest_sleepy
-	else
-		return false
-	end
+    range = range or max_int
+    local closest_sleepy = MapFindMin(self, range, "TerritorialNest", function(nest, me, range)
+        if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
+            return me:GetDist2D(nest)
+        end
+    end, self, range)
+    if closest_sleepy then
+        return closest_sleepy
+    else
+        return false
+    end
 end
 
 function EnhancedTerritorialNest:support_arrived(allied_unit)
-	--print("A unit supporting me has arrived!")
-	local my_strongest_tier = 0
-	if self.state == 'asleep' then
-		--print("This is going to try and wake me up!")
-		if not self.wake_up_alarms then
-			self.wake_up_alarms = 0
-		end
-		self.wake_up_alarms = self.wake_up_alarms + 1
-		local awake = MapCount(true, "TerritorialNest", function(nest, me)
-			if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
-				return true
-			end
-		end, self)
-		-- make it so that each nest needs more units to wake it up
-		local threshold = 1
-		if Faction_aggression_threshold > threshold then
-			threshold = Faction_aggression_threshold
-		end
-		-- This means the first nest only needs a single wake up event
-		local threshold = threshold * awake
-		if self.wake_up_alarms > threshold then
-			--print("It did wake me up!")
-			self:SwitchState('awake')
-		else
-			--print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
-		end
-		goto continue
-	end
-	local hatchling_tier = EE_get_tier(self.hatchling_class)
-	local adult_tier = EE_get_tier(self.adult_class)
-	local elder_tier = EE_get_tier(self.elder_class)
-	local my_best = Max(hatchling_tier, adult_tier, elder_tier)
-	for _, defender in ipairs(self.nest_members) do
-		local d_tier = EE_get_tier(defender.class)
-		if d_tier > my_best then
-			my_best = d_tier
-		end
-	end
-	--print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
-	local compare
-	if allied_unit.class then
-		compare = allied_unit.class
-	else
-		compare = allied_unit.id
-	end
-	--print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
-	if EE_get_tier(compare) > my_best then
-		--print("It is!")
-		self.attacks_done = self.attacks_done + 1
-		if self.attacks_done > self.attacks_to_evo then
-			--print("And it triggered an evolution!")
-			self:change_nest_herd(true)
-		end
-		goto continue
-	else
-		--print("It was not")
-	end
-	--print("Storing this units EP cost in the nearby structrues and reducing attack time!")
-	local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
-	self:give_ep_to_struct(EP_of_unit)
-	local attack_cd = self.attack_delay
-	-- each unit will reduce the attack cd by 5%
-	self.attack_time = self.attack_time - (5 * DivRound(attack_cd, 100))
-	::continue::
+    --print("A unit supporting me has arrived!")
+    local my_strongest_tier = 0
+    if self.state == 'asleep' then
+        --print("This is going to try and wake me up!")
+        if not self.wake_up_alarms then
+            self.wake_up_alarms = 0
+        end
+        self.wake_up_alarms = self.wake_up_alarms + 1
+        local awake = MapCount(true, "TerritorialNest", function(nest, me)
+            if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
+                return true
+            end
+        end, self)
+        -- make it so that each nest needs more units to wake it up
+        local threshold = 1
+        if Faction_aggression_threshold > threshold then
+            threshold = Faction_aggression_threshold
+        end
+        -- This means the first nest only needs a single wake up event
+        local threshold = threshold * awake
+        if self.wake_up_alarms > threshold then
+            --print("It did wake me up!")
+            self:SwitchState('awake')
+        else
+            --print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
+        end
+        goto continue
+    end
+    local hatchling_tier = EE_get_tier(self.hatchling_class)
+    local adult_tier = EE_get_tier(self.adult_class)
+    local elder_tier = EE_get_tier(self.elder_class)
+    local my_best = Max(hatchling_tier, adult_tier, elder_tier)
+    for _, defender in ipairs(self.nest_members) do
+        local d_tier = EE_get_tier(defender.class)
+        if d_tier > my_best then
+            my_best = d_tier
+        end
+    end
+    --print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
+    local compare
+    if allied_unit.class then
+        compare = allied_unit.class
+    else
+        compare = allied_unit.id
+    end
+    --print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
+    if EE_get_tier(compare) > my_best then
+        --print("It is!")
+        self.attacks_done = self.attacks_done + 1
+        if self.attacks_done > self.attacks_to_evo then
+            --print("And it triggered an evolution!")
+            self:change_nest_herd(true)
+        end
+        goto continue
+    else
+        --print("It was not")
+    end
+    --print("Storing this units EP cost in the nearby structrues and reducing attack time!")
+    local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
+    self:give_ep_to_struct(EP_of_unit)
+    local attack_cd = self.attack_delay
+    -- each unit will reduce the attack cd by 5%
+    self.attack_time = self.attack_time - (5 * DivRound(attack_cd, 100))
+    ::continue::
 end
 
 function EnhancedTerritorialNest:mega_consume()
-	DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
-	local multiplier = Get_difficulty_offset()
-	for i = 1, 3 * multiplier do
-		self:consume_closest_node()
-	end
+    DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
+    local multiplier = Get_difficulty_offset()
+    for i = 1, 3 * multiplier do
+        self:consume_closest_node()
+    end
 end
 
 function EnhancedTerritorialNest:alert_neighbor(allied_sleepy_nest)
-	DebugPrint("Nest is sending support to the closest nest!\n")
-	local spawn_def = SpawnDefs['Nest_wakeup_alarm']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.SpawnClass = self.adult_class
-	instance.AdditionalClassList = {}
-	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t, {}, 100)
+    DebugPrint("Nest is sending support to the closest nest!\n")
+    local spawn_def = SpawnDefs['Nest_wakeup_alarm']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.SpawnClass = self.adult_class
+    instance.AdditionalClassList = {}
+    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:growth_event()
-	DebugPrint("Nest has grown enough to do something!\n")
-	self:UpdateNextAttackTime()
-	self:change_nest_herd()
-	local spawn_def
-	local spawn_def_selection = {}
-	if self.state == 'sleepy' then
-		spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.overflow_spawn }
-		spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.scout_nearest_quad }
-		spawn_def = table.weighted_rand(spawn_def_selection, "weight")
-		spawn_def.fun(self)
-		return
-	end
-	-- ensure quadrant + scouting grid exist before reading them (growth_event lacked the guard
-	-- that scout_nearest_quad has; on a fresh map the grid is uninitialised -> nil-index crash)
-	if not self.quadrant then
-		self.quadrant = Get_quadrant_from_obj(self, true)
-	end
-	if not self.nest_species then
-		self.nest_species = get_species_from_nest(self.class)
-	end
-	if not Nest_scouting_quadrants[self.quadrant] then
-		CreateMapGrid()
-	end
-	local unscouted = self:GetUnscoutedQuadrantsWithin()
-	local my_quad_scouted = #unscouted[1] > 0
-	local unscouted_nearby = unscouted[3]
-	if not my_quad_scouted then
-		spawn_def_selection[#spawn_def_selection + 1] = {
-			weight = 200,
-			fun = self.Scout_Specific_Quad,
-			input = self
-				.quadrant
-		}
-	elseif #unscouted_nearby > 0 then
-		local to_scout = table.weighted_rand(unscouted_nearby, function(entry) return 100 end)
-		spawn_def_selection[#spawn_def_selection + 1] = {
-			weight = (100 * #unscouted_nearby),
-			fun = self
-				.Scout_Specific_Quad,
-			input = to_scout
-		}
-	elseif #unscouted[#unscouted] > 0 then
-		local to_scout = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
-		spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.Scout_Specific_Quad, input = to_scout }
-	end
-	local attack_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
-	local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
-	if #nearby_enemies > 0 then
-		for _, enemy in ipairs(nearby_enemies) do
-			local weight = 100
-			if enemy.state == 'asleep' then
-				weight = weight * 2
-			end
-			spawn_def_selection[#spawn_def_selection + 1] = {
-				weight = weight,
-				fun = self.nest_attack_non_player,
-				input =
-					enemy
-			}
-		end
-	end
-	-- note this means if a nest is awaken by another species, it will still be aggressive towards the player
-	if self:IsPlayerKnown() and not self:IsAsleep() and self:can_be_aggressive() then
-		-- Attack the player only if this nest is the front line of its species; if a same-species ally is ahead of us
-		-- toward the survivors AND in roughly our own direction, support it instead. The angular gate stops support
-		-- being sent to a ~180-degree-opposite nest (which would cross the player's base).
-		local support_target = self:GetSupportTarget()
-		if support_target then
-			spawn_def_selection[#spawn_def_selection + 1] = {
-				weight = 150,
-				fun = self.nest_support_closest,
-				input =
-					support_target
-			}
-		else
-			spawn_def_selection[#spawn_def_selection + 1] = { weight = 300, fun = self.nest_attack_player }
-		end
-	else
-		local scouting
-		if #unscouted[#unscouted] > 0 then
-			scouting = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
-		else
-			-- we force scout the quadrant with the oldest scouted time as a major major backup
-			for i = 1, #Nest_scouting_quadrants do
-				if Nest_scouting_quadrants[i][self.nest_species].last_scout then
-					scouting = i
-					break
-				end
-				scouting = unscouted[1][1]
-			end
-		end
-		-- if the player is not known, we ALWAYS want to scout and find them
-		spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.Scout_Specific_Quad, input = scouting }
-	end
-	-- if there is a nest within ~3 quadrant lengths
-	local wake_up_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
-	local sleepy = self:ClosestSleepyNest(wake_up_range)
-	if sleepy then
-		spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.alert_neighbor, input = sleepy }
-	end
-	-- always leave the options to just vomit enemies in the nearby area
-	-- and consume a lot of nearby biomass
-	spawn_def_selection[#spawn_def_selection + 1] = { weight = 10, fun = self.overflow_spawn }
-	spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.mega_consume }
-	spawn_def = table.weighted_rand(spawn_def_selection, "weight")
-	if spawn_def.input then
-		spawn_def.fun(self, spawn_def.input)
-	else
-		spawn_def.fun(self)
-	end
+    DebugPrint("Nest has grown enough to do something!\n")
+    self:UpdateNextAttackTime()
+    self:change_nest_herd()
+    local spawn_def
+    local spawn_def_selection = {}
+    if self.state == 'sleepy' then
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.overflow_spawn }
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.scout_nearest_quad }
+        spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+        spawn_def.fun(self)
+        return
+    end
+    -- ensure quadrant + scouting grid exist before reading them (growth_event lacked the guard
+    -- that scout_nearest_quad has; on a fresh map the grid is uninitialised -> nil-index crash)
+    if not self.quadrant then
+        self.quadrant = Get_quadrant_from_obj(self, true)
+    end
+    if not self.nest_species then
+        self.nest_species = get_species_from_nest(self.class)
+    end
+    if not Nest_scouting_quadrants[self.quadrant] then
+        CreateMapGrid()
+    end
+    local unscouted = self:GetUnscoutedQuadrantsWithin()
+    local my_quad_scouted = #unscouted[1] > 0
+    local unscouted_nearby = unscouted[3]
+    if not my_quad_scouted then
+        spawn_def_selection[#spawn_def_selection + 1] = {
+            weight = 200,
+            fun = self.Scout_Specific_Quad,
+            input = self
+                .quadrant
+        }
+    elseif #unscouted_nearby > 0 then
+        local to_scout = table.weighted_rand(unscouted_nearby, function(entry) return 100 end)
+        spawn_def_selection[#spawn_def_selection + 1] = {
+            weight = (100 * #unscouted_nearby),
+            fun = self
+                .Scout_Specific_Quad,
+            input = to_scout
+        }
+    elseif #unscouted[#unscouted] > 0 then
+        local to_scout = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.Scout_Specific_Quad, input = to_scout }
+    end
+    local attack_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+    local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
+    if #nearby_enemies > 0 then
+        for _, enemy in ipairs(nearby_enemies) do
+            local weight = 100
+            if enemy.state == 'asleep' then
+                weight = weight * 2
+            end
+            spawn_def_selection[#spawn_def_selection + 1] = {
+                weight = weight,
+                fun = self.nest_attack_non_player,
+                input =
+                    enemy
+            }
+        end
+    end
+    -- note this means if a nest is awaken by another species, it will still be aggressive towards the player
+    if self:IsPlayerKnown() and not self:IsAsleep() and self:can_be_aggressive() then
+        -- Attack the player only if this nest is the front line of its species; if a same-species ally is ahead of us
+        -- toward the survivors AND in roughly our own direction, support it instead. The angular gate stops support
+        -- being sent to a ~180-degree-opposite nest (which would cross the player's base).
+        local support_target = self:GetSupportTarget()
+        if support_target then
+            spawn_def_selection[#spawn_def_selection + 1] = {
+                weight = 150,
+                fun = self.nest_support_closest,
+                input =
+                    support_target
+            }
+        else
+            spawn_def_selection[#spawn_def_selection + 1] = { weight = 300, fun = self.nest_attack_player }
+        end
+    else
+        local scouting
+        if #unscouted[#unscouted] > 0 then
+            scouting = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+        else
+            -- we force scout the quadrant with the oldest scouted time as a major major backup
+            for i = 1, #Nest_scouting_quadrants do
+                if Nest_scouting_quadrants[i][self.nest_species].last_scout then
+                    scouting = i
+                    break
+                end
+                scouting = unscouted[1][1]
+            end
+        end
+        -- if the player is not known, we ALWAYS want to scout and find them
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.Scout_Specific_Quad, input = scouting }
+    end
+    -- if there is a nest within ~3 quadrant lengths
+    local wake_up_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+    local sleepy = self:ClosestSleepyNest(wake_up_range)
+    if sleepy then
+        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.alert_neighbor, input = sleepy }
+    end
+    -- always leave the options to just vomit enemies in the nearby area
+    -- and consume a lot of nearby biomass
+    spawn_def_selection[#spawn_def_selection + 1] = { weight = 10, fun = self.overflow_spawn }
+    spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.mega_consume }
+    spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+    if spawn_def.input then
+        spawn_def.fun(self, spawn_def.input)
+    else
+        spawn_def.fun(self)
+    end
 end
 
 function EnhancedTerritorialNest:UpdateNextAttackTime()
-	DebugPrint("Nest updating when to attack next\n")
-	local diff = Get_difficulty_offset() - 3
-	self.attack_delay = MoonInstance.AttackCooldownMin +
-		AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
-	if self.state == 'asleep' then self.attack_delay = self.attack_delay * 2 end
-	self.attack_time = GameTime() + self.attack_delay --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
-	DebugPrint("Next attack time:\n")
-	DebugPrint(self.attack_time)
-	DebugPrint("\nGame Time:\n")
-	DebugPrint(GameTime())
-	DebugPrint("\n")
+    DebugPrint("Nest updating when to attack next\n")
+    local diff = Get_difficulty_offset() - 3
+    self.attack_delay = MoonInstance.AttackCooldownMin +
+        AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
+    if self.state == 'asleep' then self.attack_delay = self.attack_delay * 2 end
+    self.attack_time = GameTime() + self.attack_delay --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
+    DebugPrint("Next attack time:\n")
+    DebugPrint(self.attack_time)
+    DebugPrint("\nGame Time:\n")
+    DebugPrint(GameTime())
+    DebugPrint("\n")
 end
 
 function EnhancedTerritorialNest:TooTiredCheck()
@@ -1336,348 +1336,348 @@ function EnhancedTerritorialNest:TooTiredCheck()
 end
 
 function EnhancedTerritorialNest:OnObjUpdate(time, update_interval)
-	local health = self.Health
-	if health <= 0 then return end
-	if self.attack_time < GameTime() and health > 0 and not self:IsDestroyed() then
-		DebugPrint("Nest is activating!\n")
-		self:growth_event()
-		-- grow_event contains logic to determine what this event really "does"
-	end
-	if self.consume_time < GameTime() then
-		self:consume_closest_node()
-	end
-	if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
-		if self:TooTiredCheck() then
-			self:SwitchState('asleep')
-		else
-			self.sleep_check = GameTime() + const.Scale.months
-		end
-	end
+    local health = self.Health
+    if health <= 0 then return end
+    if self.attack_time < GameTime() and health > 0 and not self:IsDestroyed() then
+        DebugPrint("Nest is activating!\n")
+        self:growth_event()
+        -- grow_event contains logic to determine what this event really "does"
+    end
+    if self.consume_time < GameTime() then
+        self:consume_closest_node()
+    end
+    if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
+        if self:TooTiredCheck() then
+            self:SwitchState('asleep')
+        else
+            self.sleep_check = GameTime() + const.Scale.months
+        end
+    end
 end
 
 function TerritorialNest:Done()
-	local members = self.nest_members
-	for i = #members, 1, -1 do
-		members[i]:SetNest(false)
-	end
-	DeleteThread(self.engagement_range_thread)
-	self.engagement_range_thread = nil
-	self:RemoveFromLabels(Game)
-	self.attack_time = max_int
+    local members = self.nest_members
+    for i = #members, 1, -1 do
+        members[i]:SetNest(false)
+    end
+    DeleteThread(self.engagement_range_thread)
+    self.engagement_range_thread = nil
+    self:RemoveFromLabels(Game)
+    self.attack_time = max_int
 end
 
 function UnitNesting:OnObjUpdate()
-	local nest = self.nest
-	if not IsValid(nest) then
-		return
-	end
-	local effect = self.NestEffect or ""
-	if effect == "" then
-		return
-	end
-	local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
-	if nest_nearby == self.nest_nearby then
-		return
-	end
-	self:give_nest_effect()
+    local nest = self.nest
+    if not IsValid(nest) then
+        return
+    end
+    local effect = self.NestEffect or ""
+    if effect == "" then
+        return
+    end
+    local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
+    if nest_nearby == self.nest_nearby then
+        return
+    end
+    self:give_nest_effect()
 end
 
 function UnitNesting:ReportScoutingResult()
-	quadrant = invader.target_quadrant
-	local day = GameTime()
-	local species = invader.location.nest_species
-	local list_of_found = self.observed_objects
-	nest_scouting_quadrants[quadrant][species]['last_scout'] = day
-	-- Override the last scouting report
-	nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
-	nest_scouting_quadrants[quadrant][species]['other_species'] = {}
-	for _, b in ipairs(list_of_found) do
-		local handle = b['handle'] or false
-		if handle then
-			nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs'] + 1] =
-				handle
-			local species = get_species_from_nest(b.class)
-			if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
-				nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
-			end
-			nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species'] + 1] =
-				handle
-		end
-	end
+    quadrant = invader.target_quadrant
+    local day = GameTime()
+    local species = invader.location.nest_species
+    local list_of_found = self.observed_objects
+    nest_scouting_quadrants[quadrant][species]['last_scout'] = day
+    -- Override the last scouting report
+    nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
+    nest_scouting_quadrants[quadrant][species]['other_species'] = {}
+    for _, b in ipairs(list_of_found) do
+        local handle = b['handle'] or false
+        if handle then
+            nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs'] + 1] =
+                handle
+            local species = get_species_from_nest(b.class)
+            if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
+                nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
+            end
+            nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species'] + 1] =
+                handle
+        end
+    end
 end
 
 -- override of base game function to give nest effect in case things go wrong
 function TerritorialNest:AddNestMember(member)
-	table.insert(self.nest_members, member)
-	if member.CombatGroup ~= self.CombatGroup then
-		member.CombatGroup = self.CombatGroup
-	end
-	-- mark guardian members as such (they stay close to the nest and protect it if attacked)
-	self:TrySetNestGuardian(member)
-	member:give_nest_effect()
+    table.insert(self.nest_members, member)
+    if member.CombatGroup ~= self.CombatGroup then
+        member.CombatGroup = self.CombatGroup
+    end
+    -- mark guardian members as such (they stay close to the nest and protect it if attacked)
+    self:TrySetNestGuardian(member)
+    member:give_nest_effect()
 end
 
 function UnitNesting:give_nest_effect()
-	if not self.nest then return end
-	local nest = self.nest
-	local give = self:IsCloser(nest, nest.territorial_range)
-	if give then
-		if IsKindOf(self, "Robot") then
-			self:AddRobotCondition('FamiliarGroundRobo', 'mod')
-		else
-			self:AddHealthCondition(self.NestEffect or "", "nest")
-		end
-	elseif IsKindOf(self, "Robot") then
-		self:RemoveRobotCondition('FamiliarGroundRobo', 'mod')
-	else
-		self:RemoveHealthConditions(self.NestEffect or "", "nest")
-	end
+    if not self.nest then return end
+    local nest = self.nest
+    local give = self:IsCloser(nest, nest.territorial_range)
+    if give then
+        if IsKindOf(self, "Robot") then
+            self:AddRobotCondition('FamiliarGroundRobo', 'mod')
+        else
+            self:AddHealthCondition(self.NestEffect or "", "nest")
+        end
+    elseif IsKindOf(self, "Robot") then
+        self:RemoveRobotCondition('FamiliarGroundRobo', 'mod')
+    else
+        self:RemoveHealthConditions(self.NestEffect or "", "nest")
+    end
 end
 
 function UnitNesting:UpdateAttachedUI()
-	if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
-	RemoveAttachedUIToObject(self, 'NestRolePermanent')
-	RemoveAttachedUIToObject(self, 'NestRoleClose')
-	RemoveAttachedUIToObject(self, 'NestRoleFar')
-	local template
-	if NA_NestRoleZoom == 3 then
-		template = 'NestRolePermanent'
-	elseif NA_NestRoleZoom == 2 then
-		template = 'NestRoleFar'
-	elseif NA_NestRoleZoom == 1 then
-		template = 'NestRoleClose'
-	end
-	if template then
-		AddAttachedUIToObject(self, template, 'Task', self)
-	end
+    if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
+    RemoveAttachedUIToObject(self, 'NestRolePermanent')
+    RemoveAttachedUIToObject(self, 'NestRoleClose')
+    RemoveAttachedUIToObject(self, 'NestRoleFar')
+    local template
+    if NA_NestRoleZoom == 3 then
+        template = 'NestRolePermanent'
+    elseif NA_NestRoleZoom == 2 then
+        template = 'NestRoleFar'
+    elseif NA_NestRoleZoom == 1 then
+        template = 'NestRoleClose'
+    end
+    if template then
+        AddAttachedUIToObject(self, template, 'Task', self)
+    end
 end
 
 function UnitNesting:GetUIRole()
-	if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
-	if self.hide_UI_on_empty and amount <= 0 then return "" end
-	local name = ''
-	if NA_NestRoleName then
-		name = self:GetHUDName(self)
-	end
-	local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
-	local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
-	local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
-	local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-	local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
-	local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-	if self.found_player then
-		return T { "<image " .. scout_found_player .. " 1800><name>", name = name }
-	elseif self.scouting then
-		return T { "<image " .. scout .. " 1800><name>", name = name }
-	elseif self.pathing_to then
-		return T { "<image " .. support .. " 1800><name>", name = name }
-	elseif self.nest then
-		local image = defender
-		return T { "<image " .. image .. " 1800><name>", name = name }
-	end
+    if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
+    if self.hide_UI_on_empty and amount <= 0 then return "" end
+    local name = ''
+    if NA_NestRoleName then
+        name = self:GetHUDName(self)
+    end
+    local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
+    local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
+    local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
+    local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+    local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
+    local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+    if self.found_player then
+        return T { "<image " .. scout_found_player .. " 1800><name>", name = name }
+    elseif self.scouting then
+        return T { "<image " .. scout .. " 1800><name>", name = name }
+    elseif self.pathing_to then
+        return T { "<image " .. support .. " 1800><name>", name = name }
+    elseif self.nest then
+        local image = defender
+        return T { "<image " .. image .. " 1800><name>", name = name }
+    end
 end
 
 local OG_ShouldShowHUDName = UnitAnimal.ShouldShowHUDName
 function UnitAnimal:ShouldShowHUDName()
-	local base = OG_ShouldShowHUDName(self)
-	if self:CheckForNewBehaviors() or self.nest then return true else return base end
-	--return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
+    local base = OG_ShouldShowHUDName(self)
+    if self:CheckForNewBehaviors() or self.nest then return true else return base end
+    --return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
 end
 
 function UnitNesting:SetNest(nest)
-	nest = nest or false
-	if nest == self.nest then return end
-	local old_nest = self.nest
-	if IsValid(old_nest) then
-		old_nest:RemoveNestMember(self)
-	end
-	self.nest = nest or nil
-	if IsValid(nest) then
-		nest:AddNestMember(self)
-		--self:AddHUDName()
-	end
+    nest = nest or false
+    if nest == self.nest then return end
+    local old_nest = self.nest
+    if IsValid(old_nest) then
+        old_nest:RemoveNestMember(self)
+    end
+    self.nest = nest or nil
+    if IsValid(nest) then
+        nest:AddNestMember(self)
+        --self:AddHUDName()
+    end
 end
 
 function is_inside_of(box, pos)
-	if box:GetDist2D(pos) == 0 then
-		return true
-	else
-		return false
-	end
+    if box:GetDist2D(pos) == 0 then
+        return true
+    else
+        return false
+    end
 end
 
 function TerritorialNest:SpawnAround(class, range, instant, burrowed)
-	local def = class and g_Classes[class]
-	if not def then return end
-	if burrowed and not def.CanBurrowInNest then return end
-	local playbox = GetPlayBox()
-	local pfclass = def.pfclass
-	local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
-	local nest_entity_radius = self:GetRadius()
-	local x, y
-	local retry = 10
-	-- overriding range given because that is usually just 10 meters...
-	range = self.max_range
-	while not x and retry > 0 do
-		x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
-		if x then
-			local temp_pos = point(x, y)
-			local playbox_check = playbox:Dist2(temp_pos) > 1
-			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-			if playbox_check or under_nest then
-				x = nil
-				retry = retry - 1
-			else
-				retry = -1
-			end
-		end
-	end
-	if not x then return end
-	if IsKindOf(def, 'Robot') then
-		local spawn_def = SpawnDefs['single_spawn_around_loc']
-		local instance = {}
-		instance.location = self
-		instance.radius = range
-		instance.PostSpawn = function(self, obj, target, context)
-			obj:SetNest(self.location)
-			obj:SetInvader(true)
-		end
-		instance.FindSpawnLoc = function(self, spawn_class, target, context)
-			return point(x, y)
-		end
-		instance.SpawnClass = class
-		spawn_def = spawn_def:CreateInstance(instance)
-		local t = spawn_def:ResolveTarget()
-		spawn_def:ActivateSpawn(t, {}, 100)
-		return true
-	else
-		local obj
-		obj = def:new()
-		obj:SetNest(self)
-		obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360 * 60, "SpawnNestMember"))
-		if not instant then
-			obj.init_with_command = "CmdSpawn"
-		end
-		return obj
-	end
-	-- in case we have changed what combat groups this nest is
-	obj.CombatGroup = self.CombatGroup
-	return false
+    local def = class and g_Classes[class]
+    if not def then return end
+    if burrowed and not def.CanBurrowInNest then return end
+    local playbox = GetPlayBox()
+    local pfclass = def.pfclass
+    local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
+    local nest_entity_radius = self:GetRadius()
+    local x, y
+    local retry = 10
+    -- overriding range given because that is usually just 10 meters...
+    range = self.max_range
+    while not x and retry > 0 do
+        x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
+        if x then
+            local temp_pos = point(x, y)
+            local playbox_check = playbox:Dist2(temp_pos) > 1
+            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+            if playbox_check or under_nest then
+                x = nil
+                retry = retry - 1
+            else
+                retry = -1
+            end
+        end
+    end
+    if not x then return end
+    if IsKindOf(def, 'Robot') then
+        local spawn_def = SpawnDefs['single_spawn_around_loc']
+        local instance = {}
+        instance.location = self
+        instance.radius = range
+        instance.PostSpawn = function(self, obj, target, context)
+            obj:SetNest(self.location)
+            obj:SetInvader(true)
+        end
+        instance.FindSpawnLoc = function(self, spawn_class, target, context)
+            return point(x, y)
+        end
+        instance.SpawnClass = class
+        spawn_def = spawn_def:CreateInstance(instance)
+        local t = spawn_def:ResolveTarget()
+        spawn_def:ActivateSpawn(t, {}, 100)
+        return true
+    else
+        local obj
+        obj = def:new()
+        obj:SetNest(self)
+        obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360 * 60, "SpawnNestMember"))
+        if not instant then
+            obj.init_with_command = "CmdSpawn"
+        end
+        return obj
+    end
+    -- in case we have changed what combat groups this nest is
+    obj.CombatGroup = self.CombatGroup
+    return false
 end
 
 function TerritorialNest:Spawn_robot_nestling(x, y, class)
-	local spawn_def = SpawnDefs['Single_Robots']
-	local instance = {}
-	instance.location = self
-	instance.nest = self
-	instance.pos = point(x, y)
-	instance.SpawnClass = class
-	instance.FindSpawnLoc = function(self, spawn_class, target, context)
-		return self.pos
-	end
-	--[[instance.PostSpawn = function(self,obj,target,context)
+    local spawn_def = SpawnDefs['Single_Robots']
+    local instance = {}
+    instance.location = self
+    instance.nest = self
+    instance.pos = point(x, y)
+    instance.SpawnClass = class
+    instance.FindSpawnLoc = function(self, spawn_class, target, context)
+        return self.pos
+    end
+    --[[instance.PostSpawn = function(self,obj,target,context)
 		obj:SetInvader(true)
 		obj:SetNest(self.nest)
 	end--]]
-	spawn_def = spawn_def:CreateInstance(instance)
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t, {}, 100)
+    spawn_def = spawn_def:CreateInstance(instance)
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 AppendClass.TerritorialNest = {
-	__parents = { "EnhancedTerritorialNest" },
+    __parents = { "EnhancedTerritorialNest" },
 }
 
 -- meta class grouping all spore buildings for easier searching
 -- We do not append ConsortiumSporeDeposit because we define it in the other file with this as a parent already
 DefineClass.NestSpore = {
-	properties = {}
+    properties = {}
 }
 
 AppendClass.ShriekerSporeDeposit = {
-	__parents = { "NestSpore" }
+    __parents = { "NestSpore" }
 }
 
 AppendClass.ScissorhandSporeDeposit = {
-	__parents = { "NestSpore" }
+    __parents = { "NestSpore" }
 }
 
 function count_effects_by_id(target, effect_id)
-	local count = 0
-	for _, effect in ipairs(target.status_effects or empty_table) do
-		if effect.id == effect_id then
-			count = count + 1
-		end
-	end
-	return count
+    local count = 0
+    for _, effect in ipairs(target.status_effects or empty_table) do
+        if effect.id == effect_id then
+            count = count + 1
+        end
+    end
+    return count
 end
 
 function decay_speed(target)
-	local effect_id = 'nest_attack_speed'
-	--[[if IsKindOf(target,'Robot') then
+    local effect_id = 'nest_attack_speed'
+    --[[if IsKindOf(target,'Robot') then
 		effect_id = 'nest_attack_speed_robot'
 		target:RemoveRobotConditions(effect_id, "ReplaceOldest")
 	end--]]
-	local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
-	local distance_to = target:GetDist2D(survivors)
-	local prox = MulDivRound(distance_to, 1, 150 * guim)
-	local count = count_effects_by_id(target, effect_id)
-	while count > prox do
-		if IsKindOf(target, 'Robot') then
-			target:RemoveRobotConditions(effect_id, "ReplaceOldest")
-			count = count_effects_by_id(target, effect_id)
-		else
-			target:RemoveHealthConditions(effect_id, "ReplaceOldest")
-			count = count_effects_by_id(target, effect_id)
-		end
-	end
+    local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
+    local distance_to = target:GetDist2D(survivors)
+    local prox = MulDivRound(distance_to, 1, 150 * guim)
+    local count = count_effects_by_id(target, effect_id)
+    while count > prox do
+        if IsKindOf(target, 'Robot') then
+            target:RemoveRobotConditions(effect_id, "ReplaceOldest")
+            count = count_effects_by_id(target, effect_id)
+        else
+            target:RemoveHealthConditions(effect_id, "ReplaceOldest")
+            count = count_effects_by_id(target, effect_id)
+        end
+    end
 end
 
 function add_delay_to_nests()
-	MapForEach(true, "TerritorialNest", function(nest)
-		if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
-			nest:UpdateNextAttackTime()
-		end
-	end)
+    MapForEach(true, "TerritorialNest", function(nest)
+        if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
+            nest:UpdateNextAttackTime()
+        end
+    end)
 end
 
 function clean_up_robots()
-	MapForEach(true, "Robot", function(robot)
-		if not robot.Invader and not robot.command_center then
-			DoneObject(robot)
-		end
-	end)
-	MapForEach(true, "ConsortiumNest", function(nest)
-		local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
-		nest:UpdateTerritoryTerrain(true, count)
-		for i = 1, count do
-			if not nest:SpawnNestMember(true) then
-				break
-			end
-		end
-	end)
+    MapForEach(true, "Robot", function(robot)
+        if not robot.Invader and not robot.command_center then
+            DoneObject(robot)
+        end
+    end)
+    MapForEach(true, "ConsortiumNest", function(nest)
+        local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
+        nest:UpdateTerritoryTerrain(true, count)
+        for i = 1, count do
+            if not nest:SpawnNestMember(true) then
+                break
+            end
+        end
+    end)
 end
 
 function delete_robots()
-	MapDelete("map", "HeavyHostileRobot_LVL1", function(robot, playbox)
-		return is_inside_of(playbox, robot)
-	end, GetPlayBox())
+    MapDelete("map", "HeavyHostileRobot_LVL1", function(robot, playbox)
+        return is_inside_of(playbox, robot)
+    end, GetPlayBox())
 end
 
 function SavegameFixups.EnhancedNestFixes()
-	add_delay_to_nests()
-	clean_up_robots()
-	delete_robots()
+    add_delay_to_nests()
+    clean_up_robots()
+    delete_robots()
 end
 
 function OnMsg.PostLoadGame()
-	delete_robots()
+    delete_robots()
 end
 
 function OnMsg.UpdateNestRoleVisuals()
-	MapForEach('map', 'UnitNesting', function(nest_member)
-		nest_member:UpdateAttachedUI()
-	end)
+    MapForEach('map', 'UnitNesting', function(nest_member)
+        nest_member:UpdateAttachedUI()
+    end)
 end
 
 --[[ Debugging ovverride

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -4,374 +4,374 @@ local hours_per_day = day_duration / hour_duration
 
 
 function Juno_Cancer(force)
-    local nests = {}
-    if force then
-        nests = MapGet(true, 'TerritorialNest', function(nest)
-            if nest.class ~= 'JunoNest' then return true end
-        end)
-    else
-        nests = MapGet(true, 'TerritorialNest', function(nest)
-            if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
-                return true
-            end
-        end)
-    end
-    if #nests > 0 then
-        local roll = AsyncRand(#nests)
-        local to_convert = nests[roll]
-        Convert_nest_into(to_convert, 'nesting_juno')
-    elseif force then
-    end
+	local nests = {}
+	if force then
+		nests = MapGet(true, 'TerritorialNest', function(nest)
+			if nest.class ~= 'JunoNest' then return true end
+		end)
+	else
+		nests = MapGet(true, 'TerritorialNest', function(nest)
+			if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
+				return true
+			end
+		end)
+	end
+	if #nests > 0 then
+		local roll = AsyncRand(#nests)
+		local to_convert = nests[roll]
+		Convert_nest_into(to_convert, 'nesting_juno')
+	elseif force then
+	end
 end
 
 function SpawnNestInsideMap(marker, seed, nest_type, danger_lvl)
-    DebugPrint("Spawning a nest\n")
-    if marker and terrain.IsWater(marker) then
-        return
-    end
-    -- danger level does nothing right now, not part of MVP
-    danger_lvl = danger_lvl or 1
-    seed = seed or InteractionRand(nil, "DailySpawn")
-    local tags = {}
-    nest_type = nest_type or Get_nest_by_region()
-    if not nest_type then
-        return
-    elseif nest_type == 'ShriekerNest' then
-        tags = { shrieker_fall = true }
-    elseif nest_type == 'ScissorhandsNest' then
-        tags = { scissorhands_nest = true }
-    else
-        --("Using backup, whatever nest type is the tag!")
-        --(nest_type)
-        tags[nest_type] = true -- future proof for PX, the nest_type input will be the needed tag
-    end
-    --(tags)
-    SuspendPassEdits("SpawndNest")
-    seed = seed or InteractionRand(nil, "DailySpawn")
-    local nest
-    --(seed)
-    --()
-    local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
-        tags_all = tags,
-    })
-    if not err then
-        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-        if nest_marker then
-            nest = nest_marker:SpawnNest(true)
-        else
-            assert(false, "Prefab without a nest marker: " .. name)
-        end
-    else
-        assert(false, "Prefab error: " .. err)
-    end
-    ResumePassEdits("SpawndNest")
-    return nest
+	DebugPrint("Spawning a nest\n")
+	if marker and terrain.IsWater(marker) then
+		return
+	end
+	-- danger level does nothing right now, not part of MVP
+	danger_lvl = danger_lvl or 1
+	seed = seed or InteractionRand(nil, "DailySpawn")
+	local tags = {}
+	nest_type = nest_type or Get_nest_by_region()
+	if not nest_type then
+		return
+	elseif nest_type == 'ShriekerNest' then
+		tags = { shrieker_fall = true }
+	elseif nest_type == 'ScissorhandsNest' then
+		tags = { scissorhands_nest = true }
+	else
+		--("Using backup, whatever nest type is the tag!")
+		--(nest_type)
+		tags[nest_type] = true -- future proof for PX, the nest_type input will be the needed tag
+	end
+	--(tags)
+	SuspendPassEdits("SpawndNest")
+	seed = seed or InteractionRand(nil, "DailySpawn")
+	local nest
+	--(seed)
+	--()
+	local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
+		tags_all = tags,
+	})
+	if not err then
+		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+		if nest_marker then
+			nest = nest_marker:SpawnNest(true)
+		else
+			assert(false, "Prefab without a nest marker: " .. name)
+		end
+	else
+		assert(false, "Prefab error: " .. err)
+	end
+	ResumePassEdits("SpawndNest")
+	return nest
 end
 
 function PlacePrefabLogic:GetPrefabLoc(seed, params)
-    seed = seed or InteractionRand(nil, "PlacePrefab")
-    local name, pos, angle, prefab, idx
-    --("Params")
-    --(params)
-    local prefabs = self:GetPrefabs(params)
-    --("Initial get of #prefabs")
-    --(#prefabs)
-    local r = 4
-    local fresh_prefabs
-    while #prefabs == 0 and r > 0 do
-        --("RETRYING BECAUSE I FAILED TO FIND")
-        prefabs = self:GetPrefabs(params)
-        local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
-        --("non-self prefab get count")
-        --(#fresh_prefabs)
-        --("self get of #prefabs")
-        --(#prefabs)
-        r = r - 1
-        if #fresh_prefabs > #prefabs then
-            prefabs = fresh_prefabs
-        end
-    end
-    local retry
-    while true do
-        local idx
-        if #prefabs > 1 then
-            prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
-        else
-            prefab = prefabs[1]
-        end
-        ----(prefab)
-        assert(prefab)
-        if not prefab then
-            return
-        end
-        pos = params and params.pos
-        if not pos then
-            pos = self:GetVisualPos()
-            if not self.FixAtCenter then
-                local reserved_radius
-                if params and params.avoid_reserved_locations and self.reserved_locations then
-                    reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
-                end
-                local radius = prefab.max_radius * const.TypeTileSize
-                local free_dist = self.MaxPrefabRadius - radius
-                if free_dist > 0 then
-                    local center = pos
-                    pos = false
-                    local retries = params and params.avoid_reserved_retries or 16
-                    for i = 1, retries do
-                        local ra, rr
-                        ra, seed = BraidRandom(seed, 360 * 60)
-                        rr, seed = BraidRandom(seed, free_dist)
-                        local pos_i = RotateRadius(rr, ra, center)
-                        if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
-                            pos = pos_i
-                            break
-                        end
-                    end
-                elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
-                    pos = false
-                end
-            end
-        end
-        if pos then
-            name = PrefabMarkers[prefab]
-            angle = params and params.angle
-            if not angle then
-                angle = self:GetAngle()
-                local rand_angle = self.RandAngle
-                if rand_angle > 0 then
-                    local desired_angle = params and params.desired_angle
-                    if desired_angle then
-                        local angle_diff = AngleDiff(desired_angle, angle)
-                        if abs(angle_diff) <= rand_angle then
-                            angle = desired_angle
-                        else
-                            local min_angle, max_angle = angle - rand_angle, angle + rand_angle
-                            if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
-                                angle = min_angle
-                            else
-                                angle = max_angle
-                            end
-                        end
-                    else
-                        local da
-                        da, seed = BraidRandom(seed, -rand_angle, rand_angle)
-                        angle = angle + da
-                    end
-                end
-            end
-            return name, pos, angle, prefab, seed
-        end
-        if #prefabs == 1 then
-            return
-        end
-        table.remove_rotate(prefabs, idx)
-    end
+	seed = seed or InteractionRand(nil, "PlacePrefab")
+	local name, pos, angle, prefab, idx
+	--("Params")
+	--(params)
+	local prefabs = self:GetPrefabs(params)
+	--("Initial get of #prefabs")
+	--(#prefabs)
+	local r = 4
+	local fresh_prefabs
+	while #prefabs == 0 and r > 0 do
+		--("RETRYING BECAUSE I FAILED TO FIND")
+		prefabs = self:GetPrefabs(params)
+		local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
+		--("non-self prefab get count")
+		--(#fresh_prefabs)
+		--("self get of #prefabs")
+		--(#prefabs)
+		r = r - 1
+		if #fresh_prefabs > #prefabs then
+			prefabs = fresh_prefabs
+		end
+	end
+	local retry
+	while true do
+		local idx
+		if #prefabs > 1 then
+			prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
+		else
+			prefab = prefabs[1]
+		end
+		----(prefab)
+		assert(prefab)
+		if not prefab then
+			return
+		end
+		pos = params and params.pos
+		if not pos then
+			pos = self:GetVisualPos()
+			if not self.FixAtCenter then
+				local reserved_radius
+				if params and params.avoid_reserved_locations and self.reserved_locations then
+					reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
+				end
+				local radius = prefab.max_radius * const.TypeTileSize
+				local free_dist = self.MaxPrefabRadius - radius
+				if free_dist > 0 then
+					local center = pos
+					pos = false
+					local retries = params and params.avoid_reserved_retries or 16
+					for i = 1, retries do
+						local ra, rr
+						ra, seed = BraidRandom(seed, 360 * 60)
+						rr, seed = BraidRandom(seed, free_dist)
+						local pos_i = RotateRadius(rr, ra, center)
+						if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
+							pos = pos_i
+							break
+						end
+					end
+				elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
+					pos = false
+				end
+			end
+		end
+		if pos then
+			name = PrefabMarkers[prefab]
+			angle = params and params.angle
+			if not angle then
+				angle = self:GetAngle()
+				local rand_angle = self.RandAngle
+				if rand_angle > 0 then
+					local desired_angle = params and params.desired_angle
+					if desired_angle then
+						local angle_diff = AngleDiff(desired_angle, angle)
+						if abs(angle_diff) <= rand_angle then
+							angle = desired_angle
+						else
+							local min_angle, max_angle = angle - rand_angle, angle + rand_angle
+							if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
+								angle = min_angle
+							else
+								angle = max_angle
+							end
+						end
+					else
+						local da
+						da, seed = BraidRandom(seed, -rand_angle, rand_angle)
+						angle = angle + da
+					end
+				end
+			end
+			return name, pos, angle, prefab, seed
+		end
+		if #prefabs == 1 then
+			return
+		end
+		table.remove_rotate(prefabs, idx)
+	end
 end
 
 RecursiveCallMethods.RegisterTarget = "call"
 
 DefineClass.EnhancedTerritorialNest = {
 
-    properties = {
-        { category = "Nest", id = "state",             name = "State of nest",                                 editor = "choice", template = true,   items = { "asleep", "sleepy", "awake", "allied" }, default = 'asleep',                                                                                                      modifiable = true, help = "state of the nest" },
-        { category = "Nest", id = "attack_time",       name = "Nest Attack Time",                              editor = "number", default = max_int, modifiable = true,                                help = "When a nest will attack next if not asleep." },
-        { category = "Nest", id = "attack_delay",      name = "Nest Attack Delay",                             editor = "number", default = max_int, modifiable = true,                                help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)" },
-        { category = "Nest", id = "attacks_done",      name = "Nest Attack Count",                             editor = "number", default = 0,       modifiable = true,                                help = "Number of attacks this nest has sent total" },
-        { category = "Nest", id = "attacks_to_evo",    name = "attacks needed to force evolution",             editor = "number", default = 4,       modifiable = true,                                help = "How much EP is needed to evolve the nest denizens" },
-        { category = "Nest", id = "proximity",         name = "Nests proximity to players stuff",              editor = "number", default = 1,       modifiable = true,                                help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates" },
-        { category = "Nest", id = "ui_attack_percent", name = "How close the attack time is to occuring",      editor = "number", scale = "%",       default = 0,                                      modifiable = true,                                                                                                        help = "" },
-        { category = "Nest", id = "ui_evo",            name = "How close this nest is too evolving it's herd", editor = "number", scale = "%",       default = 0,                                      modifiable = true,                                                                                                        help = "" },
-        { category = "Nest", id = "base_strength",     name = "Base % str of an attack this will send",        editor = "number", scale = "%",       default = 30,                                     modifiable = true,                                                                                                        help = "" },
-        { category = "Nest", id = "consume_time",      name = "When nest will eat the next node",              editor = "number", default = 0,       modifiable = true,                                help = "This is routinely updated based on each individual nest" },
-    },
-    state = 'asleep',
-    attack_time = max_int,
-    attack_delay = max_int,
-    attacks_done = 0,
-    attacks_to_evo = 4,
-    base_strength = 20,
-    consume_time = max_int,
-    proximity = 1,
-    ui_attack_percent = 0,
-    ui_evo = 0,
-    sleep_check = 0,
-    awoken_at = 0,
-    attacked_by_player = false,
-    other_species_attacks = {},
+	properties = {
+		{ category = "Nest", id = "state",             name = "State of nest",                                 editor = "choice", template = true,   items = { "asleep", "sleepy", "awake", "allied" }, default = 'asleep',                                                                                                       modifiable = true, help = "state of the nest" },
+		{ category = "Nest", id = "attack_time",       name = "Nest Attack Time",                              editor = "number", default = max_int, modifiable = true,                                 help = "When a nest will attack next if not asleep." },
+		{ category = "Nest", id = "attack_delay",      name = "Nest Attack Delay",                             editor = "number", default = max_int, modifiable = true,                                 help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)" },
+		{ category = "Nest", id = "attacks_done",      name = "Nest Attack Count",                             editor = "number", default = 0,       modifiable = true,                                 help = "Number of attacks this nest has sent total" },
+		{ category = "Nest", id = "attacks_to_evo",    name = "attacks needed to force evolution",             editor = "number", default = 4,       modifiable = true,                                 help = "How much EP is needed to evolve the nest denizens" },
+		{ category = "Nest", id = "proximity",         name = "Nests proximity to players stuff",              editor = "number", default = 1,       modifiable = true,                                 help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates" },
+		{ category = "Nest", id = "ui_attack_percent", name = "How close the attack time is to occuring",      editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
+		{ category = "Nest", id = "ui_evo",            name = "How close this nest is too evolving it's herd", editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
+		{ category = "Nest", id = "base_strength",     name = "Base % str of an attack this will send",        editor = "number", scale = "%",       default = 30,                                      modifiable = true,                                                                                                        help = "" },
+		{ category = "Nest", id = "consume_time",      name = "When nest will eat the next node",              editor = "number", default = 0,       modifiable = true,                                 help = "This is routinely updated based on each individual nest" },
+	},
+	state = 'asleep',
+	attack_time = max_int,
+	attack_delay = max_int,
+	attacks_done = 0,
+	attacks_to_evo = 4,
+	base_strength = 20,
+	consume_time = max_int,
+	proximity = 1,
+	ui_attack_percent = 0,
+	ui_evo = 0,
+	sleep_check = 0,
+	awoken_at = 0,
+	attacked_by_player = false,
+	other_species_attacks = {},
 }
 
 function EnhancedTerritorialNest:Align_cgroup_members()
-    for _, v in ipairs(self.nest_members) do
-        v.CombatGroup = self.CombatGroup
-    end
+	for _, v in ipairs(self.nest_members) do
+		v.CombatGroup = self.CombatGroup
+	end
 end
 
 function NestDelayedInit(nest)
-    nest:UpdateNextAttackTime()
-    nest:get_proximity()
-    --nest:force_inert_if_capped()
-    nest.quadrant = Get_quadrant_from_obj(nest, true)
-    nest.spawned_on = GameTime()
+	nest:UpdateNextAttackTime()
+	nest:get_proximity()
+	--nest:force_inert_if_capped()
+	nest.quadrant = Get_quadrant_from_obj(nest, true)
+	nest.spawned_on = GameTime()
 end
 
 --~Presets.UnitSpeciesGroup.Default[Presets.NestingSpeciesPreset.Default[get_species_from_nest(SelectedObj.class)].unit_species]
 function EnhancedTerritorialNest:Init()
-    self.attack_time = max_int
-    self.consume_time = max_int
-    self.nest_species = get_species_from_nest(self.class)
-    local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
-    local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
-    local desired_cgroup = full_species_details.primary_combat_group
-    if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups, self.CombatGroup) then
-        self.CombatGroup = desired_cgroup
-        self:Align_cgroup_members()
-    end
-    -- wait a day then reset the above
-    CreateGameTimeThread(function(this_nest)
-        Sleep(day_duration)
-        NestDelayedInit(this_nest)
-    end, self)
+	self.attack_time = max_int
+	self.consume_time = max_int
+	self.nest_species = get_species_from_nest(self.class)
+	local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
+	local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
+	local desired_cgroup = full_species_details.primary_combat_group
+	if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups, self.CombatGroup) then
+		self.CombatGroup = desired_cgroup
+		self:Align_cgroup_members()
+	end
+	-- wait a day then reset the above
+	CreateGameTimeThread(function(this_nest)
+		Sleep(day_duration)
+		NestDelayedInit(this_nest)
+	end, self)
 end
 
 function EnhancedTerritorialNest:get_next_consume_time()
-    local wait_for = AsyncRand(hour_duration * 24, hour_duration * 36)
-    self.consume_time = GameTime() + wait_for
+	local wait_for = AsyncRand(hour_duration * 24, hour_duration * 36)
+	self.consume_time = GameTime() + wait_for
 end
 
 --This technically just increases the nest members, because the base game uses the nests herd to set the controlled territory
 function EnhancedTerritorialNest:expand()
-    DebugPrint("Nest Expanding it's territory!\n")
-    local expand_by = 6
-    local nodes = 0
-    local max_growths = 5
-    local grows = 0
-    while nodes < 30 and grows < max_growths do
-        --(nodes)
-        --("expanded the distance ",grows,' times')
-        nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
-            if not IsKindOf(thing, 'NestSpore') then return true end
-        end)
-        grows = grows + 1
-        --("At this increased radius, there are ",nodes,' valid nodes to consume')
-    end
-    --("There was enough nodes nearby to warrant an increase of",grows*expand_by,' meter radius')
-    self.elders_max_count = self.elders_max_count + grows
-    self.hatchlings_max_count = self.hatchlings_max_count + grows
-    self.adults_max_count = self.adults_max_count + grows
+	DebugPrint("Nest Expanding it's territory!\n")
+	local expand_by = 6
+	local nodes = 0
+	local max_growths = 5
+	local grows = 0
+	while nodes < 30 and grows < max_growths do
+		--(nodes)
+		--("expanded the distance ",grows,' times')
+		nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
+			if not IsKindOf(thing, 'NestSpore') then return true end
+		end)
+		grows = grows + 1
+		--("At this increased radius, there are ",nodes,' valid nodes to consume')
+	end
+	--("There was enough nodes nearby to warrant an increase of",grows*expand_by,' meter radius')
+	self.elders_max_count = self.elders_max_count + grows
+	self.hatchlings_max_count = self.hatchlings_max_count + grows
+	self.adults_max_count = self.adults_max_count + grows
 end
 
 function Convert_nest_into(nest_to_convert, other_species, delete_old_members)
-    if not Presets.NestingSpeciesPreset.Default[other_species] then return end
-    local species = Presets.NestingSpeciesPreset.Default[other_species]
-    local o_species_tags = species.PrefabTags
-    local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
-    local spore_building_def = my_current.spore_buildings
-    local spores = MapGet(nest_to_convert, nest_to_convert.max_range, spore_building_def)
-    if delete_old_members then
-        for _, member in ipairs(nest_to_convert.nest_members) do
-            member:SetNest(false)
-            DoneObject(member)
-        end
-    end
-    for _, spore in ipairs(spores) do
-        DoneObject(spore)
-    end
-    local def = g_Classes['FallingDebrisMarker']
-    local old_marker = MapFindNearest(nest_to_convert, true, 'TerritorialNestMarker')
-    DoneObject(nest_to_convert)
-    local pos = old_marker:GetPos()
-    local new_marker = def:new()
-    new_marker:SetPosAngle(pos)
-    DoneObject(old_marker)
+	if not Presets.NestingSpeciesPreset.Default[other_species] then return end
+	local species = Presets.NestingSpeciesPreset.Default[other_species]
+	local o_species_tags = species.PrefabTags
+	local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
+	local spore_building_def = my_current.spore_buildings
+	local spores = MapGet(nest_to_convert, nest_to_convert.max_range, spore_building_def)
+	if delete_old_members then
+		for _, member in ipairs(nest_to_convert.nest_members) do
+			member:SetNest(false)
+			DoneObject(member)
+		end
+	end
+	for _, spore in ipairs(spores) do
+		DoneObject(spore)
+	end
+	local def = g_Classes['FallingDebrisMarker']
+	local old_marker = MapFindNearest(nest_to_convert, true, 'TerritorialNestMarker')
+	DoneObject(nest_to_convert)
+	local pos = old_marker:GetPos()
+	local new_marker = def:new()
+	new_marker:SetPosAngle(pos)
+	DoneObject(old_marker)
 
-    SuspendPassEdits("SpawndNest")
-    local seed = InteractionRand(nil, "DailySpawn")
-    local nest
-    --(seed)
-    --()
-    local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
-        tags_all = o_species_tags,
-    })
-    if not err then
-        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-        if nest_marker then
-            nest = nest_marker:SpawnNest(true)
-        else
-            assert(false, "Prefab without a nest marker: " .. name)
-        end
-    else
-        assert(false, "Prefab error: " .. err)
-    end
-    ResumePassEdits("SpawndNest")
-    AddGameNotification("JunoNestSpawned", nil, nil, { nest })
-    return nest
-    --SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
+	SuspendPassEdits("SpawndNest")
+	local seed = InteractionRand(nil, "DailySpawn")
+	local nest
+	--(seed)
+	--()
+	local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
+		tags_all = o_species_tags,
+	})
+	if not err then
+		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+		if nest_marker then
+			nest = nest_marker:SpawnNest(true)
+		else
+			assert(false, "Prefab without a nest marker: " .. name)
+		end
+	else
+		assert(false, "Prefab error: " .. err)
+	end
+	ResumePassEdits("SpawndNest")
+	AddGameNotification("JunoNestSpawned", nil, nil, { nest })
+	return nest
+	--SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
 end
 
 function EnhancedTerritorialNest:give_ep_to_struct(ep)
-    if not ep then return end
-    Bkob_Log_NA("Nest storing EP in support structures\n")
-    local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
-    Bkob_Log_NA(spore_building_def.class)
-    Bkob_Log_NA(self.territorial_range)
-    local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
-    Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
-    local progress_each = DivRound(ep, #spores_near)
-    local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]
-    local spore_res_prog = spore_res.progress
-    local units_to_give = Max(1, DivRound(progress_each, spore_res_prog))
-    Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ", units_to_give)
-    for _, spore in ipairs(spores_near) do
-        spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
-    end
+	if not ep then return end
+	Bkob_Log_NA("Nest storing EP in support structures\n")
+	local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
+	Bkob_Log_NA(spore_building_def.class)
+	Bkob_Log_NA(self.territorial_range)
+	local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
+	Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
+	local progress_each = DivRound(ep, #spores_near)
+	local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]
+	local spore_res_prog = spore_res.progress
+	local units_to_give = Max(1, DivRound(progress_each, spore_res_prog))
+	Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ", units_to_give)
+	for _, spore in ipairs(spores_near) do
+		spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
+	end
 end
 
 function EnhancedTerritorialNest:consume_closest_node()
-    DebugPrint("Nest consuming nearest node\n")
-    self.consume_time = max_int
-    local closest_res = MapFindNearest(self, self, self.territorial_range, "EntityClass", function(thing)
-        if (IsKindOf(thing, 'MineableRock') or IsKindOf(thing, 'Plant')) and not (IsKindOf(thing, 'NestSpore')) then return true end
-    end)
-    Bkob_Log_NA(closest_res)
-    if not closest_res then
-        self:expand()
-        return --we expand instead of consuming
-    end
-    local res
-    local amount
-    if IsKindOf(closest_res, 'Plant') then
-        local res_array = closest_res:GetCutResources() or closest_res:GetHarvestResources()
-        res = res_array[1]['resource']
-        amount = res_array[1]['amount']
-    else
-        res = closest_res.MineResource
-        amount = closest_res.MineAmount
-    end
-    local node_res_units = DivRound(amount, const.ResourceScale)
-    local ep_scale = 1000
-    local progress = DivRound(Resources[res].progress * node_res_units, 10)
-    Bkob_Log_NA("Nest is eating a ", closest_res.class)
-    Bkob_Log_NA('Node has ', node_res_units, ' of ', res, ' in it! which is ', progress, ' EP')
-    local EP_to_give = DivRound(progress, 4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
-    Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ", EP_to_give)
-    DoneObject(closest_res)
-    self:give_ep_to_struct(EP_to_give)
-    local attack_cd = self.attack_delay
-    self.attack_time = self.attack_time - DivRound(attack_cd, 100)
-    self:get_next_consume_time()
+	DebugPrint("Nest consuming nearest node\n")
+	self.consume_time = max_int
+	local closest_res = MapFindNearest(self, self, self.territorial_range, "EntityClass", function(thing)
+		if (IsKindOf(thing, 'MineableRock') or IsKindOf(thing, 'Plant')) and not (IsKindOf(thing, 'NestSpore')) then return true end
+	end)
+	Bkob_Log_NA(closest_res)
+	if not closest_res then
+		self:expand()
+		return --we expand instead of consuming
+	end
+	local res
+	local amount
+	if IsKindOf(closest_res, 'Plant') then
+		local res_array = closest_res:GetCutResources() or closest_res:GetHarvestResources()
+		res = res_array[1]['resource']
+		amount = res_array[1]['amount']
+	else
+		res = closest_res.MineResource
+		amount = closest_res.MineAmount
+	end
+	local node_res_units = DivRound(amount, const.ResourceScale)
+	local ep_scale = 1000
+	local progress = DivRound(Resources[res].progress * node_res_units, 10)
+	Bkob_Log_NA("Nest is eating a ", closest_res.class)
+	Bkob_Log_NA('Node has ', node_res_units, ' of ', res, ' in it! which is ', progress, ' EP')
+	local EP_to_give = DivRound(progress, 4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
+	Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ", EP_to_give)
+	DoneObject(closest_res)
+	self:give_ep_to_struct(EP_to_give)
+	local attack_cd = self.attack_delay
+	self.attack_time = self.attack_time - DivRound(attack_cd, 100)
+	self:get_next_consume_time()
 end
 
 function EnhancedTerritorialNest:GetStoryBitPopupImage()
-    if self.class == 'ShriekerNest' then
-        return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-    elseif self.class == 'ScissorhandsNest' then
-        return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
-    elseif self.class == 'ConsortiumNest' then
-        return 'ConsortiumNestVariant.PNG'
-    else
-        return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-    end
+	if self.class == 'ShriekerNest' then
+		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
+	elseif self.class == 'ScissorhandsNest' then
+		return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
+	elseif self.class == 'ConsortiumNest' then
+		return 'ConsortiumNestVariant.PNG'
+	else
+		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
+	end
 end
 
 -- Closest does 2 things
@@ -380,347 +380,347 @@ end
 -- nest:Dist2D(me) < MulDivRound(3 * distance_to_beat,1,2) is my current way to detect if a nest is "in between" the player and this nest
 
 function EnhancedTerritorialNest:get_proximity()
-    local center = AveragePoint2D(GetValidSurvivorsOnMap())
-    local dist_to_center = self:GetDist2D(center)
-    local rate = 150 * guim -- 150 meters per thresholdz
-    local prox = DivRound(dist_to_center, rate)
-    prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
-    self.proximity = prox
-    return prox
+	local center = AveragePoint2D(GetValidSurvivorsOnMap())
+	local dist_to_center = self:GetDist2D(center)
+	local rate = 150 * guim     -- 150 meters per thresholdz
+	local prox = DivRound(dist_to_center, rate)
+	prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
+	self.proximity = prox
+	return prox
 end
 
 function EnhancedTerritorialNest:Getui_evo()
-    DebugPrint("Getting the UI % how close to an evo the nest is\n")
-    local option_1 = DivRound(self.attacks_done * 100, self.attacks_to_evo)
-    local option_2 = check_count_and_upgrade(self.elder_class, {}, 100)
-    if option_2 ~= self.elder_class then
-        return 100 -- will show 100% if the EP is already high enough to trigger a "passive" evo
-    else
-        return Max(1, option_1)
-    end
+	DebugPrint("Getting the UI % how close to an evo the nest is\n")
+	local option_1 = DivRound(self.attacks_done * 100, self.attacks_to_evo)
+	local option_2 = check_count_and_upgrade(self.elder_class, {}, 100)
+	if option_2 ~= self.elder_class then
+		return 100 -- will show 100% if the EP is already high enough to trigger a "passive" evo
+	else
+		return Max(1, option_1)
+	end
 end
 
 function EnhancedTerritorialNest:Getui_attack_strength()
-    --local max_possible = per_species_nest_max*10
-    if self.state == 'asleep' then
-        return 10
-    else
-        return self:calculate_attack_strength('player')
-    end
+	--local max_possible = per_species_nest_max*10
+	if self.state == 'asleep' then
+		return 10
+	else
+		return self:calculate_attack_strength('player')
+	end
 end
 
 function EnhancedTerritorialNest:Getui_attack_cap()
-    local player_attack = self:calculate_attack_strength('player')
-    local current_cap = self:get_attack_cap()
-    return DivRound(player_attack * 100, current_cap)
+	local player_attack = self:calculate_attack_strength('player')
+	local current_cap = self:get_attack_cap()
+	return DivRound(player_attack * 100, current_cap)
 end
 
 function EnhancedTerritorialNest:Getui_attack_percent()
-    DebugPrint("Getting the UI % of how close an attack from the nest is\n")
-    local time_till_attack = self.attack_time - GameTime()
-    local num = self.attack_delay - time_till_attack
-    local percent = DivRound(num * 100, self.attack_delay)
-    return Max(1, percent)
+	DebugPrint("Getting the UI % of how close an attack from the nest is\n")
+	local time_till_attack = self.attack_time - GameTime()
+	local num = self.attack_delay - time_till_attack
+	local percent = DivRound(num * 100, self.attack_delay)
+	return Max(1, percent)
 end
 
 function EnhancedTerritorialNest:IsAsleep()
-    return self.state == 'asleep'
+	return self.state == 'asleep'
 end
 
 function EnhancedTerritorialNest:IsAwake()
-    return self.state == 'awake'
+	return self.state == 'awake'
 end
 
 function EnhancedTerritorialNest:IsSleepy()
-    return self.state == 'sleepy'
+	return self.state == 'sleepy'
 end
 
 function EnhancedTerritorialNest:change_nest_herd(force_evo)
-    Bkob_Log("Nest calculating if it needs to upgrade\n")
-    Bkob_Log("Forced Evo: ", force_evo)
-    local elder = self.elder_class
-    local upgraded_flag = false
-    local evo, _, __
-    if force_evo then
-        evo = Find_evolution(g_Classes[elder])
-    else
-        local AdditionalClassList = {}
-        AdditionalClassList[#AdditionalClassList + 1] = { self.adult_class, 150 }
-        AdditionalClassList[#AdditionalClassList + 1] = { self.hatchling_class, 50 }
-        evo, _, __ = check_count_and_upgrade(elder, AdditionalClassList, 100)
-    end
-    if evo == elder and self.adult_class == self.hatchling_class and self.adult_class == self.elder_class then
-        return upgraded_flag
-    end
-    -- base nests will just chain their units down
-    upgraded_flag = true
-    self.hatchling_class = self.adult_class
-    self.adult_class = self.elder_class
-    self.elder_class = evo
-    -- remove any newly-invalid creatures from nest_creatures
-    local removed = false
-    for _, unit in ipairs(self.nest_members) do
-        local class = unit.class
-        if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
-            self:RemoveNestMember(unit)
-            -- This will force spawn a new set of higher tier nests.
-            -- If Nests are left unnattended they can get quite large groups defending it
-        end
-    end
-    if removed then
-        self:UpdateNextSpawnTime()
-    end
-    if upgraded_flag then
-        -- just to make sure we know how close the player is now that they have more stuff
-        self:get_proximity()
-        NA_log_nest_evolved(self)
-        self.attacks_done = 0
-        self.attacks_to_evo = self.attacks_to_evo + 1
-    end
-    return upgraded_flag
+	Bkob_Log("Nest calculating if it needs to upgrade\n")
+	Bkob_Log("Forced Evo: ", force_evo)
+	local elder = self.elder_class
+	local upgraded_flag = false
+	local evo, _, __
+	if force_evo then
+		evo = Find_evolution(g_Classes[elder])
+	else
+		local AdditionalClassList = {}
+		AdditionalClassList[#AdditionalClassList + 1] = { self.adult_class, 150 }
+		AdditionalClassList[#AdditionalClassList + 1] = { self.hatchling_class, 50 }
+		evo, _, __ = check_count_and_upgrade(elder, AdditionalClassList, 100)
+	end
+	if evo == elder and self.adult_class == self.hatchling_class and self.adult_class == self.elder_class then
+		return upgraded_flag
+	end
+	-- base nests will just chain their units down
+	upgraded_flag = true
+	self.hatchling_class = self.adult_class
+	self.adult_class = self.elder_class
+	self.elder_class = evo
+	-- remove any newly-invalid creatures from nest_creatures
+	local removed = false
+	for _, unit in ipairs(self.nest_members) do
+		local class = unit.class
+		if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
+			self:RemoveNestMember(unit)
+			-- This will force spawn a new set of higher tier nests.
+			-- If Nests are left unnattended they can get quite large groups defending it
+		end
+	end
+	if removed then
+		self:UpdateNextSpawnTime()
+	end
+	if upgraded_flag then
+		-- just to make sure we know how close the player is now that they have more stuff
+		self:get_proximity()
+		NA_log_nest_evolved(self)
+		self.attacks_done = 0
+		self.attacks_to_evo = self.attacks_to_evo + 1
+	end
+	return upgraded_flag
 end
 
 function EnhancedTerritorialNest:can_be_aggressive(who)
-    if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
-        return true
-    elseif who == 'player' and self.attacked_by_player then
-        return true
-    elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
-        return true
-    else
-        return false
-    end
+	if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
+		return true
+	elseif who == 'player' and self.attacked_by_player then
+		return true
+	elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
+		return true
+	else
+		return false
+	end
 end
 
 function EnhancedTerritorialNest:RegisterTarget(unit, time)
-    if unit.player then
-        self.attacked_by_player = true
-    elseif unit.nest then
-        unit.nest.attacked_by_player = true
-    end
-    local tags = unit['UnitTags']
-    if tags and self.state == 'asleep' and tags['Human'] then
-        DebugPrint("Nest registering a human attacker!\n")
-        self:SwitchState('sleepy')
-    end
-    if unit.nest then
-        DebugPrint("Nest registering another nest attacker!\n")
-        if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
-            self:SwitchState('sleepy')
-        end
-    end
+	if unit.player then
+		self.attacked_by_player = true
+	elseif unit.nest then
+		unit.nest.attacked_by_player = true
+	end
+	local tags = unit['UnitTags']
+	if tags and self.state == 'asleep' and tags['Human'] then
+		DebugPrint("Nest registering a human attacker!\n")
+		self:SwitchState('sleepy')
+	end
+	if unit.nest then
+		DebugPrint("Nest registering another nest attacker!\n")
+		if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
+			self:SwitchState('sleepy')
+		end
+	end
 end
 
 function EnhancedTerritorialNest:set_new_max_hp()
-    DebugPrint("Nest raising max HP\n")
-    local base_hp = 100000
-    local diff = Get_difficulty_offset()
-    local max_possible_hp = base_hp * 100 * diff
-    if self.state == 'awake' then
-        self.MaxHealth = max_possible_hp
-        self.health_regen = 5
-    elseif self.state == 'sleepy' then
-        self.MaxHealth = DivRound(max_possible_hp, 2)
-        self.health_regen = 1
-    elseif self.state == 'asleep' then
-        self.health_regen = 0
-        self.MaxHealth = base_hp
-    end
+	DebugPrint("Nest raising max HP\n")
+	local base_hp = 100000
+	local diff = Get_difficulty_offset()
+	local max_possible_hp = base_hp * 100 * diff
+	if self.state == 'awake' then
+		self.MaxHealth = max_possible_hp
+		self.health_regen = 5
+	elseif self.state == 'sleepy' then
+		self.MaxHealth = DivRound(max_possible_hp, 2)
+		self.health_regen = 1
+	elseif self.state == 'asleep' then
+		self.health_regen = 0
+		self.MaxHealth = base_hp
+	end
 end
 
 function EnhancedTerritorialNest:SwitchState(new_state)
-    DebugPrint("Nest switching it's internal state!\n")
-    new_state = new_state or nil
-    local notif_level = Nest_Notifications
-    if not new_state or new_state == self.state then
-        return
-    end
-    if new_state == 'sleepy' and self.state == 'asleep' then
-        self.sleep_check = GameTime() + const.Scale.months
-        if notif_level == 2 then
-            ForceActivateStoryBit('asleep_too_sleepy', self, true)
-        elseif notif_level == 1 then
-            AddGameNotification("waking_up", nil, nil, { self })
-        end
-    elseif new_state == "asleep" and not (self.state == "awake") then
-        if notif_level == 2 then
-            -- woken up
-            ForceActivateStoryBit('back_to_sleep', self, true)
-        elseif notif_level == 1 then
-            AddGameNotification("back_to_sleep", nil, nil, { self })
-        end
-    end
-    self.state = new_state
-    self:UpdateNextAttackTime()
-    self:set_new_max_hp()
+	DebugPrint("Nest switching it's internal state!\n")
+	new_state = new_state or nil
+	local notif_level = Nest_Notifications
+	if not new_state or new_state == self.state then
+		return
+	end
+	if new_state == 'sleepy' and self.state == 'asleep' then
+		self.sleep_check = GameTime() + const.Scale.months
+		if notif_level == 2 then
+			ForceActivateStoryBit('asleep_too_sleepy', self, true)
+		elseif notif_level == 1 then
+			AddGameNotification("waking_up", nil, nil, { self })
+		end
+	elseif new_state == "asleep" and not (self.state == "awake") then
+		if notif_level == 2 then
+			-- woken up
+			ForceActivateStoryBit('back_to_sleep', self, true)
+		elseif notif_level == 1 then
+			AddGameNotification("back_to_sleep", nil, nil, { self })
+		end
+	end
+	self.state = new_state
+	self:UpdateNextAttackTime()
+	self:set_new_max_hp()
 end
 
 function EnhancedTerritorialNest:get_attack_cap()
-    local base = 50
-    local awake_same_nests = MapCount(true, "TerritorialNest", function(other_nest, this_nest)
-        if IsKindOf(other_nest, this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
-            return true
-        end
-    end, self)
-    local nest_based_cap = awake_same_nests * 10
-    local year = const.Scale.years
-    local time_based_cap = MulDivTrunc(1, GameTime(), year) * 50 + 50
-    if base > time_based_cap and base > nest_based_cap then
-        return base
-    elseif time_based_cap > nest_based_cap then
-        return time_based_cap
-    else
-        return nest_based_cap
-    end
-    return base
+	local base = 50
+	local awake_same_nests = MapCount(true, "TerritorialNest", function(other_nest, this_nest)
+		if IsKindOf(other_nest, this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
+			return true
+		end
+	end, self)
+	local nest_based_cap = awake_same_nests * 10
+	local year = const.Scale.years
+	local time_based_cap = MulDivTrunc(1, GameTime(), year) * 50 + 50
+	if base > time_based_cap and base > nest_based_cap then
+		return base
+	elseif time_based_cap > nest_based_cap then
+		return time_based_cap
+	else
+		return nest_based_cap
+	end
+	return base
 end
 
 function EnhancedTerritorialNest:calculate_interspecies_war_strength(who)
-    DebugPrint("Calculating interspecies war strength\n")
-    local nest_EP = 0
-    for _, defender in ipairs(who.nest_members) do
-        nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
-    end
-    local rand = 75 + AsyncRand(75)
-    return nest_EP + rand
+	DebugPrint("Calculating interspecies war strength\n")
+	local nest_EP = 0
+	for _, defender in ipairs(who.nest_members) do
+		nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
+	end
+	local rand = 75 + AsyncRand(75)
+	return nest_EP + rand
 end
 
 function EnhancedTerritorialNest:calculate_attack_strength(who)
-    DebugPrint("Nest calculating it's attack score\n")
-    if who == 'player' then
-        local max_attack_strength_allowed = self:get_attack_cap()
-        local base_strength = self.base_strength or 20
-        local diff_increase
-        if Get_difficulty_offset() > 5 then
-            diff_increase = 10
-        else
-            diff_increase = 0
-        end
-        local species = get_species_from_nest(self.class)
-        local banked = 0
-        local species_banked_aggr = species .. '_banked_aggr'
-        if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
-            banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
-        else
-            DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
-            Nest_Species_Savegame_Stats[self.nest_species] = {}
-            Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
-        end
-        local subsequent_attacks = self.attacks_done * 10
-        local prox_loss = self.proximity * 10
-        local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
-        -- Make sure we don't go below base or above cap
-        local filtered_strength = Max(base_strength, Min(max_attack_strength_allowed, unfiltered_strength))
-        DebugPrint("Desired attack strength: ")
-        DebugPrint(unfiltered_strength)
-        DebugPrint("\nActual attack strength:")
-        DebugPrint(filtered_strength)
-        DebugPrint("\n")
-        return filtered_strength
-    elseif IsKindOf(who, 'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
-        return self:calculate_interspecies_war_strength(who)
-    else
-        return 10
-    end
+	DebugPrint("Nest calculating it's attack score\n")
+	if who == 'player' then
+		local max_attack_strength_allowed = self:get_attack_cap()
+		local base_strength = self.base_strength or 20
+		local diff_increase
+		if Get_difficulty_offset() > 5 then
+			diff_increase = 10
+		else
+			diff_increase = 0
+		end
+		local species = get_species_from_nest(self.class)
+		local banked = 0
+		local species_banked_aggr = species .. '_banked_aggr'
+		if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
+			banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
+		else
+			DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
+			Nest_Species_Savegame_Stats[self.nest_species] = {}
+			Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
+		end
+		local subsequent_attacks = self.attacks_done * 10
+		local prox_loss = self.proximity * 10
+		local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
+		-- Make sure we don't go below base or above cap
+		local filtered_strength = Max(base_strength, Min(max_attack_strength_allowed, unfiltered_strength))
+		DebugPrint("Desired attack strength: ")
+		DebugPrint(unfiltered_strength)
+		DebugPrint("\nActual attack strength:")
+		DebugPrint(filtered_strength)
+		DebugPrint("\n")
+		return filtered_strength
+	elseif IsKindOf(who, 'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
+		return self:calculate_interspecies_war_strength(who)
+	else
+		return 10
+	end
 end
 
 function nest_find_spawn_fake(spawndef_instance, spawn_class, target)
-    local def = spawn_class and g_Classes[spawn_class]
-    local pfclass = def.pfclass
-    local range = spawndef_instance.nest.max_range
-    local target_retry = 7
-    local x, y
-    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-    local playbox = GetPlayBox()
-    local nest_entity_radius = spawndef_instance.nest:GetRadius()
-    for i = 1, target_retry do
-        x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
-        local temp_pos = point(x, y)
-        local playbox_check = playbox:Dist2(temp_pos) > 1
-        local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-        if playbox_check or under_nest then
-            x = nil
-            target_retry = target_retry - 1
-            range = range * 2
-        else
-            local possible_pos = point(x, y)
-            return possible_pos
-        end
-    end
-    ::continue::
-    dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest, 7))
+	local def = spawn_class and g_Classes[spawn_class]
+	local pfclass = def.pfclass
+	local range = spawndef_instance.nest.max_range
+	local target_retry = 7
+	local x, y
+	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+	local playbox = GetPlayBox()
+	local nest_entity_radius = spawndef_instance.nest:GetRadius()
+	for i = 1, target_retry do
+		x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
+		local temp_pos = point(x, y)
+		local playbox_check = playbox:Dist2(temp_pos) > 1
+		local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+		if playbox_check or under_nest then
+			x = nil
+			target_retry = target_retry - 1
+			range = range * 2
+		else
+			local possible_pos = point(x, y)
+			return possible_pos
+		end
+	end
+	::continue::
+	dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest, 7))
 end
 
 function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
-    --print("Finding spawn point near a nest!")
-    local playbox = GetPlayBox()
-    if not target then
-        --print("Didn't get a target to spawn near!")
-        target = spawndef_instance:ResolveTarget()
-    end
-    local def = spawn_class and g_Classes[spawn_class]
-    local pfclass = def.pfclass
-    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-    if not pos then print("no pos found!") end
-    local nest_entity_radius = spawndef_instance.nest:GetRadius()
-    local x, y
-    local retry = 10
-    local range = spawndef_instance.nest.max_range
-    local target_radius = 30 * guim
-    while not x and retry > 0 do
-        local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
-        if not spot_closest_to_target then
-            target_radius = target_radius * 2
-        else
-            x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
-            local temp_pos = point(x, y)
-            local playbox_check = playbox:Dist2(temp_pos) > 1
-            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-            if playbox_check or under_nest then
-                x = nil
-                retry = retry - 1
-                range = range * 2
-            else
-                local possible_pos = point(x, y)
-                if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
-                    --print("Found a point!")
-                    return possible_pos
-                else
-                    retry = retry - 1
-                    range = range * 2
-                end
-            end
-        end
-        return nil
-    end
+	--print("Finding spawn point near a nest!")
+	local playbox = GetPlayBox()
+	if not target then
+		--print("Didn't get a target to spawn near!")
+		target = spawndef_instance:ResolveTarget()
+	end
+	local def = spawn_class and g_Classes[spawn_class]
+	local pfclass = def.pfclass
+	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+	if not pos then print("no pos found!") end
+	local nest_entity_radius = spawndef_instance.nest:GetRadius()
+	local x, y
+	local retry = 10
+	local range = spawndef_instance.nest.max_range
+	local target_radius = 30 * guim
+	while not x and retry > 0 do
+		local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
+		if not spot_closest_to_target then
+			target_radius = target_radius * 2
+		else
+			x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
+			local temp_pos = point(x, y)
+			local playbox_check = playbox:Dist2(temp_pos) > 1
+			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+			if playbox_check or under_nest then
+				x = nil
+				retry = retry - 1
+				range = range * 2
+			else
+				local possible_pos = point(x, y)
+				if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
+					--print("Found a point!")
+					return possible_pos
+				else
+					retry = retry - 1
+					range = range * 2
+				end
+			end
+		end
+		return nil
+	end
 end
 
 local post_spawn_animal = function(self, obj, target, context)
-    obj.CombatHostile = true
-    Msg("SpawnedAnimalThreat", obj)
-    give_nest_speed_effect(obj, self.nest.proximity)
+	obj.CombatHostile = true
+	Msg("SpawnedAnimalThreat", obj)
+	give_nest_speed_effect(obj, self.nest.proximity)
 end
 
 local post_spawn_robot = function(self, obj, target, context)
-    obj:SetInvader(true)
-    Msg("SpawnedAnimalThreat", obj)
-    give_nest_speed_effect(obj, self.nest.proximity)
+	obj:SetInvader(true)
+	Msg("SpawnedAnimalThreat", obj)
+	give_nest_speed_effect(obj, self.nest.proximity)
 end
 
 function give_nest_speed_effect(ob, prox)
-    local robot_flag = false
-    local times = prox or 1
-    if IsKindOf(ob, 'Robot') then
-        robot_flag = true
-    end
-    while times > 0 do
-        if robot_flag then
-            ob:AddRobotCondition('nest_attack_speed_robot', 'mod')
-        else
-            ob:AddHealthCondition('nest_attack_speed', 'mod')
-        end
-        times = times - 1
-    end
+	local robot_flag = false
+	local times = prox or 1
+	if IsKindOf(ob, 'Robot') then
+		robot_flag = true
+	end
+	while times > 0 do
+		if robot_flag then
+			ob:AddRobotCondition('nest_attack_speed_robot', 'mod')
+		else
+			ob:AddHealthCondition('nest_attack_speed', 'mod')
+		end
+		times = times - 1
+	end
 end
 
 --[[
@@ -751,67 +751,67 @@ quadrants[1] = {
 --]]
 
 function EnhancedTerritorialNest:IsQuadrantScouted(quad_no)
-    local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
-    if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
-        return false
-    else
-        return true
-    end
+	local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
+	if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
+		return false
+	else
+		return true
+	end
 end
 
 function EnhancedTerritorialNest:MarkScouted(other_species, time)
-    rawset(self, other_species, time)
+	rawset(self, other_species, time)
 end
 
 function ReportScoutingResults(quad_no, species, objects_to_report, player_found, nest)
-    Reset_quadrant(quad_no, species)
-    if nest.quadrant_scouting then
-        nest.quadrant_scouting = false
-    end
-    local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
-    if player_found then
-        scout_quad_logs['player_presence'] = true
-        DebugPrint("Player presence detected in this quadrant!\n")
-        if nest:IsAsleep() then
-            nest:SwitchState('sleepy')
-        end
-    end
-    scout_quad_logs.last_scout = GameTime()
-    scout_quad_logs['map_objs'] = objects_to_report
-    for _, obj in ipairs(objects_to_report) do
-        if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
-            if scout_quad_logs[that_species] then
-                scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
-                nest:MarkScouted(self.nest_species, GameTime())
-            else
-                scout_quad_logs[that_species] = {}
-                scout_quad_logs[that_species][1] = nest
-            end
-        end
-        scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
-    end
+	Reset_quadrant(quad_no, species)
+	if nest.quadrant_scouting then
+		nest.quadrant_scouting = false
+	end
+	local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
+	if player_found then
+		scout_quad_logs['player_presence'] = true
+		DebugPrint("Player presence detected in this quadrant!\n")
+		if nest:IsAsleep() then
+			nest:SwitchState('sleepy')
+		end
+	end
+	scout_quad_logs.last_scout = GameTime()
+	scout_quad_logs['map_objs'] = objects_to_report
+	for _, obj in ipairs(objects_to_report) do
+		if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
+			if scout_quad_logs[that_species] then
+				scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
+				nest:MarkScouted(self.nest_species, GameTime())
+			else
+				scout_quad_logs[that_species] = {}
+				scout_quad_logs[that_species][1] = nest
+			end
+		end
+		scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
+	end
 end
 
 -- TODO instead of cheat learning about the quadrant, send out a nesting unit to scout
 function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
-    DebugPrint("Nest is releasing a scouting unit!!\n")
-    local spawn_def = SpawnDefs['Nest_scout_passive']
-    --used by invader to know what quadrant is to be scouted
-    -- And to track if the scout ever returned
-    if self.quadrant_scouting then
-        DebugPrint("Whelp, looks like my last scout is MIA...")
-    end
-    self.quadrant_scouting = quad_no
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.adult_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
-    --[[
+	DebugPrint("Nest is releasing a scouting unit!!\n")
+	local spawn_def = SpawnDefs['Nest_scout_passive']
+	--used by invader to know what quadrant is to be scouted
+	-- And to track if the scout ever returned
+	if self.quadrant_scouting then
+		DebugPrint("Whelp, looks like my last scout is MIA...")
+	end
+	self.quadrant_scouting = quad_no
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.adult_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
+	--[[
 	if not Nest_scouting_quadrants[quad_no] then
 		CreateMapGrid()
 	end
@@ -824,213 +824,213 @@ function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
 end
 
 function MegaScout(nest)
-    for i = 1, 25 do
-        nest:Scout_Specific_Quad(i)
-    end
+	for i = 1, 25 do
+		nest:Scout_Specific_Quad(i)
+	end
 end
 
 -- Currently this will just cheat
 -- I want to build out scouting behavior to allow the player to interact with a species learning about the map
 function EnhancedTerritorialNest:scout_nearest_quad()
-    DebugPrint("\nScouting closest usncouted quad!\n")
-    if not self.quadrant then
-        self.quadrant = Get_quadrant_from_obj(self, true)
-    end
-    if not self.nest_species then
-        self.nest_species = get_species_from_nest(self.class)
-    end
-    if not Nest_scouting_quadrants[1] then
-        CreateMapGrid()
-    end
-    local to_scout
-    local shouldnt_scout = {}
-    if not Nest_scouting_quadrants[self.quadrant] then
-        CreateMapGrid()
-    end
-    local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-    if not my_species_quad_logs then
-        CreateMapGrid()
-        my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-    end
-    if my_species_quad_logs.last_scout == 0 then
-        to_scout = self.quadrant
-    elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
-        to_scout = self.quadrant
-        goto continue
-    end
-    shouldnt_scout[#shouldnt_scout + 1] = self.quadrant
-    for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
-        --ignoring diagonals because..... its hard
-        for _, no in ipairs(shouldnt_scout) do
-            for _, q in ipairs(Get_adjacent_quads(no)) do
-                if not table.find(shouldnt_scout, q) then
-                    if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
-                        to_scout = q
-                        goto continue
-                    elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
-                        shouldnt_scout[#shouldnt_scout + 1] = q
-                    else
-                        --print("Whelp, guess Im going to scout quadrant",q,"now!\n")
-                        to_scout = q
-                        goto continue
-                    end
-                end
-            end
-        end
-    end
-    ::continue::
-    if not to_scout then
-        DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
-        return
-    else
-        DebugPrint("I am scouting this quadrant:", to_scout, '\n')
-    end
-    self:Scout_Specific_Quad(to_scout)
+	DebugPrint("\nScouting closest usncouted quad!\n")
+	if not self.quadrant then
+		self.quadrant = Get_quadrant_from_obj(self, true)
+	end
+	if not self.nest_species then
+		self.nest_species = get_species_from_nest(self.class)
+	end
+	if not Nest_scouting_quadrants[1] then
+		CreateMapGrid()
+	end
+	local to_scout
+	local shouldnt_scout = {}
+	if not Nest_scouting_quadrants[self.quadrant] then
+		CreateMapGrid()
+	end
+	local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+	if not my_species_quad_logs then
+		CreateMapGrid()
+		my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+	end
+	if my_species_quad_logs.last_scout == 0 then
+		to_scout = self.quadrant
+	elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
+		to_scout = self.quadrant
+		goto continue
+	end
+	shouldnt_scout[#shouldnt_scout + 1] = self.quadrant
+	for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
+		--ignoring diagonals because..... its hard
+		for _, no in ipairs(shouldnt_scout) do
+			for _, q in ipairs(Get_adjacent_quads(no)) do
+				if not table.find(shouldnt_scout, q) then
+					if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
+						to_scout = q
+						goto continue
+					elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
+						shouldnt_scout[#shouldnt_scout + 1] = q
+					else
+						--print("Whelp, guess Im going to scout quadrant",q,"now!\n")
+						to_scout = q
+						goto continue
+					end
+				end
+			end
+		end
+	end
+	::continue::
+	if not to_scout then
+		DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
+		return
+	else
+		DebugPrint("I am scouting this quadrant:", to_scout, '\n')
+	end
+	self:Scout_Specific_Quad(to_scout)
 end
 
 function EnhancedTerritorialNest:nest_attack_player()
-    DebugPrint("Nest is attacking the player directly!\n")
-    local spawn_def = SpawnDefs['nest_attack']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.elder_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    local atk_str = self:calculate_attack_strength('player')
-    spawn_def:ActivateSpawn(t, {}, atk_str)
+	DebugPrint("Nest is attacking the player directly!\n")
+	local spawn_def = SpawnDefs['nest_attack']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.elder_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	local atk_str = self:calculate_attack_strength('player')
+	spawn_def:ActivateSpawn(t, {}, atk_str)
 end
 
 function EnhancedTerritorialNest:nest_attack_non_player(enemy_nest)
-    DebugPrint("Nest is attacking a non player target near it!\n")
-    local spawn_def = SpawnDefs['nest_attack']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.elder_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    print("ACTIVATING SPAWN!")
-    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength(enemy_nest))
+	DebugPrint("Nest is attacking a non player target near it!\n")
+	local spawn_def = SpawnDefs['nest_attack']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.elder_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	print("ACTIVATING SPAWN!")
+	spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength(enemy_nest))
 end
 
 function EnhancedTerritorialNest:nest_support_closest(ally_nest)
-    DebugPrint("Nest is sending support to the closest nest!\n")
-    local spawn_def = SpawnDefs['Support_same_species_passive']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.adult_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    -- Support the specific in-sector ally chosen by GetSupportTarget: target IT so the reinforcement
-    -- spawns near the ally (and does not march across the player's base). Fall back to the SpawnDef's
-    -- own target resolution when called without an explicit ally.
-    local t = ally_nest or spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
+	DebugPrint("Nest is sending support to the closest nest!\n")
+	local spawn_def = SpawnDefs['Support_same_species_passive']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.adult_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	-- Support the specific in-sector ally chosen by GetSupportTarget: target IT so the reinforcement
+	-- spawns near the ally (and does not march across the player's base). Fall back to the SpawnDef's
+	-- own target resolution when called without an explicit ally.
+	local t = ally_nest or spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:overflow_spawn()
-    DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
-    local spawn_def = SpawnDefs['nest_overflow']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.elder_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength())
+	DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
+	local spawn_def = SpawnDefs['nest_overflow']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.elder_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength())
 end
 
 function EnhancedTerritorialNest:GetUnscoutedQuadrantsWithin(range)
-    range = range or 5
-    local unscouted = {}
-    local processed_quads = {}
-    local distance = 1
-    unscouted[distance] = {}
-    --print("I am in quadrant", self.quadrant,'\n')
-    if self:IsQuadrantScouted(self.quadrant) then
-        local distance_entry = unscouted[distance]
-        distance_entry[#distance_entry + 1] = self.quadrant
-    end
-    processed_quads[#processed_quads + 1] = self.quadrant
-    local temp_processed = {}
-    for i = 1, range do
-        distance = distance + 1
-        -- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
-        unscouted[distance] = table.copy(unscouted[distance - 1])
-        --print("Now checking quadrants at distance ",distance-1,'\n')
-        local distance_entry = unscouted[distance]
-        for _, qu in ipairs(processed_quads) do
-            local adjacent = Get_adjacent_quads(qu)
-            --print("Looking through these: ", adjacent,'\n')
-            for _, qua in ipairs(adjacent) do
-                if not table.find(processed_quads, qua) and not table.find(temp_processed, qua) then
-                    temp_processed[#temp_processed + 1] = qua
-                    local scouted = self:IsQuadrantScouted(qua)
-                    if not scouted then
-                        distance_entry[#distance_entry + 1] = qua
-                    end
-                end
-            end
-        end
-        --print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
-        --print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
-        for _, v in ipairs(temp_processed) do
-            processed_quads[#processed_quads + 1] = v
-        end
-        temp_processed = {}
-    end
-    return unscouted
+	range = range or 5
+	local unscouted = {}
+	local processed_quads = {}
+	local distance = 1
+	unscouted[distance] = {}
+	--print("I am in quadrant", self.quadrant,'\n')
+	if self:IsQuadrantScouted(self.quadrant) then
+		local distance_entry = unscouted[distance]
+		distance_entry[#distance_entry + 1] = self.quadrant
+	end
+	processed_quads[#processed_quads + 1] = self.quadrant
+	local temp_processed = {}
+	for i = 1, range do
+		distance = distance + 1
+		-- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
+		unscouted[distance] = table.copy(unscouted[distance - 1])
+		--print("Now checking quadrants at distance ",distance-1,'\n')
+		local distance_entry = unscouted[distance]
+		for _, qu in ipairs(processed_quads) do
+			local adjacent = Get_adjacent_quads(qu)
+			--print("Looking through these: ", adjacent,'\n')
+			for _, qua in ipairs(adjacent) do
+				if not table.find(processed_quads, qua) and not table.find(temp_processed, qua) then
+					temp_processed[#temp_processed + 1] = qua
+					local scouted = self:IsQuadrantScouted(qua)
+					if not scouted then
+						distance_entry[#distance_entry + 1] = qua
+					end
+				end
+			end
+		end
+		--print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
+		--print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
+		for _, v in ipairs(temp_processed) do
+			processed_quads[#processed_quads + 1] = v
+		end
+		temp_processed = {}
+	end
+	return unscouted
 end
 
 function EnhancedTerritorialNest:IsPlayerKnown()
-    local my_species = get_species_from_nest(self.class)
-    for _, quad in ipairs(Nest_scouting_quadrants) do
-        if quad[my_species].player_presence then
-            return true
-        end
-    end
-    return false
+	local my_species = get_species_from_nest(self.class)
+	for _, quad in ipairs(Nest_scouting_quadrants) do
+		if quad[my_species].player_presence then
+			return true
+		end
+	end
+	return false
 end
 
 function EnhancedTerritorialNest:IsCloserToPlayer(other_nest)
-    local compare_point = Get_center_of_survivors()
-    local my_distance = self:GetDist2D(compare_point)
-    local other_distance = other_nest:GetDist2D(compare_point)
-    return my_distance < other_distance
+	local compare_point = Get_center_of_survivors()
+	local my_distance = self:GetDist2D(compare_point)
+	local other_distance = other_nest:GetDist2D(compare_point)
+	return my_distance < other_distance
 end
 
 function EnhancedTerritorialNest:IsClosestToPlayer()
-    --local my_species = get_species_from_nest(self.class)
-    local compare_point = Get_center_of_survivors()
-    --print("Center of survivors is: ",compare_point,'\n')
-    local my_distance = self:GetDist2D(compare_point)
-    --print("I am this far away from it: ",my_distance,'\n')
-    local nest_dist = {}
-    MapForEach("map", self.class, function(nest, compare_point, me)
-        if nest ~= me then
-            nest_dist[#nest_dist + 1] = { nest = nest, dist = nest:GetDist2D(compare_point) }
-        end
-    end, compare_point, self)
-    local closest = self
-    --print(nest_dist,'\n')
-    for _, v in ipairs(nest_dist) do
-        if v.dist < my_distance then
-            closest = v.nest
-        end
-    end
-    return closest == self
+	--local my_species = get_species_from_nest(self.class)
+	local compare_point = Get_center_of_survivors()
+	--print("Center of survivors is: ",compare_point,'\n')
+	local my_distance = self:GetDist2D(compare_point)
+	--print("I am this far away from it: ",my_distance,'\n')
+	local nest_dist = {}
+	MapForEach("map", self.class, function(nest, compare_point, me)
+		if nest ~= me then
+			nest_dist[#nest_dist + 1] = { nest = nest, dist = nest:GetDist2D(compare_point) }
+		end
+	end, compare_point, self)
+	local closest = self
+	--print(nest_dist,'\n')
+	for _, v in ipairs(nest_dist) do
+		if v.dist < my_distance then
+			closest = v.nest
+		end
+	end
+	return closest == self
 end
 
 -- A nest attacks the player only when it is the most-forward of its species; a nest behind a same-species ally sends
@@ -1039,281 +1039,296 @@ end
 -- opposite (on the far side of the player), which is what would march units through the player's base. Returns the ally
 -- nest to support, or false if this nest is the front line.
 function EnhancedTerritorialNest:GetSupportTarget()
-    local center = Get_center_of_survivors()
-    local my_dist = self:GetDist2D(center)
-    local my_bearing = CalcOrientation(center, self:GetPos())
-    local sector = 60 * 60 -- +-60 degrees (HG angles are in 1/60-degree units) -> a 120-degree forward arc
-    local best, best_dist
-    MapForEach("map", self.class, function(nest, me)
-        if nest == me then return end
-        local n_dist = nest:GetDist2D(center)
-        if n_dist >= my_dist then return end                                                     -- only nests ahead of me (closer to the survivors)
-        if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
-        if not best or n_dist < best_dist then
-            best, best_dist = nest, n_dist
-        end
-    end, self)
-    return best or false
+	local center = Get_center_of_survivors()
+	local my_dist = self:GetDist2D(center)
+	local my_bearing = CalcOrientation(center, self:GetPos())
+	local sector = 60 * 60 -- +-60 degrees (HG angles are in 1/60-degree units) -> a 120-degree forward arc
+	local best, best_dist
+	MapForEach("map", self.class, function(nest, me)
+		if nest == me then return end
+		local n_dist = nest:GetDist2D(center)
+		if n_dist >= my_dist then return end                                                           -- only nests ahead of me (closer to the survivors)
+		if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
+		if not best or n_dist < best_dist then
+			best, best_dist = nest, n_dist
+		end
+	end, self)
+	return best or false
 end
 
 function EnhancedTerritorialNest:GetNearbyEnemiesNonPlayer(range)
-    local valid_targets = MapGet(self, range, "TerritorialNest", function(nest, me)
-        if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species
-            and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
-            return true
-        end
-    end, self)
-    local closest = {}
-    for _, target in ipairs(valid_targets) do
-        if table.find(closest, target.nest_species) then
-            closest[target.nest_species] = target
-        else
-            closest[target.nest_species] = {}
-            closest[target.nest_species][1] = target
-        end
-    end
-    range = range or 5
-    local enemy_selection = {}
-    local processed_quads = {}
-    local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-    for _, species in pairs(my_quad.other_species) do
-        table.insert_unique(enemy_selection, species)
-    end
-    processed_quads[#processed_quads + 1] = self.quadrant
-    local temp_processed = {}
-    for i = 1, range do
-        for _, no in ipairs(processed_quads) do
-            for _, q in ipairs(Get_adjacent_quads(no)) do
-                local this_quad = Nest_scouting_quadrants[q][self.nest_species]
-                if not table.find(processed_quads, q) and not table.find(temp_processed, q) then
-                    temp_processed[#temp_processed + 1] = q
-                    for _, species in pairs(this_quad.other_species) do
-                        table.insert_unique(enemy_selection, species)
-                    end
-                end
-            end
-        end
-        for _, v in ipairs(temp_processed) do
-            processed_quads[#processed_quads + 1] = v
-        end
-        temp_processed = {}
-    end
-    return enemy_selection
+	local valid_targets = MapGet(self, range, "TerritorialNest", function(nest, me)
+		if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species
+			and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
+			return true
+		end
+	end, self)
+	local closest = {}
+	for _, target in ipairs(valid_targets) do
+		if table.find(closest, target.nest_species) then
+			closest[target.nest_species] = target
+		else
+			closest[target.nest_species] = {}
+			closest[target.nest_species][1] = target
+		end
+	end
+	range = range or 5
+	local enemy_selection = {}
+	local processed_quads = {}
+	local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+	for _, species in pairs(my_quad.other_species) do
+		table.insert_unique(enemy_selection, species)
+	end
+	processed_quads[#processed_quads + 1] = self.quadrant
+	local temp_processed = {}
+	for i = 1, range do
+		for _, no in ipairs(processed_quads) do
+			for _, q in ipairs(Get_adjacent_quads(no)) do
+				local this_quad = Nest_scouting_quadrants[q][self.nest_species]
+				if not table.find(processed_quads, q) and not table.find(temp_processed, q) then
+					temp_processed[#temp_processed + 1] = q
+					for _, species in pairs(this_quad.other_species) do
+						table.insert_unique(enemy_selection, species)
+					end
+				end
+			end
+		end
+		for _, v in ipairs(temp_processed) do
+			processed_quads[#processed_quads + 1] = v
+		end
+		temp_processed = {}
+	end
+	return enemy_selection
 end
 
 function EnhancedTerritorialNest:ClosestSleepyNest(range)
-    range = range or max_int
-    local closest_sleepy = MapFindMin(self, range, "TerritorialNest", function(nest, me, range)
-        if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
-            return me:GetDist2D(nest)
-        end
-    end, self, range)
-    if closest_sleepy then
-        return closest_sleepy
-    else
-        return false
-    end
+	range = range or max_int
+	local closest_sleepy = MapFindMin(self, range, "TerritorialNest", function(nest, me, range)
+		if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
+			return me:GetDist2D(nest)
+		end
+	end, self, range)
+	if closest_sleepy then
+		return closest_sleepy
+	else
+		return false
+	end
 end
 
 function EnhancedTerritorialNest:support_arrived(allied_unit)
-    --print("A unit supporting me has arrived!")
-    local my_strongest_tier = 0
-    if self.state == 'asleep' then
-        --print("This is going to try and wake me up!")
-        if not self.wake_up_alarms then
-            self.wake_up_alarms = 0
-        end
-        self.wake_up_alarms = self.wake_up_alarms + 1
-        local awake = MapCount(true, "TerritorialNest", function(nest, me)
-            if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
-                return true
-            end
-        end, self)
-        -- make it so that each nest needs more units to wake it up
-        local threshold = 1
-        if Faction_aggression_threshold > threshold then
-            threshold = Faction_aggression_threshold
-        end
-        -- This means the first nest only needs a single wake up event
-        local threshold = threshold * awake
-        if self.wake_up_alarms > threshold then
-            --print("It did wake me up!")
-            self:SwitchState('awake')
-        else
-            --print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
-        end
-        goto continue
-    end
-    local hatchling_tier = EE_get_tier(self.hatchling_class)
-    local adult_tier = EE_get_tier(self.adult_class)
-    local elder_tier = EE_get_tier(self.elder_class)
-    local my_best = Max(hatchling_tier, adult_tier, elder_tier)
-    for _, defender in ipairs(self.nest_members) do
-        local d_tier = EE_get_tier(defender.class)
-        if d_tier > my_best then
-            my_best = d_tier
-        end
-    end
-    --print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
-    local compare
-    if allied_unit.class then
-        compare = allied_unit.class
-    else
-        compare = allied_unit.id
-    end
-    --print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
-    if EE_get_tier(compare) > my_best then
-        --print("It is!")
-        self.attacks_done = self.attacks_done + 1
-        if self.attacks_done > self.attacks_to_evo then
-            --print("And it triggered an evolution!")
-            self:change_nest_herd(true)
-        end
-        goto continue
-    else
-        --print("It was not")
-    end
-    --print("Storing this units EP cost in the nearby structrues and reducing attack time!")
-    local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
-    self:give_ep_to_struct(EP_of_unit)
-    local attack_cd = self.attack_delay
-    -- each unit will reduce the attack cd by 5%
-    self.attack_time = self.attack_time - (5 * DivRound(attack_cd, 100))
-    ::continue::
+	--print("A unit supporting me has arrived!")
+	local my_strongest_tier = 0
+	if self.state == 'asleep' then
+		--print("This is going to try and wake me up!")
+		if not self.wake_up_alarms then
+			self.wake_up_alarms = 0
+		end
+		self.wake_up_alarms = self.wake_up_alarms + 1
+		local awake = MapCount(true, "TerritorialNest", function(nest, me)
+			if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
+				return true
+			end
+		end, self)
+		-- make it so that each nest needs more units to wake it up
+		local threshold = 1
+		if Faction_aggression_threshold > threshold then
+			threshold = Faction_aggression_threshold
+		end
+		-- This means the first nest only needs a single wake up event
+		local threshold = threshold * awake
+		if self.wake_up_alarms > threshold then
+			--print("It did wake me up!")
+			self:SwitchState('awake')
+		else
+			--print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
+		end
+		goto continue
+	end
+	local hatchling_tier = EE_get_tier(self.hatchling_class)
+	local adult_tier = EE_get_tier(self.adult_class)
+	local elder_tier = EE_get_tier(self.elder_class)
+	local my_best = Max(hatchling_tier, adult_tier, elder_tier)
+	for _, defender in ipairs(self.nest_members) do
+		local d_tier = EE_get_tier(defender.class)
+		if d_tier > my_best then
+			my_best = d_tier
+		end
+	end
+	--print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
+	local compare
+	if allied_unit.class then
+		compare = allied_unit.class
+	else
+		compare = allied_unit.id
+	end
+	--print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
+	if EE_get_tier(compare) > my_best then
+		--print("It is!")
+		self.attacks_done = self.attacks_done + 1
+		if self.attacks_done > self.attacks_to_evo then
+			--print("And it triggered an evolution!")
+			self:change_nest_herd(true)
+		end
+		goto continue
+	else
+		--print("It was not")
+	end
+	--print("Storing this units EP cost in the nearby structrues and reducing attack time!")
+	local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
+	self:give_ep_to_struct(EP_of_unit)
+	local attack_cd = self.attack_delay
+	-- each unit will reduce the attack cd by 5%
+	self.attack_time = self.attack_time - (5 * DivRound(attack_cd, 100))
+	::continue::
 end
 
 function EnhancedTerritorialNest:mega_consume()
-    DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
-    local multiplier = Get_difficulty_offset()
-    for i = 1, 3 * multiplier do
-        self:consume_closest_node()
-    end
+	DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
+	local multiplier = Get_difficulty_offset()
+	for i = 1, 3 * multiplier do
+		self:consume_closest_node()
+	end
 end
 
 function EnhancedTerritorialNest:alert_neighbor(allied_sleepy_nest)
-    DebugPrint("Nest is sending support to the closest nest!\n")
-    local spawn_def = SpawnDefs['Nest_wakeup_alarm']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.adult_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
+	DebugPrint("Nest is sending support to the closest nest!\n")
+	local spawn_def = SpawnDefs['Nest_wakeup_alarm']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.adult_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:growth_event()
-    DebugPrint("Nest has grown enough to do something!\n")
-    self:UpdateNextAttackTime()
-    self:change_nest_herd()
-    local spawn_def
-    local spawn_def_selection = {}
-    if self.state == 'sleepy' then
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.overflow_spawn }
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.scout_nearest_quad }
-        spawn_def = table.weighted_rand(spawn_def_selection, "weight")
-        spawn_def.fun(self)
-        return
-    end
-    -- ensure quadrant + scouting grid exist before reading them (growth_event lacked the guard
-    -- that scout_nearest_quad has; on a fresh map the grid is uninitialised -> nil-index crash)
-    if not self.quadrant then
-        self.quadrant = Get_quadrant_from_obj(self, true)
-    end
-    if not self.nest_species then
-        self.nest_species = get_species_from_nest(self.class)
-    end
-    if not Nest_scouting_quadrants[self.quadrant] then
-        CreateMapGrid()
-    end
-    local unscouted = self:GetUnscoutedQuadrantsWithin()
-    local my_quad_scouted = #unscouted[1] > 0
-    local unscouted_nearby = unscouted[3]
-    if not my_quad_scouted then
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 200, fun = self.Scout_Specific_Quad, input = self
-        .quadrant }
-    elseif #unscouted_nearby > 0 then
-        local to_scout = table.weighted_rand(unscouted_nearby, function(entry) return 100 end)
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = (100 * #unscouted_nearby), fun = self
-        .Scout_Specific_Quad, input = to_scout }
-    elseif #unscouted[#unscouted] > 0 then
-        local to_scout = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.Scout_Specific_Quad, input = to_scout }
-    end
-    local attack_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
-    local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
-    if #nearby_enemies > 0 then
-        for _, enemy in ipairs(nearby_enemies) do
-            local weight = 100
-            if enemy.state == 'asleep' then
-                weight = weight * 2
-            end
-            spawn_def_selection[#spawn_def_selection + 1] = { weight = weight, fun = self.nest_attack_non_player, input =
-            enemy }
-        end
-    end
-    -- note this means if a nest is awaken by another species, it will still be aggressive towards the player
-    if self:IsPlayerKnown() and not self:IsAsleep() and self:can_be_aggressive() then
-        -- Per Ark Builder (now with the angular check he hadn't finished): attack the player only if
-        -- this nest is the front line of its species; if a same-species ally is ahead of us toward
-        -- the survivors AND in roughly our own direction, support it instead. The angular gate stops
-        -- support being sent to a ~180-degree-opposite nest (which would cross the player's base).
-        local support_target = self:GetSupportTarget()
-        if support_target then
-            spawn_def_selection[#spawn_def_selection + 1] = { weight = 150, fun = self.nest_support_closest, input =
-            support_target }
-        else
-            spawn_def_selection[#spawn_def_selection + 1] = { weight = 300, fun = self.nest_attack_player }
-        end
-    else
-        local scouting
-        if #unscouted[#unscouted] > 0 then
-            scouting = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
-        else
-            -- we force scout the quadrant with the oldest scouted time as a major major backup
-            for i = 1, #Nest_scouting_quadrants do
-                if Nest_scouting_quadrants[i][self.nest_species].last_scout then
-                    scouting = i
-                    break
-                end
-                scouting = unscouted[1][1]
-            end
-        end
-        -- if the player is not known, we ALWAYS want to scout and find them
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.Scout_Specific_Quad, input = scouting }
-    end
-    -- if there is a nest within ~3 quadrant lengths
-    local wake_up_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
-    local sleepy = self:ClosestSleepyNest(wake_up_range)
-    if sleepy then
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.alert_neighbor, input = sleepy }
-    end
-    -- always leave the options to just vomit enemies in the nearby area
-    -- and consume a lot of nearby biomass
-    spawn_def_selection[#spawn_def_selection + 1] = { weight = 10, fun = self.overflow_spawn }
-    spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.mega_consume }
-    spawn_def = table.weighted_rand(spawn_def_selection, "weight")
-    if spawn_def.input then
-        spawn_def.fun(self, spawn_def.input)
-    else
-        spawn_def.fun(self)
-    end
+	DebugPrint("Nest has grown enough to do something!\n")
+	self:UpdateNextAttackTime()
+	self:change_nest_herd()
+	local spawn_def
+	local spawn_def_selection = {}
+	if self.state == 'sleepy' then
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.overflow_spawn }
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.scout_nearest_quad }
+		spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+		spawn_def.fun(self)
+		return
+	end
+	-- ensure quadrant + scouting grid exist before reading them (growth_event lacked the guard
+	-- that scout_nearest_quad has; on a fresh map the grid is uninitialised -> nil-index crash)
+	if not self.quadrant then
+		self.quadrant = Get_quadrant_from_obj(self, true)
+	end
+	if not self.nest_species then
+		self.nest_species = get_species_from_nest(self.class)
+	end
+	if not Nest_scouting_quadrants[self.quadrant] then
+		CreateMapGrid()
+	end
+	local unscouted = self:GetUnscoutedQuadrantsWithin()
+	local my_quad_scouted = #unscouted[1] > 0
+	local unscouted_nearby = unscouted[3]
+	if not my_quad_scouted then
+		spawn_def_selection[#spawn_def_selection + 1] = {
+			weight = 200,
+			fun = self.Scout_Specific_Quad,
+			input = self
+				.quadrant
+		}
+	elseif #unscouted_nearby > 0 then
+		local to_scout = table.weighted_rand(unscouted_nearby, function(entry) return 100 end)
+		spawn_def_selection[#spawn_def_selection + 1] = {
+			weight = (100 * #unscouted_nearby),
+			fun = self
+				.Scout_Specific_Quad,
+			input = to_scout
+		}
+	elseif #unscouted[#unscouted] > 0 then
+		local to_scout = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.Scout_Specific_Quad, input = to_scout }
+	end
+	local attack_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+	local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
+	if #nearby_enemies > 0 then
+		for _, enemy in ipairs(nearby_enemies) do
+			local weight = 100
+			if enemy.state == 'asleep' then
+				weight = weight * 2
+			end
+			spawn_def_selection[#spawn_def_selection + 1] = {
+				weight = weight,
+				fun = self.nest_attack_non_player,
+				input =
+					enemy
+			}
+		end
+	end
+	-- note this means if a nest is awaken by another species, it will still be aggressive towards the player
+	if self:IsPlayerKnown() and not self:IsAsleep() and self:can_be_aggressive() then
+		-- Attack the player only if this nest is the front line of its species; if a same-species ally is ahead of us
+		-- toward the survivors AND in roughly our own direction, support it instead. The angular gate stops support
+		-- being sent to a ~180-degree-opposite nest (which would cross the player's base).
+		local support_target = self:GetSupportTarget()
+		if support_target then
+			spawn_def_selection[#spawn_def_selection + 1] = {
+				weight = 150,
+				fun = self.nest_support_closest,
+				input =
+					support_target
+			}
+		else
+			spawn_def_selection[#spawn_def_selection + 1] = { weight = 300, fun = self.nest_attack_player }
+		end
+	else
+		local scouting
+		if #unscouted[#unscouted] > 0 then
+			scouting = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+		else
+			-- we force scout the quadrant with the oldest scouted time as a major major backup
+			for i = 1, #Nest_scouting_quadrants do
+				if Nest_scouting_quadrants[i][self.nest_species].last_scout then
+					scouting = i
+					break
+				end
+				scouting = unscouted[1][1]
+			end
+		end
+		-- if the player is not known, we ALWAYS want to scout and find them
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.Scout_Specific_Quad, input = scouting }
+	end
+	-- if there is a nest within ~3 quadrant lengths
+	local wake_up_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+	local sleepy = self:ClosestSleepyNest(wake_up_range)
+	if sleepy then
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.alert_neighbor, input = sleepy }
+	end
+	-- always leave the options to just vomit enemies in the nearby area
+	-- and consume a lot of nearby biomass
+	spawn_def_selection[#spawn_def_selection + 1] = { weight = 10, fun = self.overflow_spawn }
+	spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.mega_consume }
+	spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+	if spawn_def.input then
+		spawn_def.fun(self, spawn_def.input)
+	else
+		spawn_def.fun(self)
+	end
 end
 
 function EnhancedTerritorialNest:UpdateNextAttackTime()
-    DebugPrint("Nest updating when to attack next\n")
-    local diff = Get_difficulty_offset() - 3
-    self.attack_delay = MoonInstance.AttackCooldownMin +
-    AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
-    if self.state == 'asleep' then self.attack_delay = self.attack_delay * 2 end
-    self.attack_time = GameTime() + self.attack_delay  --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
-    DebugPrint("Next attack time:\n")
-    DebugPrint(self.attack_time)
-    DebugPrint("\nGame Time:\n")
-    DebugPrint(GameTime())
-    DebugPrint("\n")
+	DebugPrint("Nest updating when to attack next\n")
+	local diff = Get_difficulty_offset() - 3
+	self.attack_delay = MoonInstance.AttackCooldownMin +
+		AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
+	if self.state == 'asleep' then self.attack_delay = self.attack_delay * 2 end
+	self.attack_time = GameTime() + self.attack_delay --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
+	DebugPrint("Next attack time:\n")
+	DebugPrint(self.attack_time)
+	DebugPrint("\nGame Time:\n")
+	DebugPrint(GameTime())
+	DebugPrint("\n")
 end
 
 function EnhancedTerritorialNest:TooTiredCheck()
@@ -1321,348 +1336,348 @@ function EnhancedTerritorialNest:TooTiredCheck()
 end
 
 function EnhancedTerritorialNest:OnObjUpdate(time, update_interval)
-    local health = self.Health
-    if health <= 0 then return end
-    if self.attack_time < GameTime() and health > 0 and not self:IsDestroyed() then
-        DebugPrint("Nest is activating!\n")
-        self:growth_event()
-        -- grow_event contains logic to determine what this event really "does"
-    end
-    if self.consume_time < GameTime() then
-        self:consume_closest_node()
-    end
-    if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
-        if self:TooTiredCheck() then
-            self:SwitchState('asleep')
-        else
-            self.sleep_check = GameTime() + const.Scale.months
-        end
-    end
+	local health = self.Health
+	if health <= 0 then return end
+	if self.attack_time < GameTime() and health > 0 and not self:IsDestroyed() then
+		DebugPrint("Nest is activating!\n")
+		self:growth_event()
+		-- grow_event contains logic to determine what this event really "does"
+	end
+	if self.consume_time < GameTime() then
+		self:consume_closest_node()
+	end
+	if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
+		if self:TooTiredCheck() then
+			self:SwitchState('asleep')
+		else
+			self.sleep_check = GameTime() + const.Scale.months
+		end
+	end
 end
 
 function TerritorialNest:Done()
-    local members = self.nest_members
-    for i = #members, 1, -1 do
-        members[i]:SetNest(false)
-    end
-    DeleteThread(self.engagement_range_thread)
-    self.engagement_range_thread = nil
-    self:RemoveFromLabels(Game)
-    self.attack_time = max_int
+	local members = self.nest_members
+	for i = #members, 1, -1 do
+		members[i]:SetNest(false)
+	end
+	DeleteThread(self.engagement_range_thread)
+	self.engagement_range_thread = nil
+	self:RemoveFromLabels(Game)
+	self.attack_time = max_int
 end
 
 function UnitNesting:OnObjUpdate()
-    local nest = self.nest
-    if not IsValid(nest) then
-        return
-    end
-    local effect = self.NestEffect or ""
-    if effect == "" then
-        return
-    end
-    local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
-    if nest_nearby == self.nest_nearby then
-        return
-    end
-    self:give_nest_effect()
+	local nest = self.nest
+	if not IsValid(nest) then
+		return
+	end
+	local effect = self.NestEffect or ""
+	if effect == "" then
+		return
+	end
+	local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
+	if nest_nearby == self.nest_nearby then
+		return
+	end
+	self:give_nest_effect()
 end
 
 function UnitNesting:ReportScoutingResult()
-    quadrant = invader.target_quadrant
-    local day = GameTime()
-    local species = invader.location.nest_species
-    local list_of_found = self.observed_objects
-    nest_scouting_quadrants[quadrant][species]['last_scout'] = day
-    -- Override the last scouting report
-    nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
-    nest_scouting_quadrants[quadrant][species]['other_species'] = {}
-    for _, b in ipairs(list_of_found) do
-        local handle = b['handle'] or false
-        if handle then
-            nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs'] + 1] =
-            handle
-            local species = get_species_from_nest(b.class)
-            if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
-                nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
-            end
-            nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species'] + 1] =
-            handle
-        end
-    end
+	quadrant = invader.target_quadrant
+	local day = GameTime()
+	local species = invader.location.nest_species
+	local list_of_found = self.observed_objects
+	nest_scouting_quadrants[quadrant][species]['last_scout'] = day
+	-- Override the last scouting report
+	nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
+	nest_scouting_quadrants[quadrant][species]['other_species'] = {}
+	for _, b in ipairs(list_of_found) do
+		local handle = b['handle'] or false
+		if handle then
+			nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs'] + 1] =
+				handle
+			local species = get_species_from_nest(b.class)
+			if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
+				nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
+			end
+			nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species'] + 1] =
+				handle
+		end
+	end
 end
 
 -- override of base game function to give nest effect in case things go wrong
 function TerritorialNest:AddNestMember(member)
-    table.insert(self.nest_members, member)
-    if member.CombatGroup ~= self.CombatGroup then
-        member.CombatGroup = self.CombatGroup
-    end
-    -- mark guardian members as such (they stay close to the nest and protect it if attacked)
-    self:TrySetNestGuardian(member)
-    member:give_nest_effect()
+	table.insert(self.nest_members, member)
+	if member.CombatGroup ~= self.CombatGroup then
+		member.CombatGroup = self.CombatGroup
+	end
+	-- mark guardian members as such (they stay close to the nest and protect it if attacked)
+	self:TrySetNestGuardian(member)
+	member:give_nest_effect()
 end
 
 function UnitNesting:give_nest_effect()
-    if not self.nest then return end
-    local nest = self.nest
-    local give = self:IsCloser(nest, nest.territorial_range)
-    if give then
-        if IsKindOf(self, "Robot") then
-            self:AddRobotCondition('FamiliarGroundRobo', 'mod')
-        else
-            self:AddHealthCondition(self.NestEffect or "", "nest")
-        end
-    elseif IsKindOf(self, "Robot") then
-        self:RemoveRobotCondition('FamiliarGroundRobo', 'mod')
-    else
-        self:RemoveHealthConditions(self.NestEffect or "", "nest")
-    end
+	if not self.nest then return end
+	local nest = self.nest
+	local give = self:IsCloser(nest, nest.territorial_range)
+	if give then
+		if IsKindOf(self, "Robot") then
+			self:AddRobotCondition('FamiliarGroundRobo', 'mod')
+		else
+			self:AddHealthCondition(self.NestEffect or "", "nest")
+		end
+	elseif IsKindOf(self, "Robot") then
+		self:RemoveRobotCondition('FamiliarGroundRobo', 'mod')
+	else
+		self:RemoveHealthConditions(self.NestEffect or "", "nest")
+	end
 end
 
 function UnitNesting:UpdateAttachedUI()
-    if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
-    RemoveAttachedUIToObject(self, 'NestRolePermanent')
-    RemoveAttachedUIToObject(self, 'NestRoleClose')
-    RemoveAttachedUIToObject(self, 'NestRoleFar')
-    local template
-    if NA_NestRoleZoom == 3 then
-        template = 'NestRolePermanent'
-    elseif NA_NestRoleZoom == 2 then
-        template = 'NestRoleFar'
-    elseif NA_NestRoleZoom == 1 then
-        template = 'NestRoleClose'
-    end
-    if template then
-        AddAttachedUIToObject(self, template, 'Task', self)
-    end
+	if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
+	RemoveAttachedUIToObject(self, 'NestRolePermanent')
+	RemoveAttachedUIToObject(self, 'NestRoleClose')
+	RemoveAttachedUIToObject(self, 'NestRoleFar')
+	local template
+	if NA_NestRoleZoom == 3 then
+		template = 'NestRolePermanent'
+	elseif NA_NestRoleZoom == 2 then
+		template = 'NestRoleFar'
+	elseif NA_NestRoleZoom == 1 then
+		template = 'NestRoleClose'
+	end
+	if template then
+		AddAttachedUIToObject(self, template, 'Task', self)
+	end
 end
 
 function UnitNesting:GetUIRole()
-    if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
-    if self.hide_UI_on_empty and amount <= 0 then return "" end
-    local name = ''
-    if NA_NestRoleName then
-        name = self:GetHUDName(self)
-    end
-    local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
-    local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
-    local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
-    local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-    local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
-    local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-    if self.found_player then
-        return T { "<image " .. scout_found_player .. " 1800><name>", name = name }
-    elseif self.scouting then
-        return T { "<image " .. scout .. " 1800><name>", name = name }
-    elseif self.pathing_to then
-        return T { "<image " .. support .. " 1800><name>", name = name }
-    elseif self.nest then
-        local image = defender
-        return T { "<image " .. image .. " 1800><name>", name = name }
-    end
+	if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
+	if self.hide_UI_on_empty and amount <= 0 then return "" end
+	local name = ''
+	if NA_NestRoleName then
+		name = self:GetHUDName(self)
+	end
+	local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
+	local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
+	local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
+	local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+	local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
+	local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+	if self.found_player then
+		return T { "<image " .. scout_found_player .. " 1800><name>", name = name }
+	elseif self.scouting then
+		return T { "<image " .. scout .. " 1800><name>", name = name }
+	elseif self.pathing_to then
+		return T { "<image " .. support .. " 1800><name>", name = name }
+	elseif self.nest then
+		local image = defender
+		return T { "<image " .. image .. " 1800><name>", name = name }
+	end
 end
 
 local OG_ShouldShowHUDName = UnitAnimal.ShouldShowHUDName
 function UnitAnimal:ShouldShowHUDName()
-    local base = OG_ShouldShowHUDName(self)
-    if self:CheckForNewBehaviors() or self.nest then return true else return base end
-    --return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
+	local base = OG_ShouldShowHUDName(self)
+	if self:CheckForNewBehaviors() or self.nest then return true else return base end
+	--return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
 end
 
 function UnitNesting:SetNest(nest)
-    nest = nest or false
-    if nest == self.nest then return end
-    local old_nest = self.nest
-    if IsValid(old_nest) then
-        old_nest:RemoveNestMember(self)
-    end
-    self.nest = nest or nil
-    if IsValid(nest) then
-        nest:AddNestMember(self)
-        --self:AddHUDName()
-    end
+	nest = nest or false
+	if nest == self.nest then return end
+	local old_nest = self.nest
+	if IsValid(old_nest) then
+		old_nest:RemoveNestMember(self)
+	end
+	self.nest = nest or nil
+	if IsValid(nest) then
+		nest:AddNestMember(self)
+		--self:AddHUDName()
+	end
 end
 
 function is_inside_of(box, pos)
-    if box:GetDist2D(pos) == 0 then
-        return true
-    else
-        return false
-    end
+	if box:GetDist2D(pos) == 0 then
+		return true
+	else
+		return false
+	end
 end
 
 function TerritorialNest:SpawnAround(class, range, instant, burrowed)
-    local def = class and g_Classes[class]
-    if not def then return end
-    if burrowed and not def.CanBurrowInNest then return end
-    local playbox = GetPlayBox()
-    local pfclass = def.pfclass
-    local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
-    local nest_entity_radius = self:GetRadius()
-    local x, y
-    local retry = 10
-    -- overriding range given because that is usually just 10 meters...
-    range = self.max_range
-    while not x and retry > 0 do
-        x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
-        if x then
-            local temp_pos = point(x, y)
-            local playbox_check = playbox:Dist2(temp_pos) > 1
-            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-            if playbox_check or under_nest then
-                x = nil
-                retry = retry - 1
-            else
-                retry = -1
-            end
-        end
-    end
-    if not x then return end
-    if IsKindOf(def, 'Robot') then
-        local spawn_def = SpawnDefs['single_spawn_around_loc']
-        local instance = {}
-        instance.location = self
-        instance.radius = range
-        instance.PostSpawn = function(self, obj, target, context)
-            obj:SetNest(self.location)
-            obj:SetInvader(true)
-        end
-        instance.FindSpawnLoc = function(self, spawn_class, target, context)
-            return point(x, y)
-        end
-        instance.SpawnClass = class
-        spawn_def = spawn_def:CreateInstance(instance)
-        local t = spawn_def:ResolveTarget()
-        spawn_def:ActivateSpawn(t, {}, 100)
-        return true
-    else
-        local obj
-        obj = def:new()
-        obj:SetNest(self)
-        obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360 * 60, "SpawnNestMember"))
-        if not instant then
-            obj.init_with_command = "CmdSpawn"
-        end
-        return obj
-    end
-    -- in case we have changed what combat groups this nest is
-    obj.CombatGroup = self.CombatGroup
-    return false
+	local def = class and g_Classes[class]
+	if not def then return end
+	if burrowed and not def.CanBurrowInNest then return end
+	local playbox = GetPlayBox()
+	local pfclass = def.pfclass
+	local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
+	local nest_entity_radius = self:GetRadius()
+	local x, y
+	local retry = 10
+	-- overriding range given because that is usually just 10 meters...
+	range = self.max_range
+	while not x and retry > 0 do
+		x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
+		if x then
+			local temp_pos = point(x, y)
+			local playbox_check = playbox:Dist2(temp_pos) > 1
+			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+			if playbox_check or under_nest then
+				x = nil
+				retry = retry - 1
+			else
+				retry = -1
+			end
+		end
+	end
+	if not x then return end
+	if IsKindOf(def, 'Robot') then
+		local spawn_def = SpawnDefs['single_spawn_around_loc']
+		local instance = {}
+		instance.location = self
+		instance.radius = range
+		instance.PostSpawn = function(self, obj, target, context)
+			obj:SetNest(self.location)
+			obj:SetInvader(true)
+		end
+		instance.FindSpawnLoc = function(self, spawn_class, target, context)
+			return point(x, y)
+		end
+		instance.SpawnClass = class
+		spawn_def = spawn_def:CreateInstance(instance)
+		local t = spawn_def:ResolveTarget()
+		spawn_def:ActivateSpawn(t, {}, 100)
+		return true
+	else
+		local obj
+		obj = def:new()
+		obj:SetNest(self)
+		obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360 * 60, "SpawnNestMember"))
+		if not instant then
+			obj.init_with_command = "CmdSpawn"
+		end
+		return obj
+	end
+	-- in case we have changed what combat groups this nest is
+	obj.CombatGroup = self.CombatGroup
+	return false
 end
 
 function TerritorialNest:Spawn_robot_nestling(x, y, class)
-    local spawn_def = SpawnDefs['Single_Robots']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.pos = point(x, y)
-    instance.SpawnClass = class
-    instance.FindSpawnLoc = function(self, spawn_class, target, context)
-        return self.pos
-    end
-    --[[instance.PostSpawn = function(self,obj,target,context)
+	local spawn_def = SpawnDefs['Single_Robots']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.pos = point(x, y)
+	instance.SpawnClass = class
+	instance.FindSpawnLoc = function(self, spawn_class, target, context)
+		return self.pos
+	end
+	--[[instance.PostSpawn = function(self,obj,target,context)
 		obj:SetInvader(true)
 		obj:SetNest(self.nest)
 	end--]]
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 AppendClass.TerritorialNest = {
-    __parents = { "EnhancedTerritorialNest" },
+	__parents = { "EnhancedTerritorialNest" },
 }
 
 -- meta class grouping all spore buildings for easier searching
 -- We do not append ConsortiumSporeDeposit because we define it in the other file with this as a parent already
 DefineClass.NestSpore = {
-    properties = {}
+	properties = {}
 }
 
 AppendClass.ShriekerSporeDeposit = {
-    __parents = { "NestSpore" }
+	__parents = { "NestSpore" }
 }
 
 AppendClass.ScissorhandSporeDeposit = {
-    __parents = { "NestSpore" }
+	__parents = { "NestSpore" }
 }
 
 function count_effects_by_id(target, effect_id)
-    local count = 0
-    for _, effect in ipairs(target.status_effects or empty_table) do
-        if effect.id == effect_id then
-            count = count + 1
-        end
-    end
-    return count
+	local count = 0
+	for _, effect in ipairs(target.status_effects or empty_table) do
+		if effect.id == effect_id then
+			count = count + 1
+		end
+	end
+	return count
 end
 
 function decay_speed(target)
-    local effect_id = 'nest_attack_speed'
-    --[[if IsKindOf(target,'Robot') then
+	local effect_id = 'nest_attack_speed'
+	--[[if IsKindOf(target,'Robot') then
 		effect_id = 'nest_attack_speed_robot'
 		target:RemoveRobotConditions(effect_id, "ReplaceOldest")
 	end--]]
-    local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
-    local distance_to = target:GetDist2D(survivors)
-    local prox = MulDivRound(distance_to, 1, 150 * guim)
-    local count = count_effects_by_id(target, effect_id)
-    while count > prox do
-        if IsKindOf(target, 'Robot') then
-            target:RemoveRobotConditions(effect_id, "ReplaceOldest")
-            count = count_effects_by_id(target, effect_id)
-        else
-            target:RemoveHealthConditions(effect_id, "ReplaceOldest")
-            count = count_effects_by_id(target, effect_id)
-        end
-    end
+	local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
+	local distance_to = target:GetDist2D(survivors)
+	local prox = MulDivRound(distance_to, 1, 150 * guim)
+	local count = count_effects_by_id(target, effect_id)
+	while count > prox do
+		if IsKindOf(target, 'Robot') then
+			target:RemoveRobotConditions(effect_id, "ReplaceOldest")
+			count = count_effects_by_id(target, effect_id)
+		else
+			target:RemoveHealthConditions(effect_id, "ReplaceOldest")
+			count = count_effects_by_id(target, effect_id)
+		end
+	end
 end
 
 function add_delay_to_nests()
-    MapForEach(true, "TerritorialNest", function(nest)
-        if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
-            nest:UpdateNextAttackTime()
-        end
-    end)
+	MapForEach(true, "TerritorialNest", function(nest)
+		if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
+			nest:UpdateNextAttackTime()
+		end
+	end)
 end
 
 function clean_up_robots()
-    MapForEach(true, "Robot", function(robot)
-        if not robot.Invader and not robot.command_center then
-            DoneObject(robot)
-        end
-    end)
-    MapForEach(true, "ConsortiumNest", function(nest)
-        local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
-        nest:UpdateTerritoryTerrain(true, count)
-        for i = 1, count do
-            if not nest:SpawnNestMember(true) then
-                break
-            end
-        end
-    end)
+	MapForEach(true, "Robot", function(robot)
+		if not robot.Invader and not robot.command_center then
+			DoneObject(robot)
+		end
+	end)
+	MapForEach(true, "ConsortiumNest", function(nest)
+		local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
+		nest:UpdateTerritoryTerrain(true, count)
+		for i = 1, count do
+			if not nest:SpawnNestMember(true) then
+				break
+			end
+		end
+	end)
 end
 
 function delete_robots()
-    MapDelete("map", "HeavyHostileRobot_LVL1", function(robot, playbox)
-        return is_inside_of(playbox, robot)
-    end, GetPlayBox())
+	MapDelete("map", "HeavyHostileRobot_LVL1", function(robot, playbox)
+		return is_inside_of(playbox, robot)
+	end, GetPlayBox())
 end
 
 function SavegameFixups.EnhancedNestFixes()
-    add_delay_to_nests()
-    clean_up_robots()
-    delete_robots()
+	add_delay_to_nests()
+	clean_up_robots()
+	delete_robots()
 end
 
 function OnMsg.PostLoadGame()
-    delete_robots()
+	delete_robots()
 end
 
 function OnMsg.UpdateNestRoleVisuals()
-    MapForEach('map', 'UnitNesting', function(nest_member)
-        nest_member:UpdateAttachedUI()
-    end)
+	MapForEach('map', 'UnitNesting', function(nest_member)
+		nest_member:UpdateAttachedUI()
+	end)
 end
 
 --[[ Debugging ovverride

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -4,374 +4,374 @@ local hours_per_day = day_duration / hour_duration
 
 
 function Juno_Cancer(force)
-    local nests = {}
-    if force then
-        nests = MapGet(true, 'TerritorialNest', function(nest)
-            if nest.class ~= 'JunoNest' then return true end
-        end)
-    else
-        nests = MapGet(true, 'TerritorialNest', function(nest)
-            if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
-                return true
-            end
-        end)
-    end
-    if #nests > 0 then
-        local roll = AsyncRand(#nests)
-        local to_convert = nests[roll]
-        Convert_nest_into(to_convert, 'nesting_juno')
-    elseif force then
-    end
+	local nests = {}
+	if force then
+		nests = MapGet(true, 'TerritorialNest', function(nest)
+			if nest.class ~= 'JunoNest' then return true end
+		end)
+	else
+		nests = MapGet(true, 'TerritorialNest', function(nest)
+			if GameTime() - cosnt.year > nest.spawned_on and nest.class ~= 'JunoNest' then
+				return true
+			end
+		end)
+	end
+	if #nests > 0 then
+		local roll = AsyncRand(#nests)
+		local to_convert = nests[roll]
+		Convert_nest_into(to_convert, 'nesting_juno')
+	elseif force then
+	end
 end
 
 function SpawnNestInsideMap(marker, seed, nest_type, danger_lvl)
-    DebugPrint("Spawning a nest\n")
-    if marker and terrain.IsWater(marker) then
-        return
-    end
-    -- danger level does nothing right now, not part of MVP
-    danger_lvl = danger_lvl or 1
-    seed = seed or InteractionRand(nil, "DailySpawn")
-    local tags = {}
-    nest_type = nest_type or Get_nest_by_region()
-    if not nest_type then
-        return
-    elseif nest_type == 'ShriekerNest' then
-        tags = { shrieker_fall = true }
-    elseif nest_type == 'ScissorhandsNest' then
-        tags = { scissorhands_nest = true }
-    else
-        --("Using backup, whatever nest type is the tag!")
-        --(nest_type)
-        tags[nest_type] = true -- future proof for PX, the nest_type input will be the needed tag
-    end
-    --(tags)
-    SuspendPassEdits("SpawndNest")
-    seed = seed or InteractionRand(nil, "DailySpawn")
-    local nest
-    --(seed)
-    --()
-    local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
-        tags_all = tags,
-    })
-    if not err then
-        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-        if nest_marker then
-            nest = nest_marker:SpawnNest(true)
-        else
-            assert(false, "Prefab without a nest marker: " .. name)
-        end
-    else
-        assert(false, "Prefab error: " .. err)
-    end
-    ResumePassEdits("SpawndNest")
-    return nest
+	DebugPrint("Spawning a nest\n")
+	if marker and terrain.IsWater(marker) then
+		return
+	end
+	-- danger level does nothing right now, not part of MVP
+	danger_lvl = danger_lvl or 1
+	seed = seed or InteractionRand(nil, "DailySpawn")
+	local tags = {}
+	nest_type = nest_type or Get_nest_by_region()
+	if not nest_type then
+		return
+	elseif nest_type == 'ShriekerNest' then
+		tags = { shrieker_fall = true }
+	elseif nest_type == 'ScissorhandsNest' then
+		tags = { scissorhands_nest = true }
+	else
+		--("Using backup, whatever nest type is the tag!")
+		--(nest_type)
+		tags[nest_type] = true -- future proof for PX, the nest_type input will be the needed tag
+	end
+	--(tags)
+	SuspendPassEdits("SpawndNest")
+	seed = seed or InteractionRand(nil, "DailySpawn")
+	local nest
+	--(seed)
+	--()
+	local err, objs, pos, prefab, name, inv_bbox = marker:PlacePrefab(seed, {
+		tags_all = tags,
+	})
+	if not err then
+		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+		if nest_marker then
+			nest = nest_marker:SpawnNest(true)
+		else
+			assert(false, "Prefab without a nest marker: " .. name)
+		end
+	else
+		assert(false, "Prefab error: " .. err)
+	end
+	ResumePassEdits("SpawndNest")
+	return nest
 end
 
 function PlacePrefabLogic:GetPrefabLoc(seed, params)
-    seed = seed or InteractionRand(nil, "PlacePrefab")
-    local name, pos, angle, prefab, idx
-    --("Params")
-    --(params)
-    local prefabs = self:GetPrefabs(params)
-    --("Initial get of #prefabs")
-    --(#prefabs)
-    local r = 4
-    local fresh_prefabs
-    while #prefabs == 0 and r > 0 do
-        --("RETRYING BECAUSE I FAILED TO FIND")
-        prefabs = self:GetPrefabs(params)
-        local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
-        --("non-self prefab get count")
-        --(#fresh_prefabs)
-        --("self get of #prefabs")
-        --(#prefabs)
-        r = r - 1
-        if #fresh_prefabs > #prefabs then
-            prefabs = fresh_prefabs
-        end
-    end
-    local retry
-    while true do
-        local idx
-        if #prefabs > 1 then
-            prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
-        else
-            prefab = prefabs[1]
-        end
-        ----(prefab)
-        assert(prefab)
-        if not prefab then
-            return
-        end
-        pos = params and params.pos
-        if not pos then
-            pos = self:GetVisualPos()
-            if not self.FixAtCenter then
-                local reserved_radius
-                if params and params.avoid_reserved_locations and self.reserved_locations then
-                    reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
-                end
-                local radius = prefab.max_radius * const.TypeTileSize
-                local free_dist = self.MaxPrefabRadius - radius
-                if free_dist > 0 then
-                    local center = pos
-                    pos = false
-                    local retries = params and params.avoid_reserved_retries or 16
-                    for i = 1, retries do
-                        local ra, rr
-                        ra, seed = BraidRandom(seed, 360 * 60)
-                        rr, seed = BraidRandom(seed, free_dist)
-                        local pos_i = RotateRadius(rr, ra, center)
-                        if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
-                            pos = pos_i
-                            break
-                        end
-                    end
-                elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
-                    pos = false
-                end
-            end
-        end
-        if pos then
-            name = PrefabMarkers[prefab]
-            angle = params and params.angle
-            if not angle then
-                angle = self:GetAngle()
-                local rand_angle = self.RandAngle
-                if rand_angle > 0 then
-                    local desired_angle = params and params.desired_angle
-                    if desired_angle then
-                        local angle_diff = AngleDiff(desired_angle, angle)
-                        if abs(angle_diff) <= rand_angle then
-                            angle = desired_angle
-                        else
-                            local min_angle, max_angle = angle - rand_angle, angle + rand_angle
-                            if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
-                                angle = min_angle
-                            else
-                                angle = max_angle
-                            end
-                        end
-                    else
-                        local da
-                        da, seed = BraidRandom(seed, -rand_angle, rand_angle)
-                        angle = angle + da
-                    end
-                end
-            end
-            return name, pos, angle, prefab, seed
-        end
-        if #prefabs == 1 then
-            return
-        end
-        table.remove_rotate(prefabs, idx)
-    end
+	seed = seed or InteractionRand(nil, "PlacePrefab")
+	local name, pos, angle, prefab, idx
+	--("Params")
+	--(params)
+	local prefabs = self:GetPrefabs(params)
+	--("Initial get of #prefabs")
+	--(#prefabs)
+	local r = 4
+	local fresh_prefabs
+	while #prefabs == 0 and r > 0 do
+		--("RETRYING BECAUSE I FAILED TO FIND")
+		prefabs = self:GetPrefabs(params)
+		local fresh_prefabs = PlacePrefabLogic:GetPrefabs(params)
+		--("non-self prefab get count")
+		--(#fresh_prefabs)
+		--("self get of #prefabs")
+		--(#prefabs)
+		r = r - 1
+		if #fresh_prefabs > #prefabs then
+			prefabs = fresh_prefabs
+		end
+	end
+	local retry
+	while true do
+		local idx
+		if #prefabs > 1 then
+			prefab, idx, seed = table.weighted_rand(prefabs, "weight", seed)
+		else
+			prefab = prefabs[1]
+		end
+		----(prefab)
+		assert(prefab)
+		if not prefab then
+			return
+		end
+		pos = params and params.pos
+		if not pos then
+			pos = self:GetVisualPos()
+			if not self.FixAtCenter then
+				local reserved_radius
+				if params and params.avoid_reserved_locations and self.reserved_locations then
+					reserved_radius = (prefab.min_radius + prefab.max_radius) * const.TypeTileSize / 2
+				end
+				local radius = prefab.max_radius * const.TypeTileSize
+				local free_dist = self.MaxPrefabRadius - radius
+				if free_dist > 0 then
+					local center = pos
+					pos = false
+					local retries = params and params.avoid_reserved_retries or 16
+					for i = 1, retries do
+						local ra, rr
+						ra, seed = BraidRandom(seed, 360 * 60)
+						rr, seed = BraidRandom(seed, free_dist)
+						local pos_i = RotateRadius(rr, ra, center)
+						if not reserved_radius or self:CheckReservedLocations(pos_i, reserved_radius) then
+							pos = pos_i
+							break
+						end
+					end
+				elseif reserved_radius and not self:CheckReservedLocations(pos, reserved_radius) then
+					pos = false
+				end
+			end
+		end
+		if pos then
+			name = PrefabMarkers[prefab]
+			angle = params and params.angle
+			if not angle then
+				angle = self:GetAngle()
+				local rand_angle = self.RandAngle
+				if rand_angle > 0 then
+					local desired_angle = params and params.desired_angle
+					if desired_angle then
+						local angle_diff = AngleDiff(desired_angle, angle)
+						if abs(angle_diff) <= rand_angle then
+							angle = desired_angle
+						else
+							local min_angle, max_angle = angle - rand_angle, angle + rand_angle
+							if abs(AngleDiff(desired_angle, min_angle)) < abs(AngleDiff(desired_angle, max_angle)) then
+								angle = min_angle
+							else
+								angle = max_angle
+							end
+						end
+					else
+						local da
+						da, seed = BraidRandom(seed, -rand_angle, rand_angle)
+						angle = angle + da
+					end
+				end
+			end
+			return name, pos, angle, prefab, seed
+		end
+		if #prefabs == 1 then
+			return
+		end
+		table.remove_rotate(prefabs, idx)
+	end
 end
 
 RecursiveCallMethods.RegisterTarget = "call"
 
 DefineClass.EnhancedTerritorialNest = {
 
-    properties = {
-        { category = "Nest", id = "state",             name = "State of nest",                                 editor = "choice", template = true,   items = { "asleep", "sleepy", "awake", "allied" }, default = 'asleep',                                                                                                       modifiable = true, help = "state of the nest" },
-        { category = "Nest", id = "attack_time",       name = "Nest Attack Time",                              editor = "number", default = max_int, modifiable = true,                                 help = "When a nest will attack next if not asleep." },
-        { category = "Nest", id = "attack_delay",      name = "Nest Attack Delay",                             editor = "number", default = max_int, modifiable = true,                                 help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)" },
-        { category = "Nest", id = "attacks_done",      name = "Nest Attack Count",                             editor = "number", default = 0,       modifiable = true,                                 help = "Number of attacks this nest has sent total" },
-        { category = "Nest", id = "attacks_to_evo",    name = "attacks needed to force evolution",             editor = "number", default = 4,       modifiable = true,                                 help = "How much EP is needed to evolve the nest denizens" },
-        { category = "Nest", id = "proximity",         name = "Nests proximity to players stuff",              editor = "number", default = 1,       modifiable = true,                                 help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates" },
-        { category = "Nest", id = "ui_attack_percent", name = "How close the attack time is to occuring",      editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
-        { category = "Nest", id = "ui_evo",            name = "How close this nest is too evolving it's herd", editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
-        { category = "Nest", id = "base_strength",     name = "Base % str of an attack this will send",        editor = "number", scale = "%",       default = 30,                                      modifiable = true,                                                                                                        help = "" },
-        { category = "Nest", id = "consume_time",      name = "When nest will eat the next node",              editor = "number", default = 0,       modifiable = true,                                 help = "This is routinely updated based on each individual nest" },
-    },
-    state = 'asleep',
-    attack_time = max_int,
-    attack_delay = max_int,
-    attacks_done = 0,
-    attacks_to_evo = 4,
-    base_strength = 20,
-    consume_time = max_int,
-    proximity = 1,
-    ui_attack_percent = 0,
-    ui_evo = 0,
-    sleep_check = 0,
-    awoken_at = 0,
-    attacked_by_player = false,
-    other_species_attacks = {},
+	properties = {
+		{ category = "Nest", id = "state",             name = "State of nest",                                 editor = "choice", template = true,   items = { "asleep", "sleepy", "awake", "allied" }, default = 'asleep',                                                                                                       modifiable = true, help = "state of the nest" },
+		{ category = "Nest", id = "attack_time",       name = "Nest Attack Time",                              editor = "number", default = max_int, modifiable = true,                                 help = "When a nest will attack next if not asleep." },
+		{ category = "Nest", id = "attack_delay",      name = "Nest Attack Delay",                             editor = "number", default = max_int, modifiable = true,                                 help = "Exact time a nest picks to attack after it's last attack (Used in some internal calcualtions/UI percentage bars)" },
+		{ category = "Nest", id = "attacks_done",      name = "Nest Attack Count",                             editor = "number", default = 0,       modifiable = true,                                 help = "Number of attacks this nest has sent total" },
+		{ category = "Nest", id = "attacks_to_evo",    name = "attacks needed to force evolution",             editor = "number", default = 4,       modifiable = true,                                 help = "How much EP is needed to evolve the nest denizens" },
+		{ category = "Nest", id = "proximity",         name = "Nests proximity to players stuff",              editor = "number", default = 1,       modifiable = true,                                 help = "Higher numbers indicate close distance to the players presence, and effects attack/evo/consumption rates" },
+		{ category = "Nest", id = "ui_attack_percent", name = "How close the attack time is to occuring",      editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
+		{ category = "Nest", id = "ui_evo",            name = "How close this nest is too evolving it's herd", editor = "number", scale = "%",       default = 0,                                       modifiable = true,                                                                                                        help = "" },
+		{ category = "Nest", id = "base_strength",     name = "Base % str of an attack this will send",        editor = "number", scale = "%",       default = 30,                                      modifiable = true,                                                                                                        help = "" },
+		{ category = "Nest", id = "consume_time",      name = "When nest will eat the next node",              editor = "number", default = 0,       modifiable = true,                                 help = "This is routinely updated based on each individual nest" },
+	},
+	state = 'asleep',
+	attack_time = max_int,
+	attack_delay = max_int,
+	attacks_done = 0,
+	attacks_to_evo = 4,
+	base_strength = 20,
+	consume_time = max_int,
+	proximity = 1,
+	ui_attack_percent = 0,
+	ui_evo = 0,
+	sleep_check = 0,
+	awoken_at = 0,
+	attacked_by_player = false,
+	other_species_attacks = {},
 }
 
 function EnhancedTerritorialNest:Align_cgroup_members()
-    for _, v in ipairs(self.nest_members) do
-        v.CombatGroup = self.CombatGroup
-    end
+	for _, v in ipairs(self.nest_members) do
+		v.CombatGroup = self.CombatGroup
+	end
 end
 
 function NestDelayedInit(nest)
-    nest:UpdateNextAttackTime()
-    nest:get_proximity()
-    --nest:force_inert_if_capped()
-    nest.quadrant = Get_quadrant_from_obj(nest, true)
-    nest.spawned_on = GameTime()
+	nest:UpdateNextAttackTime()
+	nest:get_proximity()
+	--nest:force_inert_if_capped()
+	nest.quadrant = Get_quadrant_from_obj(nest, true)
+	nest.spawned_on = GameTime()
 end
 
 --~Presets.UnitSpeciesGroup.Default[Presets.NestingSpeciesPreset.Default[get_species_from_nest(SelectedObj.class)].unit_species]
 function EnhancedTerritorialNest:Init()
-    self.attack_time = max_int
-    self.consume_time = max_int
-    self.nest_species = get_species_from_nest(self.class)
-    local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
-    local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
-    local desired_cgroup = full_species_details.primary_combat_group
-    if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups, self.CombatGroup) then
-        self.CombatGroup = desired_cgroup
-        self:Align_cgroup_members()
-    end
-    -- wait a day then reset the above
-    CreateGameTimeThread(function(this_nest)
-        Sleep(day_duration)
-        NestDelayedInit(this_nest)
-    end, self)
+	self.attack_time = max_int
+	self.consume_time = max_int
+	self.nest_species = get_species_from_nest(self.class)
+	local full_nest_details = Presets.NestingSpeciesPreset.Default[self.nest_species]
+	local full_species_details = Presets.UnitSpeciesGroup.Default[full_nest_details.unit_species]
+	local desired_cgroup = full_species_details.primary_combat_group
+	if self.CombatGroup ~= desired_cgroup and not table.find(full_species_details.allied_combat_groups, self.CombatGroup) then
+		self.CombatGroup = desired_cgroup
+		self:Align_cgroup_members()
+	end
+	-- wait a day then reset the above
+	CreateGameTimeThread(function(this_nest)
+		Sleep(day_duration)
+		NestDelayedInit(this_nest)
+	end, self)
 end
 
 function EnhancedTerritorialNest:get_next_consume_time()
-    local wait_for = AsyncRand(hour_duration * 24, hour_duration * 36)
-    self.consume_time = GameTime() + wait_for
+	local wait_for = AsyncRand(hour_duration * 24, hour_duration * 36)
+	self.consume_time = GameTime() + wait_for
 end
 
 --This technically just increases the nest members, because the base game uses the nests herd to set the controlled territory
 function EnhancedTerritorialNest:expand()
-    DebugPrint("Nest Expanding it's territory!\n")
-    local expand_by = 6
-    local nodes = 0
-    local max_growths = 5
-    local grows = 0
-    while nodes < 30 and grows < max_growths do
-        --(nodes)
-        --("expanded the distance ",grows,' times')
-        nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
-            if not IsKindOf(thing, 'NestSpore') then return true end
-        end)
-        grows = grows + 1
-        --("At this increased radius, there are ",nodes,' valid nodes to consume')
-    end
-    --("There was enough nodes nearby to warrant an increase of",grows*expand_by,' meter radius')
-    self.elders_max_count = self.elders_max_count + grows
-    self.hatchlings_max_count = self.hatchlings_max_count + grows
-    self.adults_max_count = self.adults_max_count + grows
+	DebugPrint("Nest Expanding it's territory!\n")
+	local expand_by = 6
+	local nodes = 0
+	local max_growths = 5
+	local grows = 0
+	while nodes < 30 and grows < max_growths do
+		--(nodes)
+		--("expanded the distance ",grows,' times')
+		nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
+			if not IsKindOf(thing, 'NestSpore') then return true end
+		end)
+		grows = grows + 1
+		--("At this increased radius, there are ",nodes,' valid nodes to consume')
+	end
+	--("There was enough nodes nearby to warrant an increase of",grows*expand_by,' meter radius')
+	self.elders_max_count = self.elders_max_count + grows
+	self.hatchlings_max_count = self.hatchlings_max_count + grows
+	self.adults_max_count = self.adults_max_count + grows
 end
 
 function Convert_nest_into(nest_to_convert, other_species, delete_old_members)
-    if not Presets.NestingSpeciesPreset.Default[other_species] then return end
-    local species = Presets.NestingSpeciesPreset.Default[other_species]
-    local o_species_tags = species.PrefabTags
-    local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
-    local spore_building_def = my_current.spore_buildings
-    local spores = MapGet(nest_to_convert, nest_to_convert.max_range, spore_building_def)
-    if delete_old_members then
-        for _, member in ipairs(nest_to_convert.nest_members) do
-            member:SetNest(false)
-            DoneObject(member)
-        end
-    end
-    for _, spore in ipairs(spores) do
-        DoneObject(spore)
-    end
-    local def = g_Classes['FallingDebrisMarker']
-    local old_marker = MapFindNearest(nest_to_convert, true, 'TerritorialNestMarker')
-    DoneObject(nest_to_convert)
-    local pos = old_marker:GetPos()
-    local new_marker = def:new()
-    new_marker:SetPosAngle(pos)
-    DoneObject(old_marker)
+	if not Presets.NestingSpeciesPreset.Default[other_species] then return end
+	local species = Presets.NestingSpeciesPreset.Default[other_species]
+	local o_species_tags = species.PrefabTags
+	local my_current = Presets.NestingSpeciesPreset.Default[nest_to_convert.nest_species]
+	local spore_building_def = my_current.spore_buildings
+	local spores = MapGet(nest_to_convert, nest_to_convert.max_range, spore_building_def)
+	if delete_old_members then
+		for _, member in ipairs(nest_to_convert.nest_members) do
+			member:SetNest(false)
+			DoneObject(member)
+		end
+	end
+	for _, spore in ipairs(spores) do
+		DoneObject(spore)
+	end
+	local def = g_Classes['FallingDebrisMarker']
+	local old_marker = MapFindNearest(nest_to_convert, true, 'TerritorialNestMarker')
+	DoneObject(nest_to_convert)
+	local pos = old_marker:GetPos()
+	local new_marker = def:new()
+	new_marker:SetPosAngle(pos)
+	DoneObject(old_marker)
 
-    SuspendPassEdits("SpawndNest")
-    local seed = InteractionRand(nil, "DailySpawn")
-    local nest
-    --(seed)
-    --()
-    local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
-        tags_all = o_species_tags,
-    })
-    if not err then
-        local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
-        if nest_marker then
-            nest = nest_marker:SpawnNest(true)
-        else
-            assert(false, "Prefab without a nest marker: " .. name)
-        end
-    else
-        assert(false, "Prefab error: " .. err)
-    end
-    ResumePassEdits("SpawndNest")
-    AddGameNotification("JunoNestSpawned", nil, nil, { nest })
-    return nest
-    --SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
+	SuspendPassEdits("SpawndNest")
+	local seed = InteractionRand(nil, "DailySpawn")
+	local nest
+	--(seed)
+	--()
+	local err, objs, pos, prefab, name, inv_bbox = new_marker:PlacePrefab(seed, {
+		tags_all = o_species_tags,
+	})
+	if not err then
+		local nest_marker = FindFirstIsKindOf(objs, "TerritorialNestMarker")
+		if nest_marker then
+			nest = nest_marker:SpawnNest(true)
+		else
+			assert(false, "Prefab without a nest marker: " .. name)
+		end
+	else
+		assert(false, "Prefab error: " .. err)
+	end
+	ResumePassEdits("SpawndNest")
+	AddGameNotification("JunoNestSpawned", nil, nil, { nest })
+	return nest
+	--SpawnNestInsideMap(new_marker,nil,species.nest_class, 1)
 end
 
 function EnhancedTerritorialNest:give_ep_to_struct(ep)
-    if not ep then return end
-    Bkob_Log_NA("Nest storing EP in support structures\n")
-    local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
-    Bkob_Log_NA(spore_building_def.class)
-    Bkob_Log_NA(self.territorial_range)
-    local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
-    Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
-    local progress_each = DivRound(ep, #spores_near)
-    local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]
-    local spore_res_prog = spore_res.progress
-    local units_to_give = Max(1, DivRound(progress_each, spore_res_prog))
-    Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ", units_to_give)
-    for _, spore in ipairs(spores_near) do
-        spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
-    end
+	if not ep then return end
+	Bkob_Log_NA("Nest storing EP in support structures\n")
+	local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
+	Bkob_Log_NA(spore_building_def.class)
+	Bkob_Log_NA(self.territorial_range)
+	local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
+	Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
+	local progress_each = DivRound(ep, #spores_near)
+	local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]
+	local spore_res_prog = spore_res.progress
+	local units_to_give = Max(1, DivRound(progress_each, spore_res_prog))
+	Bkob_Log_NA("Nest giving each nearby spore building this much resource units: ", units_to_give)
+	for _, spore in ipairs(spores_near) do
+		spore.MineAmount = spore.MineAmount + (units_to_give * const.ResourceScale)
+	end
 end
 
 function EnhancedTerritorialNest:consume_closest_node()
-    DebugPrint("Nest consuming nearest node\n")
-    self.consume_time = max_int
-    local closest_res = MapFindNearest(self, self, self.territorial_range, "EntityClass", function(thing)
-        if (IsKindOf(thing, 'MineableRock') or IsKindOf(thing, 'Plant')) and not (IsKindOf(thing, 'NestSpore')) then return true end
-    end)
-    Bkob_Log_NA(closest_res)
-    if not closest_res then
-        self:expand()
-        return --we expand instead of consuming
-    end
-    local res
-    local amount
-    if IsKindOf(closest_res, 'Plant') then
-        local res_array = closest_res:GetCutResources() or closest_res:GetHarvestResources()
-        res = res_array[1]['resource']
-        amount = res_array[1]['amount']
-    else
-        res = closest_res.MineResource
-        amount = closest_res.MineAmount
-    end
-    local node_res_units = DivRound(amount, const.ResourceScale)
-    local ep_scale = 1000
-    local progress = DivRound(Resources[res].progress * node_res_units, 10)
-    Bkob_Log_NA("Nest is eating a ", closest_res.class)
-    Bkob_Log_NA('Node has ', node_res_units, ' of ', res, ' in it! which is ', progress, ' EP')
-    local EP_to_give = DivRound(progress, 4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
-    Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ", EP_to_give)
-    DoneObject(closest_res)
-    self:give_ep_to_struct(EP_to_give)
-    local attack_cd = self.attack_delay
-    self.attack_time = self.attack_time - DivRound(attack_cd, 100)
-    self:get_next_consume_time()
+	DebugPrint("Nest consuming nearest node\n")
+	self.consume_time = max_int
+	local closest_res = MapFindNearest(self, self, self.territorial_range, "EntityClass", function(thing)
+		if (IsKindOf(thing, 'MineableRock') or IsKindOf(thing, 'Plant')) and not (IsKindOf(thing, 'NestSpore')) then return true end
+	end)
+	Bkob_Log_NA(closest_res)
+	if not closest_res then
+		self:expand()
+		return --we expand instead of consuming
+	end
+	local res
+	local amount
+	if IsKindOf(closest_res, 'Plant') then
+		local res_array = closest_res:GetCutResources() or closest_res:GetHarvestResources()
+		res = res_array[1]['resource']
+		amount = res_array[1]['amount']
+	else
+		res = closest_res.MineResource
+		amount = closest_res.MineAmount
+	end
+	local node_res_units = DivRound(amount, const.ResourceScale)
+	local ep_scale = 1000
+	local progress = DivRound(Resources[res].progress * node_res_units, 10)
+	Bkob_Log_NA("Nest is eating a ", closest_res.class)
+	Bkob_Log_NA('Node has ', node_res_units, ' of ', res, ' in it! which is ', progress, ' EP')
+	local EP_to_give = DivRound(progress, 4) -- flat 1/4 of EP is stored, the rest are "used" to grow / evolve
+	Bkob_Log_NA("Giving this much EP collectively to the nest nodes: ", EP_to_give)
+	DoneObject(closest_res)
+	self:give_ep_to_struct(EP_to_give)
+	local attack_cd = self.attack_delay
+	self.attack_time = self.attack_time - DivRound(attack_cd, 100)
+	self:get_next_consume_time()
 end
 
 function EnhancedTerritorialNest:GetStoryBitPopupImage()
-    if self.class == 'ShriekerNest' then
-        return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-    elseif self.class == 'ScissorhandsNest' then
-        return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
-    elseif self.class == 'ConsortiumNest' then
-        return 'ConsortiumNestVariant.PNG'
-    else
-        return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-    end
+	if self.class == 'ShriekerNest' then
+		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
+	elseif self.class == 'ScissorhandsNest' then
+		return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
+	elseif self.class == 'ConsortiumNest' then
+		return 'ConsortiumNestVariant.PNG'
+	else
+		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
+	end
 end
 
 -- Closest does 2 things
@@ -380,347 +380,347 @@ end
 -- nest:Dist2D(me) < MulDivRound(3 * distance_to_beat,1,2) is my current way to detect if a nest is "in between" the player and this nest
 
 function EnhancedTerritorialNest:get_proximity()
-    local center = AveragePoint2D(GetValidSurvivorsOnMap())
-    local dist_to_center = self:GetDist2D(center)
-    local rate = 150 * guim  -- 150 meters per thresholdz
-    local prox = DivRound(dist_to_center, rate)
-    prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
-    self.proximity = prox
-    return prox
+	local center = AveragePoint2D(GetValidSurvivorsOnMap())
+	local dist_to_center = self:GetDist2D(center)
+	local rate = 150 * guim     -- 150 meters per thresholdz
+	local prox = DivRound(dist_to_center, rate)
+	prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
+	self.proximity = prox
+	return prox
 end
 
 function EnhancedTerritorialNest:Getui_evo()
-    DebugPrint("Getting the UI % how close to an evo the nest is\n")
-    local option_1 = DivRound(self.attacks_done * 100, self.attacks_to_evo)
-    local option_2 = check_count_and_upgrade(self.elder_class, {}, 100)
-    if option_2 ~= self.elder_class then
-        return 100 -- will show 100% if the EP is already high enough to trigger a "passive" evo
-    else
-        return Max(1, option_1)
-    end
+	DebugPrint("Getting the UI % how close to an evo the nest is\n")
+	local option_1 = DivRound(self.attacks_done * 100, self.attacks_to_evo)
+	local option_2 = check_count_and_upgrade(self.elder_class, {}, 100)
+	if option_2 ~= self.elder_class then
+		return 100 -- will show 100% if the EP is already high enough to trigger a "passive" evo
+	else
+		return Max(1, option_1)
+	end
 end
 
 function EnhancedTerritorialNest:Getui_attack_strength()
-    --local max_possible = per_species_nest_max*10
-    if self.state == 'asleep' then
-        return 10
-    else
-        return self:calculate_attack_strength('player')
-    end
+	--local max_possible = per_species_nest_max*10
+	if self.state == 'asleep' then
+		return 10
+	else
+		return self:calculate_attack_strength('player')
+	end
 end
 
 function EnhancedTerritorialNest:Getui_attack_cap()
-    local player_attack = self:calculate_attack_strength('player')
-    local current_cap = self:get_attack_cap()
-    return DivRound(player_attack * 100, current_cap)
+	local player_attack = self:calculate_attack_strength('player')
+	local current_cap = self:get_attack_cap()
+	return DivRound(player_attack * 100, current_cap)
 end
 
 function EnhancedTerritorialNest:Getui_attack_percent()
-    DebugPrint("Getting the UI % of how close an attack from the nest is\n")
-    local time_till_attack = self.attack_time - GameTime()
-    local num = self.attack_delay - time_till_attack
-    local percent = DivRound(num * 100, self.attack_delay)
-    return Max(1, percent)
+	DebugPrint("Getting the UI % of how close an attack from the nest is\n")
+	local time_till_attack = self.attack_time - GameTime()
+	local num = self.attack_delay - time_till_attack
+	local percent = DivRound(num * 100, self.attack_delay)
+	return Max(1, percent)
 end
 
 function EnhancedTerritorialNest:IsAsleep()
-    return self.state == 'asleep'
+	return self.state == 'asleep'
 end
 
 function EnhancedTerritorialNest:IsAwake()
-    return self.state == 'awake'
+	return self.state == 'awake'
 end
 
 function EnhancedTerritorialNest:IsSleepy()
-    return self.state == 'sleepy'
+	return self.state == 'sleepy'
 end
 
 function EnhancedTerritorialNest:change_nest_herd(force_evo)
-    Bkob_Log("Nest calculating if it needs to upgrade\n")
-    Bkob_Log("Forced Evo: ", force_evo)
-    local elder = self.elder_class
-    local upgraded_flag = false
-    local evo, _, __
-    if force_evo then
-        evo = Find_evolution(g_Classes[elder])
-    else
-        local AdditionalClassList = {}
-        AdditionalClassList[#AdditionalClassList + 1] = { self.adult_class, 150 }
-        AdditionalClassList[#AdditionalClassList + 1] = { self.hatchling_class, 50 }
-        evo, _, __ = check_count_and_upgrade(elder, AdditionalClassList, 100)
-    end
-    if evo == elder and self.adult_class == self.hatchling_class and self.adult_class == self.elder_class then
-        return upgraded_flag
-    end
-    -- base nests will just chain their units down
-    upgraded_flag = true
-    self.hatchling_class = self.adult_class
-    self.adult_class = self.elder_class
-    self.elder_class = evo
-    -- remove any newly-invalid creatures from nest_creatures
-    local removed = false
-    for _, unit in ipairs(self.nest_members) do
-        local class = unit.class
-        if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
-            self:RemoveNestMember(unit)
-            -- This will force spawn a new set of higher tier nests.
-            -- If Nests are left unnattended they can get quite large groups defending it
-        end
-    end
-    if removed then
-        self:UpdateNextSpawnTime()
-    end
-    if upgraded_flag then
-        -- just to make sure we know how close the player is now that they have more stuff
-        self:get_proximity()
-        NA_log_nest_evolved(self)
-        self.attacks_done = 0
-        self.attacks_to_evo = self.attacks_to_evo + 1
-    end
-    return upgraded_flag
+	Bkob_Log("Nest calculating if it needs to upgrade\n")
+	Bkob_Log("Forced Evo: ", force_evo)
+	local elder = self.elder_class
+	local upgraded_flag = false
+	local evo, _, __
+	if force_evo then
+		evo = Find_evolution(g_Classes[elder])
+	else
+		local AdditionalClassList = {}
+		AdditionalClassList[#AdditionalClassList + 1] = { self.adult_class, 150 }
+		AdditionalClassList[#AdditionalClassList + 1] = { self.hatchling_class, 50 }
+		evo, _, __ = check_count_and_upgrade(elder, AdditionalClassList, 100)
+	end
+	if evo == elder and self.adult_class == self.hatchling_class and self.adult_class == self.elder_class then
+		return upgraded_flag
+	end
+	-- base nests will just chain their units down
+	upgraded_flag = true
+	self.hatchling_class = self.adult_class
+	self.adult_class = self.elder_class
+	self.elder_class = evo
+	-- remove any newly-invalid creatures from nest_creatures
+	local removed = false
+	for _, unit in ipairs(self.nest_members) do
+		local class = unit.class
+		if not class == self.elder_class and not class == self.adult_class and not class == self.hatchling_class then
+			self:RemoveNestMember(unit)
+			-- This will force spawn a new set of higher tier nests.
+			-- If Nests are left unnattended they can get quite large groups defending it
+		end
+	end
+	if removed then
+		self:UpdateNextSpawnTime()
+	end
+	if upgraded_flag then
+		-- just to make sure we know how close the player is now that they have more stuff
+		self:get_proximity()
+		NA_log_nest_evolved(self)
+		self.attacks_done = 0
+		self.attacks_to_evo = self.attacks_to_evo + 1
+	end
+	return upgraded_flag
 end
 
 function EnhancedTerritorialNest:can_be_aggressive(who)
-    if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
-        return true
-    elseif who == 'player' and self.attacked_by_player then
-        return true
-    elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
-        return true
-    else
-        return false
-    end
+	if Presets.NestingSpeciesPreset.Default[self.nest_species].aggressive then
+		return true
+	elseif who == 'player' and self.attacked_by_player then
+		return true
+	elseif Presets.NestingSpeciesPreset.Default[who] and self.other_species_attacks[who] then
+		return true
+	else
+		return false
+	end
 end
 
 function EnhancedTerritorialNest:RegisterTarget(unit, time)
-    if unit.player then
-        self.attacked_by_player = true
-    elseif unit.nest then
-        unit.nest.attacked_by_player = true
-    end
-    local tags = unit['UnitTags']
-    if tags and self.state == 'asleep' and tags['Human'] then
-        DebugPrint("Nest registering a human attacker!\n")
-        self:SwitchState('sleepy')
-    end
-    if unit.nest then
-        DebugPrint("Nest registering another nest attacker!\n")
-        if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
-            self:SwitchState('sleepy')
-        end
-    end
+	if unit.player then
+		self.attacked_by_player = true
+	elseif unit.nest then
+		unit.nest.attacked_by_player = true
+	end
+	local tags = unit['UnitTags']
+	if tags and self.state == 'asleep' and tags['Human'] then
+		DebugPrint("Nest registering a human attacker!\n")
+		self:SwitchState('sleepy')
+	end
+	if unit.nest then
+		DebugPrint("Nest registering another nest attacker!\n")
+		if self.state ~= 'awake' and unit.nest.state ~= 'asleep' then
+			self:SwitchState('sleepy')
+		end
+	end
 end
 
 function EnhancedTerritorialNest:set_new_max_hp()
-    DebugPrint("Nest raising max HP\n")
-    local base_hp = 100000
-    local diff = Get_difficulty_offset()
-    local max_possible_hp = base_hp * 100 * diff
-    if self.state == 'awake' then
-        self.MaxHealth = max_possible_hp
-        self.health_regen = 5
-    elseif self.state == 'sleepy' then
-        self.MaxHealth = DivRound(max_possible_hp, 2)
-        self.health_regen = 1
-    elseif self.state == 'asleep' then
-        self.health_regen = 0
-        self.MaxHealth = base_hp
-    end
+	DebugPrint("Nest raising max HP\n")
+	local base_hp = 100000
+	local diff = Get_difficulty_offset()
+	local max_possible_hp = base_hp * 100 * diff
+	if self.state == 'awake' then
+		self.MaxHealth = max_possible_hp
+		self.health_regen = 5
+	elseif self.state == 'sleepy' then
+		self.MaxHealth = DivRound(max_possible_hp, 2)
+		self.health_regen = 1
+	elseif self.state == 'asleep' then
+		self.health_regen = 0
+		self.MaxHealth = base_hp
+	end
 end
 
 function EnhancedTerritorialNest:SwitchState(new_state)
-    DebugPrint("Nest switching it's internal state!\n")
-    new_state = new_state or nil
-    local notif_level = Nest_Notifications
-    if not new_state or new_state == self.state then
-        return
-    end
-    if new_state == 'sleepy' and self.state == 'asleep' then
-        self.sleep_check = GameTime() + const.Scale.months
-        if notif_level == 2 then
-            ForceActivateStoryBit('asleep_too_sleepy', self, true)
-        elseif notif_level == 1 then
-            AddGameNotification("waking_up", nil, nil, { self })
-        end
-    elseif new_state == "asleep" and not (self.state == "awake") then
-        if notif_level == 2 then
-            -- woken up
-            ForceActivateStoryBit('back_to_sleep', self, true)
-        elseif notif_level == 1 then
-            AddGameNotification("back_to_sleep", nil, nil, { self })
-        end
-    end
-    self.state = new_state
-    self:UpdateNextAttackTime()
-    self:set_new_max_hp()
+	DebugPrint("Nest switching it's internal state!\n")
+	new_state = new_state or nil
+	local notif_level = Nest_Notifications
+	if not new_state or new_state == self.state then
+		return
+	end
+	if new_state == 'sleepy' and self.state == 'asleep' then
+		self.sleep_check = GameTime() + const.Scale.months
+		if notif_level == 2 then
+			ForceActivateStoryBit('asleep_too_sleepy', self, true)
+		elseif notif_level == 1 then
+			AddGameNotification("waking_up", nil, nil, { self })
+		end
+	elseif new_state == "asleep" and not (self.state == "awake") then
+		if notif_level == 2 then
+			-- woken up
+			ForceActivateStoryBit('back_to_sleep', self, true)
+		elseif notif_level == 1 then
+			AddGameNotification("back_to_sleep", nil, nil, { self })
+		end
+	end
+	self.state = new_state
+	self:UpdateNextAttackTime()
+	self:set_new_max_hp()
 end
 
 function EnhancedTerritorialNest:get_attack_cap()
-    local base = 50
-    local awake_same_nests = MapCount(true, "TerritorialNest", function(other_nest, this_nest)
-        if IsKindOf(other_nest, this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
-            return true
-        end
-    end, self)
-    local nest_based_cap = awake_same_nests * 10
-    local year = const.Scale.years
-    local time_based_cap = MulDivTrunc(1, GameTime(), year) * 50 + 50
-    if base > time_based_cap and base > nest_based_cap then
-        return base
-    elseif time_based_cap > nest_based_cap then
-        return time_based_cap
-    else
-        return nest_based_cap
-    end
-    return base
+	local base = 50
+	local awake_same_nests = MapCount(true, "TerritorialNest", function(other_nest, this_nest)
+		if IsKindOf(other_nest, this_nest) and not (other_nest.state == 'asleep') and other_nest ~= this_nest then
+			return true
+		end
+	end, self)
+	local nest_based_cap = awake_same_nests * 10
+	local year = const.Scale.years
+	local time_based_cap = MulDivTrunc(1, GameTime(), year) * 50 + 50
+	if base > time_based_cap and base > nest_based_cap then
+		return base
+	elseif time_based_cap > nest_based_cap then
+		return time_based_cap
+	else
+		return nest_based_cap
+	end
+	return base
 end
 
 function EnhancedTerritorialNest:calculate_interspecies_war_strength(who)
-    DebugPrint("Calculating interspecies war strength\n")
-    local nest_EP = 0
-    for _, defender in ipairs(who.nest_members) do
-        nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
-    end
-    local rand = 75 + AsyncRand(75)
-    return nest_EP + rand
+	DebugPrint("Calculating interspecies war strength\n")
+	local nest_EP = 0
+	for _, defender in ipairs(who.nest_members) do
+		nest_EP = nest_EP + g_Classes[defender.class].EventProgressValue
+	end
+	local rand = 75 + AsyncRand(75)
+	return nest_EP + rand
 end
 
 function EnhancedTerritorialNest:calculate_attack_strength(who)
-    DebugPrint("Nest calculating it's attack score\n")
-    if who == 'player' then
-        local max_attack_strength_allowed = self:get_attack_cap()
-        local base_strength = self.base_strength or 20
-        local diff_increase
-        if Get_difficulty_offset() > 5 then
-            diff_increase = 10
-        else
-            diff_increase = 0
-        end
-        local species = get_species_from_nest(self.class)
-        local banked = 0
-        local species_banked_aggr = species .. '_banked_aggr'
-        if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
-            banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
-        else
-            DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
-            Nest_Species_Savegame_Stats[self.nest_species] = {}
-            Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
-        end
-        local subsequent_attacks = self.attacks_done * 10
-        local prox_loss = self.proximity * 10
-        local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
-        -- Make sure we don't go below base or above cap
-        local filtered_strength = Max(base_strength, Min(max_attack_strength_allowed, unfiltered_strength))
-        DebugPrint("Desired attack strength: ")
-        DebugPrint(unfiltered_strength)
-        DebugPrint("\nActual attack strength:")
-        DebugPrint(filtered_strength)
-        DebugPrint("\n")
-        return filtered_strength
-    elseif IsKindOf(who, 'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
-        return self:calculate_interspecies_war_strength(who)
-    else
-        return 10
-    end
+	DebugPrint("Nest calculating it's attack score\n")
+	if who == 'player' then
+		local max_attack_strength_allowed = self:get_attack_cap()
+		local base_strength = self.base_strength or 20
+		local diff_increase
+		if Get_difficulty_offset() > 5 then
+			diff_increase = 10
+		else
+			diff_increase = 0
+		end
+		local species = get_species_from_nest(self.class)
+		local banked = 0
+		local species_banked_aggr = species .. '_banked_aggr'
+		if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] then
+			banked = Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr]
+		else
+			DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
+			Nest_Species_Savegame_Stats[self.nest_species] = {}
+			Nest_Species_Savegame_Stats[self.nest_species][species_banked_aggr] = 0
+		end
+		local subsequent_attacks = self.attacks_done * 10
+		local prox_loss = self.proximity * 10
+		local unfiltered_strength = base_strength + banked + subsequent_attacks + diff_increase - prox_loss
+		-- Make sure we don't go below base or above cap
+		local filtered_strength = Max(base_strength, Min(max_attack_strength_allowed, unfiltered_strength))
+		DebugPrint("Desired attack strength: ")
+		DebugPrint(unfiltered_strength)
+		DebugPrint("\nActual attack strength:")
+		DebugPrint(filtered_strength)
+		DebugPrint("\n")
+		return filtered_strength
+	elseif IsKindOf(who, 'EnhancedTerritorialNest') and self.nest_species ~= get_species_from_nest(who.class) then
+		return self:calculate_interspecies_war_strength(who)
+	else
+		return 10
+	end
 end
 
 function nest_find_spawn_fake(spawndef_instance, spawn_class, target)
-    local def = spawn_class and g_Classes[spawn_class]
-    local pfclass = def.pfclass
-    local range = spawndef_instance.nest.max_range
-    local target_retry = 7
-    local x, y
-    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-    local playbox = GetPlayBox()
-    local nest_entity_radius = spawndef_instance.nest:GetRadius()
-    for i = 1, target_retry do
-        x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
-        local temp_pos = point(x, y)
-        local playbox_check = playbox:Dist2(temp_pos) > 1
-        local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-        if playbox_check or under_nest then
-            x = nil
-            target_retry = target_retry - 1
-            range = range * 2
-        else
-            local possible_pos = point(x, y)
-            return possible_pos
-        end
-    end
-    ::continue::
-    dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest, 7))
+	local def = spawn_class and g_Classes[spawn_class]
+	local pfclass = def.pfclass
+	local range = spawndef_instance.nest.max_range
+	local target_retry = 7
+	local x, y
+	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+	local playbox = GetPlayBox()
+	local nest_entity_radius = spawndef_instance.nest:GetRadius()
+	for i = 1, target_retry do
+		x, y = GetRandomPlayablePos(spawndef_instance.nest, range, guim, AsyncRand(), pfclass, def.radius)
+		local temp_pos = point(x, y)
+		local playbox_check = playbox:Dist2(temp_pos) > 1
+		local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+		if playbox_check or under_nest then
+			x = nil
+			target_retry = target_retry - 1
+			range = range * 2
+		else
+			local possible_pos = point(x, y)
+			return possible_pos
+		end
+	end
+	::continue::
+	dbg(spawndef_instance:DbgMarkFailedSpawn(spawndef_instance.nest, 7))
 end
 
 function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
-    --print("Finding spawn point near a nest!")
-    local playbox = GetPlayBox()
-    if not target then
-        --print("Didn't get a target to spawn near!")
-        target = spawndef_instance:ResolveTarget()
-    end
-    local def = spawn_class and g_Classes[spawn_class]
-    local pfclass = def.pfclass
-    local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-    if not pos then print("no pos found!") end
-    local nest_entity_radius = spawndef_instance.nest:GetRadius()
-    local x, y
-    local retry = 10
-    local range = spawndef_instance.nest.max_range
-    local target_radius = 30 * guim
-    while not x and retry > 0 do
-        local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
-        if not spot_closest_to_target then
-            target_radius = target_radius * 2
-        else
-            x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
-            local temp_pos = point(x, y)
-            local playbox_check = playbox:Dist2(temp_pos) > 1
-            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-            if playbox_check or under_nest then
-                x = nil
-                retry = retry - 1
-                range = range * 2
-            else
-                local possible_pos = point(x, y)
-                if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
-                    --print("Found a point!")
-                    return possible_pos
-                else
-                    retry = retry - 1
-                    range = range * 2
-                end
-            end
-        end
-        return nil
-    end
+	--print("Finding spawn point near a nest!")
+	local playbox = GetPlayBox()
+	if not target then
+		--print("Didn't get a target to spawn near!")
+		target = spawndef_instance:ResolveTarget()
+	end
+	local def = spawn_class and g_Classes[spawn_class]
+	local pfclass = def.pfclass
+	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
+	if not pos then print("no pos found!") end
+	local nest_entity_radius = spawndef_instance.nest:GetRadius()
+	local x, y
+	local retry = 10
+	local range = spawndef_instance.nest.max_range
+	local target_radius = 30 * guim
+	while not x and retry > 0 do
+		local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
+		if not spot_closest_to_target then
+			target_radius = target_radius * 2
+		else
+			x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
+			local temp_pos = point(x, y)
+			local playbox_check = playbox:Dist2(temp_pos) > 1
+			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+			if playbox_check or under_nest then
+				x = nil
+				retry = retry - 1
+				range = range * 2
+			else
+				local possible_pos = point(x, y)
+				if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
+					--print("Found a point!")
+					return possible_pos
+				else
+					retry = retry - 1
+					range = range * 2
+				end
+			end
+		end
+		return nil
+	end
 end
 
 local post_spawn_animal = function(self, obj, target, context)
-    obj.CombatHostile = true
-    Msg("SpawnedAnimalThreat", obj)
-    give_nest_speed_effect(obj, self.nest.proximity)
+	obj.CombatHostile = true
+	Msg("SpawnedAnimalThreat", obj)
+	give_nest_speed_effect(obj, self.nest.proximity)
 end
 
 local post_spawn_robot = function(self, obj, target, context)
-    obj:SetInvader(true)
-    Msg("SpawnedAnimalThreat", obj)
-    give_nest_speed_effect(obj, self.nest.proximity)
+	obj:SetInvader(true)
+	Msg("SpawnedAnimalThreat", obj)
+	give_nest_speed_effect(obj, self.nest.proximity)
 end
 
 function give_nest_speed_effect(ob, prox)
-    local robot_flag = false
-    local times = prox or 1
-    if IsKindOf(ob, 'Robot') then
-        robot_flag = true
-    end
-    while times > 0 do
-        if robot_flag then
-            ob:AddRobotCondition('nest_attack_speed_robot', 'mod')
-        else
-            ob:AddHealthCondition('nest_attack_speed', 'mod')
-        end
-        times = times - 1
-    end
+	local robot_flag = false
+	local times = prox or 1
+	if IsKindOf(ob, 'Robot') then
+		robot_flag = true
+	end
+	while times > 0 do
+		if robot_flag then
+			ob:AddRobotCondition('nest_attack_speed_robot', 'mod')
+		else
+			ob:AddHealthCondition('nest_attack_speed', 'mod')
+		end
+		times = times - 1
+	end
 end
 
 --[[
@@ -751,67 +751,67 @@ quadrants[1] = {
 --]]
 
 function EnhancedTerritorialNest:IsQuadrantScouted(quad_no)
-    local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
-    if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
-        return false
-    else
-        return true
-    end
+	local my_species_quad_logs = Nest_scouting_quadrants[quad_no][self.nest_species]
+	if my_species_quad_logs.last_scout == 0 or my_species_quad_logs.last_scout + const.Scale.years > GameTime() then
+		return false
+	else
+		return true
+	end
 end
 
 function EnhancedTerritorialNest:MarkScouted(other_species, time)
-    rawset(self, other_species, time)
+	rawset(self, other_species, time)
 end
 
 function ReportScoutingResults(quad_no, species, objects_to_report, player_found, nest)
-    Reset_quadrant(quad_no, species)
-    if nest.quadrant_scouting then
-        nest.quadrant_scouting = false
-    end
-    local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
-    if player_found then
-        scout_quad_logs['player_presence'] = true
-        DebugPrint("Player presence detected in this quadrant!\n")
-        if nest:IsAsleep() then
-            nest:SwitchState('sleepy')
-        end
-    end
-    scout_quad_logs.last_scout = GameTime()
-    scout_quad_logs['map_objs'] = objects_to_report
-    for _, obj in ipairs(objects_to_report) do
-        if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
-            if scout_quad_logs[that_species] then
-                scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
-                nest:MarkScouted(self.nest_species, GameTime())
-            else
-                scout_quad_logs[that_species] = {}
-                scout_quad_logs[that_species][1] = nest
-            end
-        end
-        scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
-    end
+	Reset_quadrant(quad_no, species)
+	if nest.quadrant_scouting then
+		nest.quadrant_scouting = false
+	end
+	local scout_quad_logs = Nest_scouting_quadrants[quad_no][species]
+	if player_found then
+		scout_quad_logs['player_presence'] = true
+		DebugPrint("Player presence detected in this quadrant!\n")
+		if nest:IsAsleep() then
+			nest:SwitchState('sleepy')
+		end
+	end
+	scout_quad_logs.last_scout = GameTime()
+	scout_quad_logs['map_objs'] = objects_to_report
+	for _, obj in ipairs(objects_to_report) do
+		if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
+			if scout_quad_logs[that_species] then
+				scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
+				nest:MarkScouted(self.nest_species, GameTime())
+			else
+				scout_quad_logs[that_species] = {}
+				scout_quad_logs[that_species][1] = nest
+			end
+		end
+		scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
+	end
 end
 
 -- TODO instead of cheat learning about the quadrant, send out a nesting unit to scout
 function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
-    DebugPrint("Nest is releasing a scouting unit!!\n")
-    local spawn_def = SpawnDefs['Nest_scout_passive']
-    --used by invader to know what quadrant is to be scouted
-    -- And to track if the scout ever returned
-    if self.quadrant_scouting then
-        DebugPrint("Whelp, looks like my last scout is MIA...")
-    end
-    self.quadrant_scouting = quad_no
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.adult_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
-    --[[
+	DebugPrint("Nest is releasing a scouting unit!!\n")
+	local spawn_def = SpawnDefs['Nest_scout_passive']
+	--used by invader to know what quadrant is to be scouted
+	-- And to track if the scout ever returned
+	if self.quadrant_scouting then
+		DebugPrint("Whelp, looks like my last scout is MIA...")
+	end
+	self.quadrant_scouting = quad_no
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.adult_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
+	--[[
 	if not Nest_scouting_quadrants[quad_no] then
 		CreateMapGrid()
 	end
@@ -824,213 +824,213 @@ function EnhancedTerritorialNest:Scout_Specific_Quad(quad_no)
 end
 
 function MegaScout(nest)
-    for i = 1, 25 do
-        nest:Scout_Specific_Quad(i)
-    end
+	for i = 1, 25 do
+		nest:Scout_Specific_Quad(i)
+	end
 end
 
 -- Currently this will just cheat
 -- I want to build out scouting behavior to allow the player to interact with a species learning about the map
 function EnhancedTerritorialNest:scout_nearest_quad()
-    DebugPrint("\nScouting closest usncouted quad!\n")
-    if not self.quadrant then
-        self.quadrant = Get_quadrant_from_obj(self, true)
-    end
-    if not self.nest_species then
-        self.nest_species = get_species_from_nest(self.class)
-    end
-    if not Nest_scouting_quadrants[1] then
-        CreateMapGrid()
-    end
-    local to_scout
-    local shouldnt_scout = {}
-    if not Nest_scouting_quadrants[self.quadrant] then
-        CreateMapGrid()
-    end
-    local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-    if not my_species_quad_logs then
-        CreateMapGrid()
-        my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-    end
-    if my_species_quad_logs.last_scout == 0 then
-        to_scout = self.quadrant
-    elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
-        to_scout = self.quadrant
-        goto continue
-    end
-    shouldnt_scout[#shouldnt_scout + 1] = self.quadrant
-    for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
-        --ignoring diagonals because..... its hard
-        for _, no in ipairs(shouldnt_scout) do
-            for _, q in ipairs(Get_adjacent_quads(no)) do
-                if not table.find(shouldnt_scout, q) then
-                    if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
-                        to_scout = q
-                        goto continue
-                    elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
-                        shouldnt_scout[#shouldnt_scout + 1] = q
-                    else
-                        --print("Whelp, guess Im going to scout quadrant",q,"now!\n")
-                        to_scout = q
-                        goto continue
-                    end
-                end
-            end
-        end
-    end
-    ::continue::
-    if not to_scout then
-        DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
-        return
-    else
-        DebugPrint("I am scouting this quadrant:", to_scout, '\n')
-    end
-    self:Scout_Specific_Quad(to_scout)
+	DebugPrint("\nScouting closest usncouted quad!\n")
+	if not self.quadrant then
+		self.quadrant = Get_quadrant_from_obj(self, true)
+	end
+	if not self.nest_species then
+		self.nest_species = get_species_from_nest(self.class)
+	end
+	if not Nest_scouting_quadrants[1] then
+		CreateMapGrid()
+	end
+	local to_scout
+	local shouldnt_scout = {}
+	if not Nest_scouting_quadrants[self.quadrant] then
+		CreateMapGrid()
+	end
+	local my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+	if not my_species_quad_logs then
+		CreateMapGrid()
+		my_species_quad_logs = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+	end
+	if my_species_quad_logs.last_scout == 0 then
+		to_scout = self.quadrant
+	elseif my_species_quad_logs.last_scout + const.Scale.years < GameTime() then
+		to_scout = self.quadrant
+		goto continue
+	end
+	shouldnt_scout[#shouldnt_scout + 1] = self.quadrant
+	for i = 1, 5 do -- this limits the max scouting range to ~4 quadrants away
+		--ignoring diagonals because..... its hard
+		for _, no in ipairs(shouldnt_scout) do
+			for _, q in ipairs(Get_adjacent_quads(no)) do
+				if not table.find(shouldnt_scout, q) then
+					if Nest_scouting_quadrants[q][self.nest_species].last_scout == 0 then
+						to_scout = q
+						goto continue
+					elseif Nest_scouting_quadrants[q][self.nest_species].last_scout + const.Scale.years > GameTime() then
+						shouldnt_scout[#shouldnt_scout + 1] = q
+					else
+						--print("Whelp, guess Im going to scout quadrant",q,"now!\n")
+						to_scout = q
+						goto continue
+					end
+				end
+			end
+		end
+	end
+	::continue::
+	if not to_scout then
+		DebugPrint("No quadrants within a length of 5 need to be scouted! Omega eating instead!\n")
+		return
+	else
+		DebugPrint("I am scouting this quadrant:", to_scout, '\n')
+	end
+	self:Scout_Specific_Quad(to_scout)
 end
 
 function EnhancedTerritorialNest:nest_attack_player()
-    DebugPrint("Nest is attacking the player directly!\n")
-    local spawn_def = SpawnDefs['nest_attack']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.elder_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    local atk_str = self:calculate_attack_strength('player')
-    spawn_def:ActivateSpawn(t, {}, atk_str)
+	DebugPrint("Nest is attacking the player directly!\n")
+	local spawn_def = SpawnDefs['nest_attack']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.elder_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	local atk_str = self:calculate_attack_strength('player')
+	spawn_def:ActivateSpawn(t, {}, atk_str)
 end
 
 function EnhancedTerritorialNest:nest_attack_non_player(enemy_nest)
-    DebugPrint("Nest is attacking a non player target near it!\n")
-    local spawn_def = SpawnDefs['nest_attack']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.elder_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    print("ACTIVATING SPAWN!")
-    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength(enemy_nest))
+	DebugPrint("Nest is attacking a non player target near it!\n")
+	local spawn_def = SpawnDefs['nest_attack']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.elder_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	print("ACTIVATING SPAWN!")
+	spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength(enemy_nest))
 end
 
 function EnhancedTerritorialNest:nest_support_closest(ally_nest)
-    DebugPrint("Nest is sending support to the closest nest!\n")
-    local spawn_def = SpawnDefs['Support_same_species_passive']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.adult_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    -- Support the specific in-sector ally chosen by GetSupportTarget: target IT so the reinforcement
-    -- spawns near the ally (and does not march across the player's base). Fall back to the SpawnDef's
-    -- own target resolution when called without an explicit ally.
-    local t = ally_nest or spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
+	DebugPrint("Nest is sending support to the closest nest!\n")
+	local spawn_def = SpawnDefs['Support_same_species_passive']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.adult_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	-- Support the specific in-sector ally chosen by GetSupportTarget: target IT so the reinforcement
+	-- spawns near the ally (and does not march across the player's base). Fall back to the SpawnDef's
+	-- own target resolution when called without an explicit ally.
+	local t = ally_nest or spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:overflow_spawn()
-    DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
-    local spawn_def = SpawnDefs['nest_overflow']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.elder_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength())
+	DebugPrint("Nest is overflowing with too much EP and is sending out a strong attack!\n")
+	local spawn_def = SpawnDefs['nest_overflow']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.elder_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.adult_class, 150 }
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, self:calculate_attack_strength())
 end
 
 function EnhancedTerritorialNest:GetUnscoutedQuadrantsWithin(range)
-    range = range or 5
-    local unscouted = {}
-    local processed_quads = {}
-    local distance = 1
-    unscouted[distance] = {}
-    --print("I am in quadrant", self.quadrant,'\n')
-    if self:IsQuadrantScouted(self.quadrant) then
-        local distance_entry = unscouted[distance]
-        distance_entry[#distance_entry + 1] = self.quadrant
-    end
-    processed_quads[#processed_quads + 1] = self.quadrant
-    local temp_processed = {}
-    for i = 1, range do
-        distance = distance + 1
-        -- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
-        unscouted[distance] = table.copy(unscouted[distance - 1])
-        --print("Now checking quadrants at distance ",distance-1,'\n')
-        local distance_entry = unscouted[distance]
-        for _, qu in ipairs(processed_quads) do
-            local adjacent = Get_adjacent_quads(qu)
-            --print("Looking through these: ", adjacent,'\n')
-            for _, qua in ipairs(adjacent) do
-                if not table.find(processed_quads, qua) and not table.find(temp_processed, qua) then
-                    temp_processed[#temp_processed + 1] = qua
-                    local scouted = self:IsQuadrantScouted(qua)
-                    if not scouted then
-                        distance_entry[#distance_entry + 1] = qua
-                    end
-                end
-            end
-        end
-        --print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
-        --print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
-        for _, v in ipairs(temp_processed) do
-            processed_quads[#processed_quads + 1] = v
-        end
-        temp_processed = {}
-    end
-    return unscouted
+	range = range or 5
+	local unscouted = {}
+	local processed_quads = {}
+	local distance = 1
+	unscouted[distance] = {}
+	--print("I am in quadrant", self.quadrant,'\n')
+	if self:IsQuadrantScouted(self.quadrant) then
+		local distance_entry = unscouted[distance]
+		distance_entry[#distance_entry + 1] = self.quadrant
+	end
+	processed_quads[#processed_quads + 1] = self.quadrant
+	local temp_processed = {}
+	for i = 1, range do
+		distance = distance + 1
+		-- to make sure that if we do returned_obj[distance] contains ALL quadrants that distance or less
+		unscouted[distance] = table.copy(unscouted[distance - 1])
+		--print("Now checking quadrants at distance ",distance-1,'\n')
+		local distance_entry = unscouted[distance]
+		for _, qu in ipairs(processed_quads) do
+			local adjacent = Get_adjacent_quads(qu)
+			--print("Looking through these: ", adjacent,'\n')
+			for _, qua in ipairs(adjacent) do
+				if not table.find(processed_quads, qua) and not table.find(temp_processed, qua) then
+					temp_processed[#temp_processed + 1] = qua
+					local scouted = self:IsQuadrantScouted(qua)
+					if not scouted then
+						distance_entry[#distance_entry + 1] = qua
+					end
+				end
+			end
+		end
+		--print("Net new quadrants processed at ", #temp_processed," quadrants at distance ",distance-1,'\n')
+		--print("This many quadrants need scouting at this distance: ",#distance_entry,'\n')
+		for _, v in ipairs(temp_processed) do
+			processed_quads[#processed_quads + 1] = v
+		end
+		temp_processed = {}
+	end
+	return unscouted
 end
 
 function EnhancedTerritorialNest:IsPlayerKnown()
-    local my_species = get_species_from_nest(self.class)
-    for _, quad in ipairs(Nest_scouting_quadrants) do
-        if quad[my_species].player_presence then
-            return true
-        end
-    end
-    return false
+	local my_species = get_species_from_nest(self.class)
+	for _, quad in ipairs(Nest_scouting_quadrants) do
+		if quad[my_species].player_presence then
+			return true
+		end
+	end
+	return false
 end
 
 function EnhancedTerritorialNest:IsCloserToPlayer(other_nest)
-    local compare_point = Get_center_of_survivors()
-    local my_distance = self:GetDist2D(compare_point)
-    local other_distance = other_nest:GetDist2D(compare_point)
-    return my_distance < other_distance
+	local compare_point = Get_center_of_survivors()
+	local my_distance = self:GetDist2D(compare_point)
+	local other_distance = other_nest:GetDist2D(compare_point)
+	return my_distance < other_distance
 end
 
 function EnhancedTerritorialNest:IsClosestToPlayer()
-    --local my_species = get_species_from_nest(self.class)
-    local compare_point = Get_center_of_survivors()
-    --print("Center of survivors is: ",compare_point,'\n')
-    local my_distance = self:GetDist2D(compare_point)
-    --print("I am this far away from it: ",my_distance,'\n')
-    local nest_dist = {}
-    MapForEach("map", self.class, function(nest, compare_point, me)
-        if nest ~= me then
-            nest_dist[#nest_dist + 1] = { nest = nest, dist = nest:GetDist2D(compare_point) }
-        end
-    end, compare_point, self)
-    local closest = self
-    --print(nest_dist,'\n')
-    for _, v in ipairs(nest_dist) do
-        if v.dist < my_distance then
-            closest = v.nest
-        end
-    end
-    return closest == self
+	--local my_species = get_species_from_nest(self.class)
+	local compare_point = Get_center_of_survivors()
+	--print("Center of survivors is: ",compare_point,'\n')
+	local my_distance = self:GetDist2D(compare_point)
+	--print("I am this far away from it: ",my_distance,'\n')
+	local nest_dist = {}
+	MapForEach("map", self.class, function(nest, compare_point, me)
+		if nest ~= me then
+			nest_dist[#nest_dist + 1] = { nest = nest, dist = nest:GetDist2D(compare_point) }
+		end
+	end, compare_point, self)
+	local closest = self
+	--print(nest_dist,'\n')
+	for _, v in ipairs(nest_dist) do
+		if v.dist < my_distance then
+			closest = v.nest
+		end
+	end
+	return closest == self
 end
 
 -- A nest attacks the player only when it is the most-forward of its species; a nest behind a same-species ally sends
@@ -1039,296 +1039,296 @@ end
 -- opposite (on the far side of the player), which is what would march units through the player's base. Returns the ally
 -- nest to support, or false if this nest is the front line.
 function EnhancedTerritorialNest:GetSupportTarget()
-    local center = Get_center_of_survivors()
-    local my_dist = self:GetDist2D(center)
-    local my_bearing = CalcOrientation(center, self:GetPos())
-    local sector = 60 * 60 -- +-60 degrees (HG angles are in 1/60-degree units) -> a 120-degree forward arc
-    local best, best_dist
-    MapForEach("map", self.class, function(nest, me)
-        if nest == me then return end
-        local n_dist = nest:GetDist2D(center)
-        if n_dist >= my_dist then return end                                                     -- only nests ahead of me (closer to the survivors)
-        if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
-        if not best or n_dist < best_dist then
-            best, best_dist = nest, n_dist
-        end
-    end, self)
-    return best or false
+	local center = Get_center_of_survivors()
+	local my_dist = self:GetDist2D(center)
+	local my_bearing = CalcOrientation(center, self:GetPos())
+	local sector = 60 * 60 -- +-60 degrees (HG angles are in 1/60-degree units) -> a 120-degree forward arc
+	local best, best_dist
+	MapForEach("map", self.class, function(nest, me)
+		if nest == me then return end
+		local n_dist = nest:GetDist2D(center)
+		if n_dist >= my_dist then return end                                                           -- only nests ahead of me (closer to the survivors)
+		if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
+		if not best or n_dist < best_dist then
+			best, best_dist = nest, n_dist
+		end
+	end, self)
+	return best or false
 end
 
 function EnhancedTerritorialNest:GetNearbyEnemiesNonPlayer(range)
-    local valid_targets = MapGet(self, range, "TerritorialNest", function(nest, me)
-        if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species
-            and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
-            return true
-        end
-    end, self)
-    local closest = {}
-    for _, target in ipairs(valid_targets) do
-        if table.find(closest, target.nest_species) then
-            closest[target.nest_species] = target
-        else
-            closest[target.nest_species] = {}
-            closest[target.nest_species][1] = target
-        end
-    end
-    range = range or 5
-    local enemy_selection = {}
-    local processed_quads = {}
-    local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
-    for _, species in pairs(my_quad.other_species) do
-        table.insert_unique(enemy_selection, species)
-    end
-    processed_quads[#processed_quads + 1] = self.quadrant
-    local temp_processed = {}
-    for i = 1, range do
-        for _, no in ipairs(processed_quads) do
-            for _, q in ipairs(Get_adjacent_quads(no)) do
-                local this_quad = Nest_scouting_quadrants[q][self.nest_species]
-                if not table.find(processed_quads, q) and not table.find(temp_processed, q) then
-                    temp_processed[#temp_processed + 1] = q
-                    for _, species in pairs(this_quad.other_species) do
-                        table.insert_unique(enemy_selection, species)
-                    end
-                end
-            end
-        end
-        for _, v in ipairs(temp_processed) do
-            processed_quads[#processed_quads + 1] = v
-        end
-        temp_processed = {}
-    end
-    return enemy_selection
+	local valid_targets = MapGet(self, range, "TerritorialNest", function(nest, me)
+		if IsKindOf(nest, "EnhancedTerritorialNest") and get_species_from_nest(nest.class) ~= me.nest_species
+			and nest[me.nest_species] and nest[me.nest_species] + const.Scale.years < GameTime() then
+			return true
+		end
+	end, self)
+	local closest = {}
+	for _, target in ipairs(valid_targets) do
+		if table.find(closest, target.nest_species) then
+			closest[target.nest_species] = target
+		else
+			closest[target.nest_species] = {}
+			closest[target.nest_species][1] = target
+		end
+	end
+	range = range or 5
+	local enemy_selection = {}
+	local processed_quads = {}
+	local my_quad = Nest_scouting_quadrants[self.quadrant][self.nest_species]
+	for _, species in pairs(my_quad.other_species) do
+		table.insert_unique(enemy_selection, species)
+	end
+	processed_quads[#processed_quads + 1] = self.quadrant
+	local temp_processed = {}
+	for i = 1, range do
+		for _, no in ipairs(processed_quads) do
+			for _, q in ipairs(Get_adjacent_quads(no)) do
+				local this_quad = Nest_scouting_quadrants[q][self.nest_species]
+				if not table.find(processed_quads, q) and not table.find(temp_processed, q) then
+					temp_processed[#temp_processed + 1] = q
+					for _, species in pairs(this_quad.other_species) do
+						table.insert_unique(enemy_selection, species)
+					end
+				end
+			end
+		end
+		for _, v in ipairs(temp_processed) do
+			processed_quads[#processed_quads + 1] = v
+		end
+		temp_processed = {}
+	end
+	return enemy_selection
 end
 
 function EnhancedTerritorialNest:ClosestSleepyNest(range)
-    range = range or max_int
-    local closest_sleepy = MapFindMin(self, range, "TerritorialNest", function(nest, me, range)
-        if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
-            return me:GetDist2D(nest)
-        end
-    end, self, range)
-    if closest_sleepy then
-        return closest_sleepy
-    else
-        return false
-    end
+	range = range or max_int
+	local closest_sleepy = MapFindMin(self, range, "TerritorialNest", function(nest, me, range)
+		if nest.nest_species == me.nest_species and nest.state == 'asleep' and me:GetDist2D(nest) < range then
+			return me:GetDist2D(nest)
+		end
+	end, self, range)
+	if closest_sleepy then
+		return closest_sleepy
+	else
+		return false
+	end
 end
 
 function EnhancedTerritorialNest:support_arrived(allied_unit)
-    --print("A unit supporting me has arrived!")
-    local my_strongest_tier = 0
-    if self.state == 'asleep' then
-        --print("This is going to try and wake me up!")
-        if not self.wake_up_alarms then
-            self.wake_up_alarms = 0
-        end
-        self.wake_up_alarms = self.wake_up_alarms + 1
-        local awake = MapCount(true, "TerritorialNest", function(nest, me)
-            if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
-                return true
-            end
-        end, self)
-        -- make it so that each nest needs more units to wake it up
-        local threshold = 1
-        if Faction_aggression_threshold > threshold then
-            threshold = Faction_aggression_threshold
-        end
-        -- This means the first nest only needs a single wake up event
-        local threshold = threshold * awake
-        if self.wake_up_alarms > threshold then
-            --print("It did wake me up!")
-            self:SwitchState('awake')
-        else
-            --print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
-        end
-        goto continue
-    end
-    local hatchling_tier = EE_get_tier(self.hatchling_class)
-    local adult_tier = EE_get_tier(self.adult_class)
-    local elder_tier = EE_get_tier(self.elder_class)
-    local my_best = Max(hatchling_tier, adult_tier, elder_tier)
-    for _, defender in ipairs(self.nest_members) do
-        local d_tier = EE_get_tier(defender.class)
-        if d_tier > my_best then
-            my_best = d_tier
-        end
-    end
-    --print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
-    local compare
-    if allied_unit.class then
-        compare = allied_unit.class
-    else
-        compare = allied_unit.id
-    end
-    --print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
-    if EE_get_tier(compare) > my_best then
-        --print("It is!")
-        self.attacks_done = self.attacks_done + 1
-        if self.attacks_done > self.attacks_to_evo then
-            --print("And it triggered an evolution!")
-            self:change_nest_herd(true)
-        end
-        goto continue
-    else
-        --print("It was not")
-    end
-    --print("Storing this units EP cost in the nearby structrues and reducing attack time!")
-    local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
-    self:give_ep_to_struct(EP_of_unit)
-    local attack_cd = self.attack_delay
-    -- each unit will reduce the attack cd by 5%
-    self.attack_time = self.attack_time - (5 * DivRound(attack_cd, 100))
-    ::continue::
+	--print("A unit supporting me has arrived!")
+	local my_strongest_tier = 0
+	if self.state == 'asleep' then
+		--print("This is going to try and wake me up!")
+		if not self.wake_up_alarms then
+			self.wake_up_alarms = 0
+		end
+		self.wake_up_alarms = self.wake_up_alarms + 1
+		local awake = MapCount(true, "TerritorialNest", function(nest, me)
+			if nest.nest_species == me.nest_species and not (nest.state == 'asleep') then
+				return true
+			end
+		end, self)
+		-- make it so that each nest needs more units to wake it up
+		local threshold = 1
+		if Faction_aggression_threshold > threshold then
+			threshold = Faction_aggression_threshold
+		end
+		-- This means the first nest only needs a single wake up event
+		local threshold = threshold * awake
+		if self.wake_up_alarms > threshold then
+			--print("It did wake me up!")
+			self:SwitchState('awake')
+		else
+			--print("It did not wake me up, I need this many more: ",threshold - self.wake_up_alarms,'\n')
+		end
+		goto continue
+	end
+	local hatchling_tier = EE_get_tier(self.hatchling_class)
+	local adult_tier = EE_get_tier(self.adult_class)
+	local elder_tier = EE_get_tier(self.elder_class)
+	local my_best = Max(hatchling_tier, adult_tier, elder_tier)
+	for _, defender in ipairs(self.nest_members) do
+		local d_tier = EE_get_tier(defender.class)
+		if d_tier > my_best then
+			my_best = d_tier
+		end
+	end
+	--print("Checking if this unit is stronger than my best! My best is: ",my_best,'\n')
+	local compare
+	if allied_unit.class then
+		compare = allied_unit.class
+	else
+		compare = allied_unit.id
+	end
+	--print("This unit is a tier: ",EE_get_tier(compare),' tier unit\n')
+	if EE_get_tier(compare) > my_best then
+		--print("It is!")
+		self.attacks_done = self.attacks_done + 1
+		if self.attacks_done > self.attacks_to_evo then
+			--print("And it triggered an evolution!")
+			self:change_nest_herd(true)
+		end
+		goto continue
+	else
+		--print("It was not")
+	end
+	--print("Storing this units EP cost in the nearby structrues and reducing attack time!")
+	local EP_of_unit = g_Classes[allied_unit.class].EventProgressValue or 0
+	self:give_ep_to_struct(EP_of_unit)
+	local attack_cd = self.attack_delay
+	-- each unit will reduce the attack cd by 5%
+	self.attack_time = self.attack_time - (5 * DivRound(attack_cd, 100))
+	::continue::
 end
 
 function EnhancedTerritorialNest:mega_consume()
-    DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
-    local multiplier = Get_difficulty_offset()
-    for i = 1, 3 * multiplier do
-        self:consume_closest_node()
-    end
+	DebugPrint("Nest is consuming a lot of biomass to speed up it's next attack and evolution!\n")
+	local multiplier = Get_difficulty_offset()
+	for i = 1, 3 * multiplier do
+		self:consume_closest_node()
+	end
 end
 
 function EnhancedTerritorialNest:alert_neighbor(allied_sleepy_nest)
-    DebugPrint("Nest is sending support to the closest nest!\n")
-    local spawn_def = SpawnDefs['Nest_wakeup_alarm']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.SpawnClass = self.adult_class
-    instance.AdditionalClassList = {}
-    instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
+	DebugPrint("Nest is sending support to the closest nest!\n")
+	local spawn_def = SpawnDefs['Nest_wakeup_alarm']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.SpawnClass = self.adult_class
+	instance.AdditionalClassList = {}
+	instance.AdditionalClassList[#instance.AdditionalClassList + 1] = { self.hatchling_class, 50 }
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function EnhancedTerritorialNest:growth_event()
-    DebugPrint("Nest has grown enough to do something!\n")
-    self:UpdateNextAttackTime()
-    self:change_nest_herd()
-    local spawn_def
-    local spawn_def_selection = {}
-    if self.state == 'sleepy' then
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.overflow_spawn }
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.scout_nearest_quad }
-        spawn_def = table.weighted_rand(spawn_def_selection, "weight")
-        spawn_def.fun(self)
-        return
-    end
-    -- ensure quadrant + scouting grid exist before reading them (growth_event lacked the guard
-    -- that scout_nearest_quad has; on a fresh map the grid is uninitialised -> nil-index crash)
-    if not self.quadrant then
-        self.quadrant = Get_quadrant_from_obj(self, true)
-    end
-    if not self.nest_species then
-        self.nest_species = get_species_from_nest(self.class)
-    end
-    if not Nest_scouting_quadrants[self.quadrant] then
-        CreateMapGrid()
-    end
-    local unscouted = self:GetUnscoutedQuadrantsWithin()
-    local my_quad_scouted = #unscouted[1] > 0
-    local unscouted_nearby = unscouted[3]
-    if not my_quad_scouted then
-        spawn_def_selection[#spawn_def_selection + 1] = {
-            weight = 200,
-            fun = self.Scout_Specific_Quad,
-            input = self
-                .quadrant
-        }
-    elseif #unscouted_nearby > 0 then
-        local to_scout = table.weighted_rand(unscouted_nearby, function(entry) return 100 end)
-        spawn_def_selection[#spawn_def_selection + 1] = {
-            weight = (100 * #unscouted_nearby),
-            fun = self
-                .Scout_Specific_Quad,
-            input = to_scout
-        }
-    elseif #unscouted[#unscouted] > 0 then
-        local to_scout = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.Scout_Specific_Quad, input = to_scout }
-    end
-    local attack_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
-    local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
-    if #nearby_enemies > 0 then
-        for _, enemy in ipairs(nearby_enemies) do
-            local weight = 100
-            if enemy.state == 'asleep' then
-                weight = weight * 2
-            end
-            spawn_def_selection[#spawn_def_selection + 1] = {
-                weight = weight,
-                fun = self.nest_attack_non_player,
-                input =
-                    enemy
-            }
-        end
-    end
-    -- note this means if a nest is awaken by another species, it will still be aggressive towards the player
-    if self:IsPlayerKnown() and not self:IsAsleep() and self:can_be_aggressive() then
-        -- Attack the player only if this nest is the front line of its species; if a same-species ally is ahead of us
-        -- toward the survivors AND in roughly our own direction, support it instead. The angular gate stops support
-        -- being sent to a ~180-degree-opposite nest (which would cross the player's base).
-        local support_target = self:GetSupportTarget()
-        if support_target then
-            spawn_def_selection[#spawn_def_selection + 1] = {
-                weight = 150,
-                fun = self.nest_support_closest,
-                input =
-                    support_target
-            }
-        else
-            spawn_def_selection[#spawn_def_selection + 1] = { weight = 300, fun = self.nest_attack_player }
-        end
-    else
-        local scouting
-        if #unscouted[#unscouted] > 0 then
-            scouting = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
-        else
-            -- we force scout the quadrant with the oldest scouted time as a major major backup
-            for i = 1, #Nest_scouting_quadrants do
-                if Nest_scouting_quadrants[i][self.nest_species].last_scout then
-                    scouting = i
-                    break
-                end
-                scouting = unscouted[1][1]
-            end
-        end
-        -- if the player is not known, we ALWAYS want to scout and find them
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.Scout_Specific_Quad, input = scouting }
-    end
-    -- if there is a nest within ~3 quadrant lengths
-    local wake_up_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
-    local sleepy = self:ClosestSleepyNest(wake_up_range)
-    if sleepy then
-        spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.alert_neighbor, input = sleepy }
-    end
-    -- always leave the options to just vomit enemies in the nearby area
-    -- and consume a lot of nearby biomass
-    spawn_def_selection[#spawn_def_selection + 1] = { weight = 10, fun = self.overflow_spawn }
-    spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.mega_consume }
-    spawn_def = table.weighted_rand(spawn_def_selection, "weight")
-    if spawn_def.input then
-        spawn_def.fun(self, spawn_def.input)
-    else
-        spawn_def.fun(self)
-    end
+	DebugPrint("Nest has grown enough to do something!\n")
+	self:UpdateNextAttackTime()
+	self:change_nest_herd()
+	local spawn_def
+	local spawn_def_selection = {}
+	if self.state == 'sleepy' then
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.overflow_spawn }
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.scout_nearest_quad }
+		spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+		spawn_def.fun(self)
+		return
+	end
+	-- ensure quadrant + scouting grid exist before reading them (growth_event lacked the guard
+	-- that scout_nearest_quad has; on a fresh map the grid is uninitialised -> nil-index crash)
+	if not self.quadrant then
+		self.quadrant = Get_quadrant_from_obj(self, true)
+	end
+	if not self.nest_species then
+		self.nest_species = get_species_from_nest(self.class)
+	end
+	if not Nest_scouting_quadrants[self.quadrant] then
+		CreateMapGrid()
+	end
+	local unscouted = self:GetUnscoutedQuadrantsWithin()
+	local my_quad_scouted = #unscouted[1] > 0
+	local unscouted_nearby = unscouted[3]
+	if not my_quad_scouted then
+		spawn_def_selection[#spawn_def_selection + 1] = {
+			weight = 200,
+			fun = self.Scout_Specific_Quad,
+			input = self
+				.quadrant
+		}
+	elseif #unscouted_nearby > 0 then
+		local to_scout = table.weighted_rand(unscouted_nearby, function(entry) return 100 end)
+		spawn_def_selection[#spawn_def_selection + 1] = {
+			weight = (100 * #unscouted_nearby),
+			fun = self
+				.Scout_Specific_Quad,
+			input = to_scout
+		}
+	elseif #unscouted[#unscouted] > 0 then
+		local to_scout = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 15, fun = self.Scout_Specific_Quad, input = to_scout }
+	end
+	local attack_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+	local nearby_enemies = self:GetNearbyEnemiesNonPlayer(attack_range)
+	if #nearby_enemies > 0 then
+		for _, enemy in ipairs(nearby_enemies) do
+			local weight = 100
+			if enemy.state == 'asleep' then
+				weight = weight * 2
+			end
+			spawn_def_selection[#spawn_def_selection + 1] = {
+				weight = weight,
+				fun = self.nest_attack_non_player,
+				input =
+					enemy
+			}
+		end
+	end
+	-- note this means if a nest is awaken by another species, it will still be aggressive towards the player
+	if self:IsPlayerKnown() and not self:IsAsleep() and self:can_be_aggressive() then
+		-- Attack the player only if this nest is the front line of its species; if a same-species ally is ahead of us
+		-- toward the survivors AND in roughly our own direction, support it instead. The angular gate stops support
+		-- being sent to a ~180-degree-opposite nest (which would cross the player's base).
+		local support_target = self:GetSupportTarget()
+		if support_target then
+			spawn_def_selection[#spawn_def_selection + 1] = {
+				weight = 150,
+				fun = self.nest_support_closest,
+				input =
+					support_target
+			}
+		else
+			spawn_def_selection[#spawn_def_selection + 1] = { weight = 300, fun = self.nest_attack_player }
+		end
+	else
+		local scouting
+		if #unscouted[#unscouted] > 0 then
+			scouting = table.weighted_rand(unscouted[#unscouted], function(entry) return 100 end)
+		else
+			-- we force scout the quadrant with the oldest scouted time as a major major backup
+			for i = 1, #Nest_scouting_quadrants do
+				if Nest_scouting_quadrants[i][self.nest_species].last_scout then
+					scouting = i
+					break
+				end
+				scouting = unscouted[1][1]
+			end
+		end
+		-- if the player is not known, we ALWAYS want to scout and find them
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.Scout_Specific_Quad, input = scouting }
+	end
+	-- if there is a nest within ~3 quadrant lengths
+	local wake_up_range = MulDivRound(NA_X_length + NA_Y_length, 3, 2)
+	local sleepy = self:ClosestSleepyNest(wake_up_range)
+	if sleepy then
+		spawn_def_selection[#spawn_def_selection + 1] = { weight = 100, fun = self.alert_neighbor, input = sleepy }
+	end
+	-- always leave the options to just vomit enemies in the nearby area
+	-- and consume a lot of nearby biomass
+	spawn_def_selection[#spawn_def_selection + 1] = { weight = 10, fun = self.overflow_spawn }
+	spawn_def_selection[#spawn_def_selection + 1] = { weight = 50, fun = self.mega_consume }
+	spawn_def = table.weighted_rand(spawn_def_selection, "weight")
+	if spawn_def.input then
+		spawn_def.fun(self, spawn_def.input)
+	else
+		spawn_def.fun(self)
+	end
 end
 
 function EnhancedTerritorialNest:UpdateNextAttackTime()
-    DebugPrint("Nest updating when to attack next\n")
-    local diff = Get_difficulty_offset() - 3
-    self.attack_delay = MoonInstance.AttackCooldownMin +
-        AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
-    if self.state == 'asleep' then self.attack_delay = self.attack_delay * 2 end
-    self.attack_time = GameTime() + self.attack_delay --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
-    DebugPrint("Next attack time:\n")
-    DebugPrint(self.attack_time)
-    DebugPrint("\nGame Time:\n")
-    DebugPrint(GameTime())
-    DebugPrint("\n")
+	DebugPrint("Nest updating when to attack next\n")
+	local diff = Get_difficulty_offset() - 3
+	self.attack_delay = MoonInstance.AttackCooldownMin +
+		AsyncRand(MoonInstance.AttackCooldownMax - MoonInstance.AttackCooldownMin)
+	if self.state == 'asleep' then self.attack_delay = self.attack_delay * 2 end
+	self.attack_time = GameTime() + self.attack_delay --AsyncRand(fastest_attack_allowed,slowest_attack_allowed)
+	DebugPrint("Next attack time:\n")
+	DebugPrint(self.attack_time)
+	DebugPrint("\nGame Time:\n")
+	DebugPrint(GameTime())
+	DebugPrint("\n")
 end
 
 function EnhancedTerritorialNest:TooTiredCheck()
@@ -1336,348 +1336,348 @@ function EnhancedTerritorialNest:TooTiredCheck()
 end
 
 function EnhancedTerritorialNest:OnObjUpdate(time, update_interval)
-    local health = self.Health
-    if health <= 0 then return end
-    if self.attack_time < GameTime() and health > 0 and not self:IsDestroyed() then
-        DebugPrint("Nest is activating!\n")
-        self:growth_event()
-        -- grow_event contains logic to determine what this event really "does"
-    end
-    if self.consume_time < GameTime() then
-        self:consume_closest_node()
-    end
-    if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
-        if self:TooTiredCheck() then
-            self:SwitchState('asleep')
-        else
-            self.sleep_check = GameTime() + const.Scale.months
-        end
-    end
+	local health = self.Health
+	if health <= 0 then return end
+	if self.attack_time < GameTime() and health > 0 and not self:IsDestroyed() then
+		DebugPrint("Nest is activating!\n")
+		self:growth_event()
+		-- grow_event contains logic to determine what this event really "does"
+	end
+	if self.consume_time < GameTime() then
+		self:consume_closest_node()
+	end
+	if self.state ~= 'asleep' and self.sleep_check ~= 0 and self.sleep_check < GameTime() then
+		if self:TooTiredCheck() then
+			self:SwitchState('asleep')
+		else
+			self.sleep_check = GameTime() + const.Scale.months
+		end
+	end
 end
 
 function TerritorialNest:Done()
-    local members = self.nest_members
-    for i = #members, 1, -1 do
-        members[i]:SetNest(false)
-    end
-    DeleteThread(self.engagement_range_thread)
-    self.engagement_range_thread = nil
-    self:RemoveFromLabels(Game)
-    self.attack_time = max_int
+	local members = self.nest_members
+	for i = #members, 1, -1 do
+		members[i]:SetNest(false)
+	end
+	DeleteThread(self.engagement_range_thread)
+	self.engagement_range_thread = nil
+	self:RemoveFromLabels(Game)
+	self.attack_time = max_int
 end
 
 function UnitNesting:OnObjUpdate()
-    local nest = self.nest
-    if not IsValid(nest) then
-        return
-    end
-    local effect = self.NestEffect or ""
-    if effect == "" then
-        return
-    end
-    local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
-    if nest_nearby == self.nest_nearby then
-        return
-    end
-    self:give_nest_effect()
+	local nest = self.nest
+	if not IsValid(nest) then
+		return
+	end
+	local effect = self.NestEffect or ""
+	if effect == "" then
+		return
+	end
+	local nest_nearby = self:IsCloser(nest, nest.territorial_range) or false
+	if nest_nearby == self.nest_nearby then
+		return
+	end
+	self:give_nest_effect()
 end
 
 function UnitNesting:ReportScoutingResult()
-    quadrant = invader.target_quadrant
-    local day = GameTime()
-    local species = invader.location.nest_species
-    local list_of_found = self.observed_objects
-    nest_scouting_quadrants[quadrant][species]['last_scout'] = day
-    -- Override the last scouting report
-    nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
-    nest_scouting_quadrants[quadrant][species]['other_species'] = {}
-    for _, b in ipairs(list_of_found) do
-        local handle = b['handle'] or false
-        if handle then
-            nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs'] + 1] =
-                handle
-            local species = get_species_from_nest(b.class)
-            if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
-                nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
-            end
-            nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species'] + 1] =
-                handle
-        end
-    end
+	quadrant = invader.target_quadrant
+	local day = GameTime()
+	local species = invader.location.nest_species
+	local list_of_found = self.observed_objects
+	nest_scouting_quadrants[quadrant][species]['last_scout'] = day
+	-- Override the last scouting report
+	nest_scouting_quadrants[quadrant][species]['map_objs'] = {}
+	nest_scouting_quadrants[quadrant][species]['other_species'] = {}
+	for _, b in ipairs(list_of_found) do
+		local handle = b['handle'] or false
+		if handle then
+			nest_scouting_quadrants[quadrant][species]['map_objs'][#nest_scouting_quadrants[quadrant][species]['map_objs'] + 1] =
+				handle
+			local species = get_species_from_nest(b.class)
+			if not nest_scouting_quadrants[quadrant][species]['other_species'][species] then
+				nest_scouting_quadrants[quadrant][species]['other_species'][species] = {}
+			end
+			nest_scouting_quadrants[quadrant][species]['other_species'][species][#nest_scouting_quadrants[quadrant][species]['other_species'] + 1] =
+				handle
+		end
+	end
 end
 
 -- override of base game function to give nest effect in case things go wrong
 function TerritorialNest:AddNestMember(member)
-    table.insert(self.nest_members, member)
-    if member.CombatGroup ~= self.CombatGroup then
-        member.CombatGroup = self.CombatGroup
-    end
-    -- mark guardian members as such (they stay close to the nest and protect it if attacked)
-    self:TrySetNestGuardian(member)
-    member:give_nest_effect()
+	table.insert(self.nest_members, member)
+	if member.CombatGroup ~= self.CombatGroup then
+		member.CombatGroup = self.CombatGroup
+	end
+	-- mark guardian members as such (they stay close to the nest and protect it if attacked)
+	self:TrySetNestGuardian(member)
+	member:give_nest_effect()
 end
 
 function UnitNesting:give_nest_effect()
-    if not self.nest then return end
-    local nest = self.nest
-    local give = self:IsCloser(nest, nest.territorial_range)
-    if give then
-        if IsKindOf(self, "Robot") then
-            self:AddRobotCondition('FamiliarGroundRobo', 'mod')
-        else
-            self:AddHealthCondition(self.NestEffect or "", "nest")
-        end
-    elseif IsKindOf(self, "Robot") then
-        self:RemoveRobotCondition('FamiliarGroundRobo', 'mod')
-    else
-        self:RemoveHealthConditions(self.NestEffect or "", "nest")
-    end
+	if not self.nest then return end
+	local nest = self.nest
+	local give = self:IsCloser(nest, nest.territorial_range)
+	if give then
+		if IsKindOf(self, "Robot") then
+			self:AddRobotCondition('FamiliarGroundRobo', 'mod')
+		else
+			self:AddHealthCondition(self.NestEffect or "", "nest")
+		end
+	elseif IsKindOf(self, "Robot") then
+		self:RemoveRobotCondition('FamiliarGroundRobo', 'mod')
+	else
+		self:RemoveHealthConditions(self.NestEffect or "", "nest")
+	end
 end
 
 function UnitNesting:UpdateAttachedUI()
-    if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
-    RemoveAttachedUIToObject(self, 'NestRolePermanent')
-    RemoveAttachedUIToObject(self, 'NestRoleClose')
-    RemoveAttachedUIToObject(self, 'NestRoleFar')
-    local template
-    if NA_NestRoleZoom == 3 then
-        template = 'NestRolePermanent'
-    elseif NA_NestRoleZoom == 2 then
-        template = 'NestRoleFar'
-    elseif NA_NestRoleZoom == 1 then
-        template = 'NestRoleClose'
-    end
-    if template then
-        AddAttachedUIToObject(self, template, 'Task', self)
-    end
+	if (not self.nest and not self:CheckForNewBehaviors()) or NA_NestRoleZoom == 0 then return end
+	RemoveAttachedUIToObject(self, 'NestRolePermanent')
+	RemoveAttachedUIToObject(self, 'NestRoleClose')
+	RemoveAttachedUIToObject(self, 'NestRoleFar')
+	local template
+	if NA_NestRoleZoom == 3 then
+		template = 'NestRolePermanent'
+	elseif NA_NestRoleZoom == 2 then
+		template = 'NestRoleFar'
+	elseif NA_NestRoleZoom == 1 then
+		template = 'NestRoleClose'
+	end
+	if template then
+		AddAttachedUIToObject(self, template, 'Task', self)
+	end
 end
 
 function UnitNesting:GetUIRole()
-    if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
-    if self.hide_UI_on_empty and amount <= 0 then return "" end
-    local name = ''
-    if NA_NestRoleName then
-        name = self:GetHUDName(self)
-    end
-    local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
-    local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
-    local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
-    local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-    local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
-    local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
-    if self.found_player then
-        return T { "<image " .. scout_found_player .. " 1800><name>", name = name }
-    elseif self.scouting then
-        return T { "<image " .. scout .. " 1800><name>", name = name }
-    elseif self.pathing_to then
-        return T { "<image " .. support .. " 1800><name>", name = name }
-    elseif self.nest then
-        local image = defender
-        return T { "<image " .. image .. " 1800><name>", name = name }
-    end
+	if not (self:CheckForNewBehaviors() or self.nest) or self:IsDead() then return end
+	if self.hide_UI_on_empty and amount <= 0 then return "" end
+	local name = ''
+	if NA_NestRoleName then
+		name = self:GetHUDName(self)
+	end
+	local scout = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_scouting.png"
+	local scout_found_player = "Mod/TGkJ3Tu/PicsOritDidntHappen/scout_found_player.png"
+	local support = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_support.png"
+	local defender = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+	local attacker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_attacker.png"
+	local wallbreaker = "Mod/TGkJ3Tu/PicsOritDidntHappen/unitnesting_defender.png"
+	if self.found_player then
+		return T { "<image " .. scout_found_player .. " 1800><name>", name = name }
+	elseif self.scouting then
+		return T { "<image " .. scout .. " 1800><name>", name = name }
+	elseif self.pathing_to then
+		return T { "<image " .. support .. " 1800><name>", name = name }
+	elseif self.nest then
+		local image = defender
+		return T { "<image " .. image .. " 1800><name>", name = name }
+	end
 end
 
 local OG_ShouldShowHUDName = UnitAnimal.ShouldShowHUDName
 function UnitAnimal:ShouldShowHUDName()
-    local base = OG_ShouldShowHUDName(self)
-    if self:CheckForNewBehaviors() or self.nest then return true else return base end
-    --return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
+	local base = OG_ShouldShowHUDName(self)
+	if self:CheckForNewBehaviors() or self.nest then return true else return base end
+	--return GetAccountStorageOptionValue("ShowSurvivorNames") and self.custom_name ~= ""
 end
 
 function UnitNesting:SetNest(nest)
-    nest = nest or false
-    if nest == self.nest then return end
-    local old_nest = self.nest
-    if IsValid(old_nest) then
-        old_nest:RemoveNestMember(self)
-    end
-    self.nest = nest or nil
-    if IsValid(nest) then
-        nest:AddNestMember(self)
-        --self:AddHUDName()
-    end
+	nest = nest or false
+	if nest == self.nest then return end
+	local old_nest = self.nest
+	if IsValid(old_nest) then
+		old_nest:RemoveNestMember(self)
+	end
+	self.nest = nest or nil
+	if IsValid(nest) then
+		nest:AddNestMember(self)
+		--self:AddHUDName()
+	end
 end
 
 function is_inside_of(box, pos)
-    if box:GetDist2D(pos) == 0 then
-        return true
-    else
-        return false
-    end
+	if box:GetDist2D(pos) == 0 then
+		return true
+	else
+		return false
+	end
 end
 
 function TerritorialNest:SpawnAround(class, range, instant, burrowed)
-    local def = class and g_Classes[class]
-    if not def then return end
-    if burrowed and not def.CanBurrowInNest then return end
-    local playbox = GetPlayBox()
-    local pfclass = def.pfclass
-    local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
-    local nest_entity_radius = self:GetRadius()
-    local x, y
-    local retry = 10
-    -- overriding range given because that is usually just 10 meters...
-    range = self.max_range
-    while not x and retry > 0 do
-        x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
-        if x then
-            local temp_pos = point(x, y)
-            local playbox_check = playbox:Dist2(temp_pos) > 1
-            local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
-            if playbox_check or under_nest then
-                x = nil
-                retry = retry - 1
-            else
-                retry = -1
-            end
-        end
-    end
-    if not x then return end
-    if IsKindOf(def, 'Robot') then
-        local spawn_def = SpawnDefs['single_spawn_around_loc']
-        local instance = {}
-        instance.location = self
-        instance.radius = range
-        instance.PostSpawn = function(self, obj, target, context)
-            obj:SetNest(self.location)
-            obj:SetInvader(true)
-        end
-        instance.FindSpawnLoc = function(self, spawn_class, target, context)
-            return point(x, y)
-        end
-        instance.SpawnClass = class
-        spawn_def = spawn_def:CreateInstance(instance)
-        local t = spawn_def:ResolveTarget()
-        spawn_def:ActivateSpawn(t, {}, 100)
-        return true
-    else
-        local obj
-        obj = def:new()
-        obj:SetNest(self)
-        obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360 * 60, "SpawnNestMember"))
-        if not instant then
-            obj.init_with_command = "CmdSpawn"
-        end
-        return obj
-    end
-    -- in case we have changed what combat groups this nest is
-    obj.CombatGroup = self.CombatGroup
-    return false
+	local def = class and g_Classes[class]
+	if not def then return end
+	if burrowed and not def.CanBurrowInNest then return end
+	local playbox = GetPlayBox()
+	local pfclass = def.pfclass
+	local pos = terrain.FindPassableTile(self, const.tfpPassClass, pfclass)
+	local nest_entity_radius = self:GetRadius()
+	local x, y
+	local retry = 10
+	-- overriding range given because that is usually just 10 meters...
+	range = self.max_range
+	while not x and retry > 0 do
+		x, y = GetRandomPlayablePos(pos, range, guim, self:RandSeed("SpawnNestMember"), pfclass, def.radius)
+		if x then
+			local temp_pos = point(x, y)
+			local playbox_check = playbox:Dist2(temp_pos) > 1
+			local under_nest = IsCloser2D(pos, temp_pos, nest_entity_radius)
+			if playbox_check or under_nest then
+				x = nil
+				retry = retry - 1
+			else
+				retry = -1
+			end
+		end
+	end
+	if not x then return end
+	if IsKindOf(def, 'Robot') then
+		local spawn_def = SpawnDefs['single_spawn_around_loc']
+		local instance = {}
+		instance.location = self
+		instance.radius = range
+		instance.PostSpawn = function(self, obj, target, context)
+			obj:SetNest(self.location)
+			obj:SetInvader(true)
+		end
+		instance.FindSpawnLoc = function(self, spawn_class, target, context)
+			return point(x, y)
+		end
+		instance.SpawnClass = class
+		spawn_def = spawn_def:CreateInstance(instance)
+		local t = spawn_def:ResolveTarget()
+		spawn_def:ActivateSpawn(t, {}, 100)
+		return true
+	else
+		local obj
+		obj = def:new()
+		obj:SetNest(self)
+		obj:SetPosAngle(x, y, const.InvalidZ, self:GetAngle() + self:Random(360 * 60, "SpawnNestMember"))
+		if not instant then
+			obj.init_with_command = "CmdSpawn"
+		end
+		return obj
+	end
+	-- in case we have changed what combat groups this nest is
+	obj.CombatGroup = self.CombatGroup
+	return false
 end
 
 function TerritorialNest:Spawn_robot_nestling(x, y, class)
-    local spawn_def = SpawnDefs['Single_Robots']
-    local instance = {}
-    instance.location = self
-    instance.nest = self
-    instance.pos = point(x, y)
-    instance.SpawnClass = class
-    instance.FindSpawnLoc = function(self, spawn_class, target, context)
-        return self.pos
-    end
-    --[[instance.PostSpawn = function(self,obj,target,context)
+	local spawn_def = SpawnDefs['Single_Robots']
+	local instance = {}
+	instance.location = self
+	instance.nest = self
+	instance.pos = point(x, y)
+	instance.SpawnClass = class
+	instance.FindSpawnLoc = function(self, spawn_class, target, context)
+		return self.pos
+	end
+	--[[instance.PostSpawn = function(self,obj,target,context)
 		obj:SetInvader(true)
 		obj:SetNest(self.nest)
 	end--]]
-    spawn_def = spawn_def:CreateInstance(instance)
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
+	spawn_def = spawn_def:CreateInstance(instance)
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 AppendClass.TerritorialNest = {
-    __parents = { "EnhancedTerritorialNest" },
+	__parents = { "EnhancedTerritorialNest" },
 }
 
 -- meta class grouping all spore buildings for easier searching
 -- We do not append ConsortiumSporeDeposit because we define it in the other file with this as a parent already
 DefineClass.NestSpore = {
-    properties = {}
+	properties = {}
 }
 
 AppendClass.ShriekerSporeDeposit = {
-    __parents = { "NestSpore" }
+	__parents = { "NestSpore" }
 }
 
 AppendClass.ScissorhandSporeDeposit = {
-    __parents = { "NestSpore" }
+	__parents = { "NestSpore" }
 }
 
 function count_effects_by_id(target, effect_id)
-    local count = 0
-    for _, effect in ipairs(target.status_effects or empty_table) do
-        if effect.id == effect_id then
-            count = count + 1
-        end
-    end
-    return count
+	local count = 0
+	for _, effect in ipairs(target.status_effects or empty_table) do
+		if effect.id == effect_id then
+			count = count + 1
+		end
+	end
+	return count
 end
 
 function decay_speed(target)
-    local effect_id = 'nest_attack_speed'
-    --[[if IsKindOf(target,'Robot') then
+	local effect_id = 'nest_attack_speed'
+	--[[if IsKindOf(target,'Robot') then
 		effect_id = 'nest_attack_speed_robot'
 		target:RemoveRobotConditions(effect_id, "ReplaceOldest")
 	end--]]
-    local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
-    local distance_to = target:GetDist2D(survivors)
-    local prox = MulDivRound(distance_to, 1, 150 * guim)
-    local count = count_effects_by_id(target, effect_id)
-    while count > prox do
-        if IsKindOf(target, 'Robot') then
-            target:RemoveRobotConditions(effect_id, "ReplaceOldest")
-            count = count_effects_by_id(target, effect_id)
-        else
-            target:RemoveHealthConditions(effect_id, "ReplaceOldest")
-            count = count_effects_by_id(target, effect_id)
-        end
-    end
+	local survivors = AveragePoint2D(GetValidSurvivorsOnMap())
+	local distance_to = target:GetDist2D(survivors)
+	local prox = MulDivRound(distance_to, 1, 150 * guim)
+	local count = count_effects_by_id(target, effect_id)
+	while count > prox do
+		if IsKindOf(target, 'Robot') then
+			target:RemoveRobotConditions(effect_id, "ReplaceOldest")
+			count = count_effects_by_id(target, effect_id)
+		else
+			target:RemoveHealthConditions(effect_id, "ReplaceOldest")
+			count = count_effects_by_id(target, effect_id)
+		end
+	end
 end
 
 function add_delay_to_nests()
-    MapForEach(true, "TerritorialNest", function(nest)
-        if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
-            nest:UpdateNextAttackTime()
-        end
-    end)
+	MapForEach(true, "TerritorialNest", function(nest)
+		if not nest.attack_delay or nest.attack_delay > MoonInstance.AttackCooldownMax then
+			nest:UpdateNextAttackTime()
+		end
+	end)
 end
 
 function clean_up_robots()
-    MapForEach(true, "Robot", function(robot)
-        if not robot.Invader and not robot.command_center then
-            DoneObject(robot)
-        end
-    end)
-    MapForEach(true, "ConsortiumNest", function(nest)
-        local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
-        nest:UpdateTerritoryTerrain(true, count)
-        for i = 1, count do
-            if not nest:SpawnNestMember(true) then
-                break
-            end
-        end
-    end)
+	MapForEach(true, "Robot", function(robot)
+		if not robot.Invader and not robot.command_center then
+			DoneObject(robot)
+		end
+	end)
+	MapForEach(true, "ConsortiumNest", function(nest)
+		local count = nest.adults_max_count + nest.elders_max_count + nest.hatchlings_max_count
+		nest:UpdateTerritoryTerrain(true, count)
+		for i = 1, count do
+			if not nest:SpawnNestMember(true) then
+				break
+			end
+		end
+	end)
 end
 
 function delete_robots()
-    MapDelete("map", "HeavyHostileRobot_LVL1", function(robot, playbox)
-        return is_inside_of(playbox, robot)
-    end, GetPlayBox())
+	MapDelete("map", "HeavyHostileRobot_LVL1", function(robot, playbox)
+		return is_inside_of(playbox, robot)
+	end, GetPlayBox())
 end
 
 function SavegameFixups.EnhancedNestFixes()
-    add_delay_to_nests()
-    clean_up_robots()
-    delete_robots()
+	add_delay_to_nests()
+	clean_up_robots()
+	delete_robots()
 end
 
 function OnMsg.PostLoadGame()
-    delete_robots()
+	delete_robots()
 end
 
 function OnMsg.UpdateNestRoleVisuals()
-    MapForEach('map', 'UnitNesting', function(nest_member)
-        nest_member:UpdateAttachedUI()
-    end)
+	MapForEach('map', 'UnitNesting', function(nest_member)
+		nest_member:UpdateAttachedUI()
+	end)
 end
 
 --[[ Debugging ovverride

--- a/Code/NA_Unit_Invader_Expansion.lua
+++ b/Code/NA_Unit_Invader_Expansion.lua
@@ -42,7 +42,17 @@ function InvaderBehaviourSupport:OnAssign(invader, end_time)
 	invader.pathing_proximity = self.ArrivalDistance or 50000
 	local my_nest_id = invader:GetNestClass()
 	invader.pathing_from = MapFindNearest(invader,true,my_nest_id)
-	invader.pathing_to = MapFindNearest(invader,true,my_nest_id, function(obj, from) if obj ~= from and obj:IsCloserToPlayer(from) then return true end end,invader.pathing_from)
+	-- Destination = nearest same-species nest that is closer to the survivors than the origin AND
+	-- within ~60 degrees of the origin's bearing from the survivor centre. The angular gate (Ark
+	-- Builder's concern) keeps support from walking across the player's base to a ~180-degree-
+	-- opposite nest. Mirrors EnhancedTerritorialNest:GetSupportTarget on the unit side.
+	local center = Get_center_of_survivors()
+	local from_bearing = invader.pathing_from and CalcOrientation(center, invader.pathing_from:GetPos())
+	invader.pathing_to = MapFindNearest(invader,true,my_nest_id, function(obj, from)
+		if obj == from or not obj:IsCloserToPlayer(from) then return end
+		if from_bearing and abs(AngleDiff(from_bearing, CalcOrientation(center, obj:GetPos()))) > 60*60 then return end
+		return true
+	end,invader.pathing_from)
 	invader:UpdateAttachedUI()
 end
 

--- a/Code/NA_Unit_Invader_Expansion.lua
+++ b/Code/NA_Unit_Invader_Expansion.lua
@@ -4,86 +4,86 @@
 -- what a nest gets from being supported is a class function inside of nest expansion
 -- ============================================================================
 DefineClass.InvaderBehaviourSupport = {
-    __parents = { "InvaderBehaviourBase", },
-    properties = {
-        {
-            id = "same_species",
-            name = "Help same species?",
-            help = "Automatically use the species as the primary spawned unit.",
-            editor = "bool",
-            default = true
-        },
-        {
-            id = "support_species",
-            name = "Species to Help",
-            help = "The source nest (can be set automatically)",
-            editor = "choice",
-            default = false,
-            items = function() return Get_species_nests() end,
-            no_edit = function(self) return self.same_species end
-        },
-        {
-            id = "ArrivalDistance",
-            name = "Arrival Distance",
-            help = "Distance to get close to the target nest before considering arrival",
-            editor = "number",
-            default = 50000,
-            scale = "m",
-            min = 5000,
-        },
-    },
-    EditorName = "Go to the second closest nest and support them.",
+	__parents = { "InvaderBehaviourBase", },
+	properties = {
+		{
+			id = "same_species",
+			name = "Help same species?",
+			help = "Automatically use the species as the primary spawned unit.",
+			editor = "bool",
+			default = true
+		},
+		{
+			id = "support_species",
+			name = "Species to Help",
+			help = "The source nest (can be set automatically)",
+			editor = "choice",
+			default = false,
+			items = function() return Get_species_nests() end,
+			no_edit = function(self) return self.same_species end
+		},
+		{
+			id = "ArrivalDistance",
+			name = "Arrival Distance",
+			help = "Distance to get close to the target nest before considering arrival",
+			editor = "number",
+			default = 50000,
+			scale = "m",
+			min = 5000,
+		},
+	},
+	EditorName = "Go to the second closest nest and support them.",
 
-    -- Runtime state
-    support_thread = false,
-    from_nest = false,
-    to_nest = false,
-    arrival_confirmed = false,
+	-- Runtime state
+	support_thread = false,
+	from_nest = false,
+	to_nest = false,
+	arrival_confirmed = false,
 }
 
 function InvaderBehaviourSupport:OnAssign(invader, end_time)
-    Bkob_Log_NA("assinging support behavior!")
-    InvaderBehaviourBase.OnAssign(self, invader, end_time)
-    invader.pathing = true
-    invader.path_until = end_time
-    invader.supporting = true
-    invader.on_arrive = function(invader, target, progress)
-        if IsKindOf(target, "TerritorialNest") then
-            target:support_arrived()
-        end
-        RemoveAttachedUIToObject(invader, 'NestRolePermanent')
-        RemoveAttachedUIToObject(invader, 'NestRoleClose')
-        RemoveAttachedUIToObject(invader, 'NestRoleFar')
-        self:SetCommand("CmdDespawn")
-        return true
-    end
-    invader.pathing_proximity = self.ArrivalDistance or 50000
-    local my_nest_id = invader:GetNestClass()
-    invader.pathing_from = MapFindNearest(invader, true, my_nest_id)
-    -- Destination = nearest same-species nest that is closer to the survivors than the origin AND within ~60 degrees of
-    -- the origin's bearing from the survivor centre. The angular gate keeps support from walking across the player's
-    -- base to a ~180-degree-opposite nest. Mirrors EnhancedTerritorialNest:GetSupportTarget on the unit side.
-    local center = Get_center_of_survivors()
-    local from_bearing = invader.pathing_from and CalcOrientation(center, invader.pathing_from:GetPos())
-    invader.pathing_to = MapFindNearest(invader, true, my_nest_id, function(obj, from)
-        if obj == from or not obj:IsCloserToPlayer(from) then return end
-        if from_bearing and abs(AngleDiff(from_bearing, CalcOrientation(center, obj:GetPos()))) > 60 * 60 then return end
-        return true
-    end, invader.pathing_from)
-    invader:UpdateAttachedUI()
+	Bkob_Log_NA("assinging support behavior!")
+	InvaderBehaviourBase.OnAssign(self, invader, end_time)
+	invader.pathing = true
+	invader.path_until = end_time
+	invader.supporting = true
+	invader.on_arrive = function(invader, target, progress)
+		if IsKindOf(target, "TerritorialNest") then
+			target:support_arrived()
+		end
+		RemoveAttachedUIToObject(invader, 'NestRolePermanent')
+		RemoveAttachedUIToObject(invader, 'NestRoleClose')
+		RemoveAttachedUIToObject(invader, 'NestRoleFar')
+		self:SetCommand("CmdDespawn")
+		return true
+	end
+	invader.pathing_proximity = self.ArrivalDistance or 50000
+	local my_nest_id = invader:GetNestClass()
+	invader.pathing_from = MapFindNearest(invader, true, my_nest_id)
+	-- Destination = nearest same-species nest that is closer to the survivors than the origin AND within ~60 degrees of
+	-- the origin's bearing from the survivor centre. The angular gate keeps support from walking across the player's
+	-- base to a ~180-degree-opposite nest. Mirrors EnhancedTerritorialNest:GetSupportTarget on the unit side.
+	local center = Get_center_of_survivors()
+	local from_bearing = invader.pathing_from and CalcOrientation(center, invader.pathing_from:GetPos())
+	invader.pathing_to = MapFindNearest(invader, true, my_nest_id, function(obj, from)
+		if obj == from or not obj:IsCloserToPlayer(from) then return end
+		if from_bearing and abs(AngleDiff(from_bearing, CalcOrientation(center, obj:GetPos()))) > 60 * 60 then return end
+		return true
+	end, invader.pathing_from)
+	invader:UpdateAttachedUI()
 end
 
 function InvaderBehaviourSupport:OnExpire(invader)
-    Bkob_Log_NA("Expire support behavior!")
-    rawset(invader, 'pathing', nil)
-    rawset(invader, 'path_until', nil)
-    rawset(invader, 'supporting', nil)
-    rawset(invader, 'on_arrive', nil)
-    rawset(invader, 'pathing_proximity', nil)
-    rawset(invader, 'pathing_from', nil)
-    rawset(invader, 'pathing_to', nil)
-    invader:UpdateAttachedUI()
-    return InvaderBehaviourBase.OnExpire(self, invader)
+	Bkob_Log_NA("Expire support behavior!")
+	rawset(invader, 'pathing', nil)
+	rawset(invader, 'path_until', nil)
+	rawset(invader, 'supporting', nil)
+	rawset(invader, 'on_arrive', nil)
+	rawset(invader, 'pathing_proximity', nil)
+	rawset(invader, 'pathing_from', nil)
+	rawset(invader, 'pathing_to', nil)
+	invader:UpdateAttachedUI()
+	return InvaderBehaviourBase.OnExpire(self, invader)
 end
 
 --[[
@@ -91,294 +91,294 @@ end
 Enables non-aggressive movement to the closest object of a certain class
 --]]
 DefineClass.InvaderBehaviourPassiveMove = {
-    __parents = { "InvaderBehaviourBase", },
-    properties = {
-        {
-            id = "target_class",
-            name = "Target Class",
-            help = "Class of the target to move to. If empty, the unit will move to a random point.",
-            editor = "choice",
-            default = "TerritorialNest",
-            items = function(
-                self)
-                return GetSpawnClasses()
-            end,
-        },
-        { id = 'complex_targeting', name = 'Use more complex targeting logic?', help = 'Instead of just picking the closest target, use a more complex logic to pick the target. Currently this is only used for picking the closest target that is also closer to the player than the unit itself.', editor = 'bool',   default = false },
-        {
-            id = 'targeting_function',
-            name = 'Find_Point_to_move_to',
-            help = 'Function to find the point to move to.',
-            editor = "expression",
-            default = function(self, invader, progress) return Get_center_of_survivors() end,
-            params = "self, invader, progress",
-            no_edit = function(self) return not self.complex_targeting end
-        },
-        {
-            id = "on_arrival",
-            name = "OnArrive",
-            help = "Function this unit performs once it arrives at the target.",
-            editor = "expression",
-            default = function(
-                invader, target, progress)
-                return true
-            end,
-            params = "invader, target, progress",
-        },
-        { id = "proximity",         name = "Stop if this close",                help = "When the unit is this many meters close to the target, trigger the on_arrival function and interrupt behavior.",                                                                                              editor = "number", default = 50000, scale = "m", min = 5000, },
-    },
-    EditorName = "Passive walk to closest target",
+	__parents = { "InvaderBehaviourBase", },
+	properties = {
+		{
+			id = "target_class",
+			name = "Target Class",
+			help = "Class of the target to move to. If empty, the unit will move to a random point.",
+			editor = "choice",
+			default = "TerritorialNest",
+			items = function(
+				self)
+				return GetSpawnClasses()
+			end,
+		},
+		{ id = 'complex_targeting', name = 'Use more complex targeting logic?', help = 'Instead of just picking the closest target, use a more complex logic to pick the target. Currently this is only used for picking the closest target that is also closer to the player than the unit itself.', editor = 'bool',   default = false },
+		{
+			id = 'targeting_function',
+			name = 'Find_Point_to_move_to',
+			help = 'Function to find the point to move to.',
+			editor = "expression",
+			default = function(self, invader, progress) return Get_center_of_survivors() end,
+			params = "self, invader, progress",
+			no_edit = function(self) return not self.complex_targeting end
+		},
+		{
+			id = "on_arrival",
+			name = "OnArrive",
+			help = "Function this unit performs once it arrives at the target.",
+			editor = "expression",
+			default = function(
+				invader, target, progress)
+				return true
+			end,
+			params = "invader, target, progress",
+		},
+		{ id = "proximity",         name = "Stop if this close",                help = "When the unit is this many meters close to the target, trigger the on_arrival function and interrupt behavior.",                                                                                              editor = "number", default = 50000, scale = "m", min = 5000, },
+	},
+	EditorName = "Passive walk to closest target",
 }
 
 function InvaderBehaviourPassiveMove:OnAssign(invader, end_time)
-    InvaderBehaviourBase.OnAssign(self, invader, end_time)
-    invader.pathing = true
-    invader.path_until = end_time
-    invader.on_arrive = self.on_arrival
-    invader.pathing_proximity = self.proximity
-    if self.complex_targeting then
-        --print("Having to calculate complex place to move too!")
-        local target = self.targeting_function(self, invader, EventProgress)
-        --print(target)
-        --print(target.class)
-        invader.pathing_to = target
-    else
-        invader.pathing_to = MapFindNearest('map', invader, true, self.target_class)
-    end
-    invader:UpdateAttachedUI()
+	InvaderBehaviourBase.OnAssign(self, invader, end_time)
+	invader.pathing = true
+	invader.path_until = end_time
+	invader.on_arrive = self.on_arrival
+	invader.pathing_proximity = self.proximity
+	if self.complex_targeting then
+		--print("Having to calculate complex place to move too!")
+		local target = self.targeting_function(self, invader, EventProgress)
+		--print(target)
+		--print(target.class)
+		invader.pathing_to = target
+	else
+		invader.pathing_to = MapFindNearest('map', invader, true, self.target_class)
+	end
+	invader:UpdateAttachedUI()
 end
 
 function InvaderBehaviourPassiveMove:OnExpire(invader)
-    rawset(invader, 'pathing', nil)
-    rawset(invader, 'path_until', nil)
-    rawset(invader, 'on_arrive', nil)
-    rawset(invader, 'pathing_proximity', nil)
-    rawset(invader, 'pathing_to', nil)
-    return InvaderBehaviourBase.OnExpire(self, invader)
+	rawset(invader, 'pathing', nil)
+	rawset(invader, 'path_until', nil)
+	rawset(invader, 'on_arrive', nil)
+	rawset(invader, 'pathing_proximity', nil)
+	rawset(invader, 'pathing_to', nil)
+	return InvaderBehaviourBase.OnExpire(self, invader)
 end
 
 --test
 function EnhancedTerritorialNest:new_behavior_qa()
-    --print("Testing new behaviors!")
-    local spawn_def
-    spawn_def = SpawnDefs['passive_move']
-    local instance = {}
-    instance.nest = self
-    spawn_def = spawn_def:CreateInstance(instance)
-    --print("Triggering spawndef!")
-    local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t, {}, 100)
+	--print("Testing new behaviors!")
+	local spawn_def
+	spawn_def = SpawnDefs['passive_move']
+	local instance = {}
+	instance.nest = self
+	spawn_def = spawn_def:CreateInstance(instance)
+	--print("Triggering spawndef!")
+	local t = spawn_def:ResolveTarget()
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function UnitInvader:FindNextScoutingPoint()
-    local valid_point = false
-    print("Trying to find a spot in quadrant,")
-    local box = Get_box_from_quadrant(self.target_quadrant)
-    local retry = 10
-    local range = self.pathing_proximity or (15 * guim)
-    while (retry > 0 and not valid_point) do
-        valid_point = self:FindValidScoutingPoint(box, self.scouted_pos, range)
-        retry = retry - 1
-        range = range + 5 * guim
-    end
-    if valid_point then
-        return valid_point
-    else
-        ForceActivateStoryBit('unable_to_scout', self, true)
-        self.pathing = false
-        return
-    end
+	local valid_point = false
+	print("Trying to find a spot in quadrant,")
+	local box = Get_box_from_quadrant(self.target_quadrant)
+	local retry = 10
+	local range = self.pathing_proximity or (15 * guim)
+	while (retry > 0 and not valid_point) do
+		valid_point = self:FindValidScoutingPoint(box, self.scouted_pos, range)
+		retry = retry - 1
+		range = range + 5 * guim
+	end
+	if valid_point then
+		return valid_point
+	else
+		ForceActivateStoryBit('unable_to_scout', self, true)
+		self.pathing = false
+		return
+	end
 end
 
 function UnitInvader:FindValidScoutingPoint(box_area, scouted_points, min_dist)
-    -- early validation identical to previous implementation
-    if not box_area or min_dist <= 0 then
-        return false
-    end
-    local w = box_area:maxx() - box_area:minx()
-    local h = box_area:maxy() - box_area:miny()
-    if w < min_dist * 2 and h < min_dist * 2 then
-        return false
-    end
+	-- early validation identical to previous implementation
+	if not box_area or min_dist <= 0 then
+		return false
+	end
+	local w = box_area:maxx() - box_area:minx()
+	local h = box_area:maxy() - box_area:miny()
+	if w < min_dist * 2 and h < min_dist * 2 then
+		return false
+	end
 
-    scouted_points = scouted_points or {}
-    local min_sq = min_dist * min_dist
+	scouted_points = scouted_points or {}
+	local min_sq = min_dist * min_dist
 
-    local my_pfclass = self:GetPfClass()
-    -- origin for connectivity: try to find a passable tile near the centre.
-    local my_pos = terrain.FindPassable(self, my_pfclass)
+	local my_pfclass = self:GetPfClass()
+	-- origin for connectivity: try to find a passable tile near the centre.
+	local my_pos = terrain.FindPassable(self, my_pfclass)
 
-    local function filter(x, y)
-        for _, pt in ipairs(scouted_points) do
-            local dx = x - pt:x()
-            local dy = y - pt:y()
-            if dx * dx + dy * dy < min_sq then
-                return false
-            end
-        end
-        if box_area:Dist2D(point(x, y)) > 0 then
-            return false
-        end
-        return true
-    end
+	local function filter(x, y)
+		for _, pt in ipairs(scouted_points) do
+			local dx = x - pt:x()
+			local dy = y - pt:y()
+			if dx * dx + dy * dy < min_sq then
+				return false
+			end
+		end
+		if box_area:Dist2D(point(x, y)) > 0 then
+			return false
+		end
+		return true
+	end
 
-    -- use ConnectivityRandomTile instead of manual loop. the function will
-    -- perform its own randomised attempts and respects connectivity; the final
-    -- argument is our filter defined above.
-    local seed = AsyncRand()
-    local retries = 4096
-    -- ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096, filter_far_from_nest)
-    local pos = ConnectivityRandomTile(seed, my_pos, my_pos, max_int, 0, my_pfclass, retries, filter)
-    --Get_box_from_quadrant(12):Dist2D(point(906300,17715500))
-    if not pos then
-        return false
-    end
-    print(box_area:Dist2D(pos))
-    return pos
+	-- use ConnectivityRandomTile instead of manual loop. the function will
+	-- perform its own randomised attempts and respects connectivity; the final
+	-- argument is our filter defined above.
+	local seed = AsyncRand()
+	local retries = 4096
+	-- ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096, filter_far_from_nest)
+	local pos = ConnectivityRandomTile(seed, my_pos, my_pos, max_int, 0, my_pfclass, retries, filter)
+	--Get_box_from_quadrant(12):Dist2D(point(906300,17715500))
+	if not pos then
+		return false
+	end
+	print(box_area:Dist2D(pos))
+	return pos
 end
 
 function UnitInvader:Get_quadrant_to_scout()
-    local my_quad = Get_quadrant_from_obj(self)
-    local my_nesting_species = self:Get_Nesting_Species()
-    if not my_nesting_species then return my_quad end
-    local nest_logs = G_nest_scout_logs[my_nesting_species].quadrants or {}
-    -- Try to scout where I am
-    if not nest_logs[my_quad] or (GameTime() - nest_logs[my_quad]) < year_duration * 2 then
-        return Collapse_quad(my_quad)
-    else
-        local retry = 2
-        local tried_quads = {}
-        tried_quads[Collapse_quad(my_quad)] = true
-        while retry > 0 do
-            for quad in ipairs(table.keys(tried_quads)) do
-                local adjacent = Get_adjacent_quads(Uncollapse_quad(quad))
-                for _, quad in ipairs(adjacent) do
-                    if not nest_logs[quad] or (GameTime() - nest_logs[quad]) < year_duration * 2 then
-                        return Collapse_quad(quad)
-                    else
-                        tried_quads[quad] = true
-                    end
-                end
-                retry = retry - 1
-            end
-        end
-    end
+	local my_quad = Get_quadrant_from_obj(self)
+	local my_nesting_species = self:Get_Nesting_Species()
+	if not my_nesting_species then return my_quad end
+	local nest_logs = G_nest_scout_logs[my_nesting_species].quadrants or {}
+	-- Try to scout where I am
+	if not nest_logs[my_quad] or (GameTime() - nest_logs[my_quad]) < year_duration * 2 then
+		return Collapse_quad(my_quad)
+	else
+		local retry = 2
+		local tried_quads = {}
+		tried_quads[Collapse_quad(my_quad)] = true
+		while retry > 0 do
+			for quad in ipairs(table.keys(tried_quads)) do
+				local adjacent = Get_adjacent_quads(Uncollapse_quad(quad))
+				for _, quad in ipairs(adjacent) do
+					if not nest_logs[quad] or (GameTime() - nest_logs[quad]) < year_duration * 2 then
+						return Collapse_quad(quad)
+					else
+						tried_quads[quad] = true
+					end
+				end
+				retry = retry - 1
+			end
+		end
+	end
 end
 
 function UnitInvader:CheckForNewBehaviors()
-    if self.pathing or self.pathing_to or self.scouting or self.wallbreaking then
-        return true
-    end
-    return false
+	if self.pathing or self.pathing_to or self.scouting or self.wallbreaking then
+		return true
+	end
+	return false
 end
 
 --FindObstructionTarget for future wall breaker behavior
 function UnitInvader:InvaderIdle()
-    self.idling = true
-    if self:IsTimeToDespawn() and self:CanDespawn() then
-        self:SetCommand("CmdDespawn")
-        return
-    end
-    local something_new = self:CheckForNewBehaviors()
-    local forced_until = self.forced_aggression_until
-    if something_new then
-        -- pass to make sure we don't force fail due to the below checks
-    elseif not forced_until or self:TryFailForceAggression() then
-        return
-    end
-    Bkob_Log_NA("Checking what we as an invader should do!")
-    if something_new then
-        print("Pathing too:")
-        print(self.pathing_to)
-        print("And I need to be this close:")
-        print(self.pathing_proximity)
-        print("And I am this far away: ")
-        print(self:GetDist2D(self.pathing_to))
-        local close_enough = self:IsCloser(self.pathing_to, self.pathing_proximity)
-        if self.scouting and close_enough then
-            print(
-                "Unit is scouting and is close enough to their curtrent point. Recording surroundings and rolling a enw point!")
-            self:near_scout_point()
-            -- we will have a new pathing_to prop from the above function
-            self:SetCommand("CmdPassiveMove")
-        elseif self.pathing then
-            print('Unit is trying to get to a specific point!')
-            if close_enough then
-                print("And they are close enough!")
-                --print("Invader Idle call detecting we are too close to the target!")
-                self.pathing = false
-                print("Arrived at passive move target!")
-                if self.on_arrive then
-                    local EP = EventProgress
-                    self.on_arrive(self, self.pathing_to, EP)
-                end
-                self.pathing = nil
-                self.pathing_to = nil
-                self:UpdateAttachedUI()
-            end
-            Bkob_Log_NA("Telling unit to start (passively) moving to a target!")
-            self:SetCommand("CmdPassiveMove")
-        end
-    elseif GameTime() >= forced_until then
-        Bkob_Log_NA("Stop attacking!")
-        self:ClearForcedAttack()
-    elseif self.forced_aggression_roam then
-        Bkob_Log_NA("Agrily roaming!")
-        self.forced_aggression_roam = nil
-        self:Roam()
-        return true
-    elseif self:IsAttackSearchActive() then
-        local new_target = self:MarkForcedTarget()
-        if new_target and not self:IsAttackTargetIgnored(new_target) then
-            local range = self:GetMaxAttackRange()
-            if pf.GetLinearDist(self, new_target) > range then
-                self.roam_start_pos = false
-                self:SetCommand("CmdForcedApproach", new_target, range)
-            else
-                self:TryAttackTargetReason("InvaderIdle", new_target)
-            end
-        end
-        local scheduled_time = self.forced_aggression_roam_scheduled
-        if not scheduled_time or scheduled_time > self.roam_at_time then
-            -- move to a new position if no attack target is found
-            self:RoamSchedule(0, 3333)
-            self.forced_aggression_roam_scheduled = self.roam_at_time
-        end
-    end
+	self.idling = true
+	if self:IsTimeToDespawn() and self:CanDespawn() then
+		self:SetCommand("CmdDespawn")
+		return
+	end
+	local something_new = self:CheckForNewBehaviors()
+	local forced_until = self.forced_aggression_until
+	if something_new then
+		-- pass to make sure we don't force fail due to the below checks
+	elseif not forced_until or self:TryFailForceAggression() then
+		return
+	end
+	Bkob_Log_NA("Checking what we as an invader should do!")
+	if something_new then
+		print("Pathing too:")
+		print(self.pathing_to)
+		print("And I need to be this close:")
+		print(self.pathing_proximity)
+		print("And I am this far away: ")
+		print(self:GetDist2D(self.pathing_to))
+		local close_enough = self:IsCloser(self.pathing_to, self.pathing_proximity)
+		if self.scouting and close_enough then
+			print(
+				"Unit is scouting and is close enough to their curtrent point. Recording surroundings and rolling a enw point!")
+			self:near_scout_point()
+			-- we will have a new pathing_to prop from the above function
+			self:SetCommand("CmdPassiveMove")
+		elseif self.pathing then
+			print('Unit is trying to get to a specific point!')
+			if close_enough then
+				print("And they are close enough!")
+				--print("Invader Idle call detecting we are too close to the target!")
+				self.pathing = false
+				print("Arrived at passive move target!")
+				if self.on_arrive then
+					local EP = EventProgress
+					self.on_arrive(self, self.pathing_to, EP)
+				end
+				self.pathing = nil
+				self.pathing_to = nil
+				self:UpdateAttachedUI()
+			end
+			Bkob_Log_NA("Telling unit to start (passively) moving to a target!")
+			self:SetCommand("CmdPassiveMove")
+		end
+	elseif GameTime() >= forced_until then
+		Bkob_Log_NA("Stop attacking!")
+		self:ClearForcedAttack()
+	elseif self.forced_aggression_roam then
+		Bkob_Log_NA("Agrily roaming!")
+		self.forced_aggression_roam = nil
+		self:Roam()
+		return true
+	elseif self:IsAttackSearchActive() then
+		local new_target = self:MarkForcedTarget()
+		if new_target and not self:IsAttackTargetIgnored(new_target) then
+			local range = self:GetMaxAttackRange()
+			if pf.GetLinearDist(self, new_target) > range then
+				self.roam_start_pos = false
+				self:SetCommand("CmdForcedApproach", new_target, range)
+			else
+				self:TryAttackTargetReason("InvaderIdle", new_target)
+			end
+		end
+		local scheduled_time = self.forced_aggression_roam_scheduled
+		if not scheduled_time or scheduled_time > self.roam_at_time then
+			-- move to a new position if no attack target is found
+			self:RoamSchedule(0, 3333)
+			self.forced_aggression_roam_scheduled = self.roam_at_time
+		end
+	end
 end
 
 function UnitInvader:CmdPassiveMove()
-    print("Got told to move passively!")
-    if not self.pathing_to then
-        print("No idea what we are trying to move too!")
-        self.pathing = false
-        return -- no target found
-    end
-    local closests_exact_pos
-    if IsValid(self.pathing_to) then
-        closests_exact_pos = self.pathing_to:GetPos()
-    else
-        closests_exact_pos = self.pathing_to
-    end
-    -- prefer a tile that respects this unit's pfclass and collision
-    local closest_to_dest = terrain.FindPassableTile(closests_exact_pos, const.tfpPassClass, self)
-    if not ConnectivityCheck(self, closest_to_dest) then
-        print("We cannot reach this class....")
-        return
-    end
-    print("Telling myself to GoTo this position:", closest_to_dest)
-    if self:IsCloser(self.pathing_to, self.pathing_proximity) then
-        --print("I am close enough to trigger my on arrive!")
-        if self.on_arrive then
-            local EP = EventProgress
-            --print("And I do have a function of it! Triggering it")
-            self.on_arrive(self, self.pathing_to, EP)
-        end
-        -- This will stop an infinite loop if the movement behavior is still waiting to timeout
-        self.pathing = false
-    else
-        self:Goto(closest_to_dest)
-    end
+	print("Got told to move passively!")
+	if not self.pathing_to then
+		print("No idea what we are trying to move too!")
+		self.pathing = false
+		return -- no target found
+	end
+	local closests_exact_pos
+	if IsValid(self.pathing_to) then
+		closests_exact_pos = self.pathing_to:GetPos()
+	else
+		closests_exact_pos = self.pathing_to
+	end
+	-- prefer a tile that respects this unit's pfclass and collision
+	local closest_to_dest = terrain.FindPassableTile(closests_exact_pos, const.tfpPassClass, self)
+	if not ConnectivityCheck(self, closest_to_dest) then
+		print("We cannot reach this class....")
+		return
+	end
+	print("Telling myself to GoTo this position:", closest_to_dest)
+	if self:IsCloser(self.pathing_to, self.pathing_proximity) then
+		--print("I am close enough to trigger my on arrive!")
+		if self.on_arrive then
+			local EP = EventProgress
+			--print("And I do have a function of it! Triggering it")
+			self.on_arrive(self, self.pathing_to, EP)
+		end
+		-- This will stop an infinite loop if the movement behavior is still waiting to timeout
+		self.pathing = false
+	else
+		self:Goto(closest_to_dest)
+	end
 end
 
 --[[
@@ -386,109 +386,109 @@ end
 Enables a non-aggressive movement to another more complicated location
 00]]
 DefineClass.InvaderBehaviourNestScout = {
-    __parents = { "InvaderBehaviourBase", },
-    properties = {
-        { id = "map_hack",        name = "Give scout map hacks?",                      help = "The scout will always learn of all classes it is looking for in the 4% of the map it is exploring", editor = "bool",   default = false },
-        {
-            id = "log_classes",
-            name = "What class should the unit record?",
-            help = "What is this unit looking for?",
-            editor = "string_list",
-            items = function(
-                self)
-                return GetSpawnClasses()
-            end,
-            default = false
-        },
-        { id = 'distance_points', name = 'Distance between scouting points (in guim)', help = 'Quadrants are approximately 200m x 200m',                                                           editor = 'number', default = 25,   scale = 'm' },
-        {
-            id = "attack_hostile",
-            name = "Is the scout hostile?",
-            help = "Will this unit fight anyone while it is roaming?",
-            editor = "bool",
-            default = false,
-            no_edit = function(
-                self)
-                return self.attack_hostile
-            end
-        },
-        {
-            id = "ForcedGroups",
-            name = "Combat Groups",
-            help =
-            "Define specific combat groups as priority targets. If empty, all groups from the specified combat classes will be targeted. If no classes are specified too, the unit will be aggressive towards everything, but its own.",
-            editor = "set",
-            default = set("Humans"),
-            items = function(
-                self)
-                return CombatGroupsSetItems()
-            end,
-            no_edit = function(
-                self)
-                return self.attack_hostile
-            end
-        },
-        {
-            id = "SearchLabels",
-            name = "Search Labels",
-            help =
-            "Define a label where to search for the targets. If missing, the search will be limited to a radius around.",
-            editor = "string_list",
-            default = { "Survivors" },
-            item_default = "",
-            items = function(
-                self)
-                return BuildingLabelComboItems()
-            end,
-            no_edit = function(
-                self)
-                return self.attack_hostile
-            end
-        },
-        {
-            id = "SearchRadius",
-            name = "Search Radius",
-            help = "Search range for the targets if no search label is defined. Leave 0 to use the invader's default.",
-            editor = "number",
-            default = 200000,
-            scale = "m",
-            no_edit = function(
-                self)
-                return self.attack_hostile
-            end
-        },
-        {
-            id = "ForcedClasses",
-            name = "Target Classes",
-            help =
-            "Define specific combat classes as priority targets. If empty, all classes with the specified combat groups will be targeted. If no groups are specified too, the unit will be aggressive towards everything, but its own..",
-            editor = "string_list",
-            default = {},
-            item_default = "",
-            items = function(
-                self)
-                return ClassDescendantsList("AttackableObject")
-            end,
-            no_edit = function(
-                self)
-                return self.attack_hostile
-            end
-        },
-        {
-            id = "KeepFormation",
-            name = "Keep Group Formation",
-            help = "I true, the invaders will approach keeping close to each other.",
-            editor = "bool",
-            default = true,
-            no_edit = function(
-                self)
-                return self.attack_hostile
-            end
-        },
-    },
-    EditorName = "Scout around the map (based on species logs)",
-    Documentation =
-    [[The <style GedHighlight>Scouting behavior</style> is to be used by nests when trying to find the player's stuff or another species territorial nest.
+	__parents = { "InvaderBehaviourBase", },
+	properties = {
+		{ id = "map_hack",        name = "Give scout map hacks?",                      help = "The scout will always learn of all classes it is looking for in the 4% of the map it is exploring", editor = "bool",   default = false },
+		{
+			id = "log_classes",
+			name = "What class should the unit record?",
+			help = "What is this unit looking for?",
+			editor = "string_list",
+			items = function(
+				self)
+				return GetSpawnClasses()
+			end,
+			default = false
+		},
+		{ id = 'distance_points', name = 'Distance between scouting points (in guim)', help = 'Quadrants are approximately 200m x 200m',                                                           editor = 'number', default = 25,   scale = 'm' },
+		{
+			id = "attack_hostile",
+			name = "Is the scout hostile?",
+			help = "Will this unit fight anyone while it is roaming?",
+			editor = "bool",
+			default = false,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "ForcedGroups",
+			name = "Combat Groups",
+			help =
+			"Define specific combat groups as priority targets. If empty, all groups from the specified combat classes will be targeted. If no classes are specified too, the unit will be aggressive towards everything, but its own.",
+			editor = "set",
+			default = set("Humans"),
+			items = function(
+				self)
+				return CombatGroupsSetItems()
+			end,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "SearchLabels",
+			name = "Search Labels",
+			help =
+			"Define a label where to search for the targets. If missing, the search will be limited to a radius around.",
+			editor = "string_list",
+			default = { "Survivors" },
+			item_default = "",
+			items = function(
+				self)
+				return BuildingLabelComboItems()
+			end,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "SearchRadius",
+			name = "Search Radius",
+			help = "Search range for the targets if no search label is defined. Leave 0 to use the invader's default.",
+			editor = "number",
+			default = 200000,
+			scale = "m",
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "ForcedClasses",
+			name = "Target Classes",
+			help =
+			"Define specific combat classes as priority targets. If empty, all classes with the specified combat groups will be targeted. If no groups are specified too, the unit will be aggressive towards everything, but its own..",
+			editor = "string_list",
+			default = {},
+			item_default = "",
+			items = function(
+				self)
+				return ClassDescendantsList("AttackableObject")
+			end,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "KeepFormation",
+			name = "Keep Group Formation",
+			help = "I true, the invaders will approach keeping close to each other.",
+			editor = "bool",
+			default = true,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+	},
+	EditorName = "Scout around the map (based on species logs)",
+	Documentation =
+	[[The <style GedHighlight>Scouting behavior</style> is to be used by nests when trying to find the player's stuff or another species territorial nest.
 Scouts will always log anything owned by the player (Buildings, Survivors, Robots, etc...), but can also log any other spawn class if specified.
 Scouting code splits the map into 200m x 200m quadrants, and the unit will pick the closest quadrant that has not been scouted in the last year by its species to explore.
 Scouting behavior:
@@ -505,140 +505,140 @@ Note 2: If <style GedHighlight>map_hack</style> is enabled, the scout will auto 
 --self:SetCommand("CmdForcedApproach", new_target, range)
 
 function InvaderBehaviourNestScout:OnAssign(invader, end_time)
-    if self.attack_hostile then
-        invader:ForceAggressionStart(self.ForcedGroups, self.ForcedClasses, end_time, self.SearchLabels,
-            self.SearchRadius, self.KeepFormation)
-    end
-    -- Initialize scouting state
-    invader.scouting = true
-    invader.observed_objects = {}
-    invader.scouted_pos = {}
-    if not invader.from_nest or not invader.from_nest.quadrant_scouting then
-        invader.target_quadrant = invader:Get_quadrant_to_scout()
-    else
-        invader.target_quadrant = invader.from_nest.quadrant_scouting
-    end
-    invader.pathing = true
-    invader.pathing_to = invader:FindNextScoutingPoint(invader.target_quadrant, invader.scouted_pos)
-    --invader.min_scout_distance = self.distance_points * guim
-    invader.looking_for = self.log_classes
-    invader.map_hack = self.map_hack
-    invader.player_found = false
-    invader.pathing_proximity = 5000
-    -- grant a buff to all scouts, making them able to see past 30 meters
-    if invader:GetDetectionRange() < 30 * guim then
-        if IsKindOf(invader, 'Robot') then
-            invader:AddRobotCondition('scouting_sight_buff_robot', 'mod')
-        else
-            invader:AddHealthCondition('scouting_sight_buff_animal', 'mod')
-        end
-    end
-    if self.map_hack then
-        invader.observed_objects = Get_objs_in_quad(invader.target_quadrant, self.log_classes)
-    end
-    invader:UpdateAttachedUI()
+	if self.attack_hostile then
+		invader:ForceAggressionStart(self.ForcedGroups, self.ForcedClasses, end_time, self.SearchLabels,
+			self.SearchRadius, self.KeepFormation)
+	end
+	-- Initialize scouting state
+	invader.scouting = true
+	invader.observed_objects = {}
+	invader.scouted_pos = {}
+	if not invader.from_nest or not invader.from_nest.quadrant_scouting then
+		invader.target_quadrant = invader:Get_quadrant_to_scout()
+	else
+		invader.target_quadrant = invader.from_nest.quadrant_scouting
+	end
+	invader.pathing = true
+	invader.pathing_to = invader:FindNextScoutingPoint(invader.target_quadrant, invader.scouted_pos)
+	--invader.min_scout_distance = self.distance_points * guim
+	invader.looking_for = self.log_classes
+	invader.map_hack = self.map_hack
+	invader.player_found = false
+	invader.pathing_proximity = 5000
+	-- grant a buff to all scouts, making them able to see past 30 meters
+	if invader:GetDetectionRange() < 30 * guim then
+		if IsKindOf(invader, 'Robot') then
+			invader:AddRobotCondition('scouting_sight_buff_robot', 'mod')
+		else
+			invader:AddHealthCondition('scouting_sight_buff_animal', 'mod')
+		end
+	end
+	if self.map_hack then
+		invader.observed_objects = Get_objs_in_quad(invader.target_quadrant, self.log_classes)
+	end
+	invader:UpdateAttachedUI()
 end
 
 function InvaderBehaviourNestScout:OnExpire(invader)
-    rawset(invader, 'scouting', nil)
-    rawset(invader, 'observed_objects', nil)
-    rawset(invader, 'scouted_pos', nil)
-    rawset(invader, 'target_quadrant', nil)
-    rawset(invader, 'pathing_to', nil)
-    --rawset(invader, 'min_scout_distance', nil)
-    rawset(invader, 'looking_for', nil)
-    rawset(invader, 'map_hack', nil)
-    if IsKindOf(invader, 'Robot') then
-        invader:RemoveRobotCondition('scouting_sight_buff_animal')
-    else
-        invader:RemoveHealthCondition('scouting_sight_buff_animal')
-    end
-    invader:UpdateAttachedUI()
-    return InvaderBehaviourBase.OnExpire(self, invader)
+	rawset(invader, 'scouting', nil)
+	rawset(invader, 'observed_objects', nil)
+	rawset(invader, 'scouted_pos', nil)
+	rawset(invader, 'target_quadrant', nil)
+	rawset(invader, 'pathing_to', nil)
+	--rawset(invader, 'min_scout_distance', nil)
+	rawset(invader, 'looking_for', nil)
+	rawset(invader, 'map_hack', nil)
+	if IsKindOf(invader, 'Robot') then
+		invader:RemoveRobotCondition('scouting_sight_buff_animal')
+	else
+		invader:RemoveHealthCondition('scouting_sight_buff_animal')
+	end
+	invader:UpdateAttachedUI()
+	return InvaderBehaviourBase.OnExpire(self, invader)
 end
 
 local detect_enum_flags = const.efVisible | const.efUnit | const.efAttackable
 local detect_game_flags = const.gofDamageable | const.gofSyncObject
 
 local function Scout_Detect(unit, self, detected_units)
-    --DbgAddSegment(unit, self, RandColor(self.handle))
-    if self == unit
-        or not unit.detect_spot
-        or not self:IsDetectionTarget(unit)
-        or not self:CanDetect(unit) then
-        return
-    end
-    for _, v in ipairs(self.looking_for) do
-        if IsKindOf(unit, v) then
-            print("I detected this, a thing I'm looking for: " .. unit.class)
-            table.insert_unique(self.observed_objects, unit)
-        end
-    end
-    if unit.player then
-        print("I detected something owned by the player!")
-        self.player_found = true
-    end
+	--DbgAddSegment(unit, self, RandColor(self.handle))
+	if self == unit
+		or not unit.detect_spot
+		or not self:IsDetectionTarget(unit)
+		or not self:CanDetect(unit) then
+		return
+	end
+	for _, v in ipairs(self.looking_for) do
+		if IsKindOf(unit, v) then
+			print("I detected this, a thing I'm looking for: " .. unit.class)
+			table.insert_unique(self.observed_objects, unit)
+		end
+	end
+	if unit.player then
+		print("I detected something owned by the player!")
+		self.player_found = true
+	end
 end
 
 function UnitDetection:detect_nearby()
-    local units = self.detected_units
-    if not self.detect_spot or not self:IsDetectionEnabled() then
-        if units then
-            self:ClearDetectionCache()
-        end
-        return
-    end
-    local seed = self:RandSeed("DetectUnits")
-    if not units then
-        units = {}
-        self.detected_units = units
-    end
-    local range = self:GetDetectionRange()
-    self:GetMaxCollisionRadius(range + MaxLosTargetRadius) -- cache information about the surrounding, boosting the surf enum effectiveness
-    self.los_checks = self
-        .los_max_checks                                 -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
-    local collection_idx = self:GetDetectCollectionIdx()
-    MapForEach(self, range, "!collection", collection_idx, "shuffle", seed, "UnitDetection", detect_enum_flags, nil,
-        detect_game_flags, Scout_Detect, self, units)
-    self.los_checks = nil
-    local count = #units
-    for i = count, 1, -1 do
-        local unit = units[i]
-        if time ~= units[unit] then
-            self:UnitExitDetection(unit)
-            units[i] = units[count]
-            units[count] = nil
-            units[unit] = nil
-            count = count - 1
-        end
-    end
+	local units = self.detected_units
+	if not self.detect_spot or not self:IsDetectionEnabled() then
+		if units then
+			self:ClearDetectionCache()
+		end
+		return
+	end
+	local seed = self:RandSeed("DetectUnits")
+	if not units then
+		units = {}
+		self.detected_units = units
+	end
+	local range = self:GetDetectionRange()
+	self:GetMaxCollisionRadius(range + MaxLosTargetRadius) -- cache information about the surrounding, boosting the surf enum effectiveness
+	self.los_checks = self
+		.los_max_checks                                    -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
+	local collection_idx = self:GetDetectCollectionIdx()
+	MapForEach(self, range, "!collection", collection_idx, "shuffle", seed, "UnitDetection", detect_enum_flags, nil,
+		detect_game_flags, Scout_Detect, self, units)
+	self.los_checks = nil
+	local count = #units
+	for i = count, 1, -1 do
+		local unit = units[i]
+		if time ~= units[unit] then
+			self:UnitExitDetection(unit)
+			units[i] = units[count]
+			units[count] = nil
+			units[unit] = nil
+			count = count - 1
+		end
+	end
 end
 
 function UnitInvader:Get_New_Scout_Point()
-    local new_three = self.pathing_to
-    local new_two = self.scouted_pos[3]
-    local new_one = self.scouted_pos[2]
-    self.scouted_pos = {}
-    self.scouted_pos[1] = new_one
-    self.scouted_pos[2] = new_two
-    self.scouted_pos[3] = new_three
-    self.pathing_to = self:FindNextScoutingPoint(self.target_quadrant, self.scouted_pos)
-    if self.pathing_to then
-        print("Pathing to new point!")
-    end
+	local new_three = self.pathing_to
+	local new_two = self.scouted_pos[3]
+	local new_one = self.scouted_pos[2]
+	self.scouted_pos = {}
+	self.scouted_pos[1] = new_one
+	self.scouted_pos[2] = new_two
+	self.scouted_pos[3] = new_three
+	self.pathing_to = self:FindNextScoutingPoint(self.target_quadrant, self.scouted_pos)
+	if self.pathing_to then
+		print("Pathing to new point!")
+	end
 end
 
 function UnitInvader:near_scout_point()
-    print("Recording things around me!")
-    self:Get_New_Scout_Point()
-    if not self.map_hack then
-        self:detect_nearby()
-    end
+	print("Recording things around me!")
+	self:Get_New_Scout_Point()
+	if not self.map_hack then
+		self:detect_nearby()
+	end
 end
 
 function TFormat.ScoutFailed(context_obj)
-    local map_name = GetMapName()
-    local quadrant = 5 --context_obj.target_quadrant
-    local unit = context_obj.actor.class or 'Unknown'
-    return Untranslated('<em>Map Name:  ' .. map_name .. '\nQuadrant:  ' .. quadrant .. '\nUnit:  ' .. unit .. '</em>')
+	local map_name = GetMapName()
+	local quadrant = 5 --context_obj.target_quadrant
+	local unit = context_obj.actor.class or 'Unknown'
+	return Untranslated('<em>Map Name:  ' .. map_name .. '\nQuadrant:  ' .. quadrant .. '\nUnit:  ' .. unit .. '</em>')
 end

--- a/Code/NA_Unit_Invader_Expansion.lua
+++ b/Code/NA_Unit_Invader_Expansion.lua
@@ -4,86 +4,86 @@
 -- what a nest gets from being supported is a class function inside of nest expansion
 -- ============================================================================
 DefineClass.InvaderBehaviourSupport = {
-	__parents = { "InvaderBehaviourBase", },
-	properties = {
-		{
-			id = "same_species",
-			name = "Help same species?",
-			help = "Automatically use the species as the primary spawned unit.",
-			editor = "bool",
-			default = true
-		},
-		{
-			id = "support_species",
-			name = "Species to Help",
-			help = "The source nest (can be set automatically)",
-			editor = "choice",
-			default = false,
-			items = function() return Get_species_nests() end,
-			no_edit = function(self) return self.same_species end
-		},
-		{
-			id = "ArrivalDistance",
-			name = "Arrival Distance",
-			help = "Distance to get close to the target nest before considering arrival",
-			editor = "number",
-			default = 50000,
-			scale = "m",
-			min = 5000,
-		},
-	},
-	EditorName = "Go to the second closest nest and support them.",
+    __parents = { "InvaderBehaviourBase", },
+    properties = {
+        {
+            id = "same_species",
+            name = "Help same species?",
+            help = "Automatically use the species as the primary spawned unit.",
+            editor = "bool",
+            default = true
+        },
+        {
+            id = "support_species",
+            name = "Species to Help",
+            help = "The source nest (can be set automatically)",
+            editor = "choice",
+            default = false,
+            items = function() return Get_species_nests() end,
+            no_edit = function(self) return self.same_species end
+        },
+        {
+            id = "ArrivalDistance",
+            name = "Arrival Distance",
+            help = "Distance to get close to the target nest before considering arrival",
+            editor = "number",
+            default = 50000,
+            scale = "m",
+            min = 5000,
+        },
+    },
+    EditorName = "Go to the second closest nest and support them.",
 
-	-- Runtime state
-	support_thread = false,
-	from_nest = false,
-	to_nest = false,
-	arrival_confirmed = false,
+    -- Runtime state
+    support_thread = false,
+    from_nest = false,
+    to_nest = false,
+    arrival_confirmed = false,
 }
 
 function InvaderBehaviourSupport:OnAssign(invader, end_time)
-	Bkob_Log_NA("assinging support behavior!")
-	InvaderBehaviourBase.OnAssign(self, invader, end_time)
-	invader.pathing = true
-	invader.path_until = end_time
-	invader.supporting = true
-	invader.on_arrive = function(invader, target, progress)
-		if IsKindOf(target, "TerritorialNest") then
-			target:support_arrived()
-		end
-		RemoveAttachedUIToObject(invader, 'NestRolePermanent')
-		RemoveAttachedUIToObject(invader, 'NestRoleClose')
-		RemoveAttachedUIToObject(invader, 'NestRoleFar')
-		self:SetCommand("CmdDespawn")
-		return true
-	end
-	invader.pathing_proximity = self.ArrivalDistance or 50000
-	local my_nest_id = invader:GetNestClass()
-	invader.pathing_from = MapFindNearest(invader, true, my_nest_id)
-	-- Destination = nearest same-species nest that is closer to the survivors than the origin AND within ~60 degrees of
-	-- the origin's bearing from the survivor centre. The angular gate keeps support from walking across the player's
-	-- base to a ~180-degree-opposite nest. Mirrors EnhancedTerritorialNest:GetSupportTarget on the unit side.
-	local center = Get_center_of_survivors()
-	local from_bearing = invader.pathing_from and CalcOrientation(center, invader.pathing_from:GetPos())
-	invader.pathing_to = MapFindNearest(invader, true, my_nest_id, function(obj, from)
-		if obj == from or not obj:IsCloserToPlayer(from) then return end
-		if from_bearing and abs(AngleDiff(from_bearing, CalcOrientation(center, obj:GetPos()))) > 60 * 60 then return end
-		return true
-	end, invader.pathing_from)
-	invader:UpdateAttachedUI()
+    Bkob_Log_NA("assinging support behavior!")
+    InvaderBehaviourBase.OnAssign(self, invader, end_time)
+    invader.pathing = true
+    invader.path_until = end_time
+    invader.supporting = true
+    invader.on_arrive = function(invader, target, progress)
+        if IsKindOf(target, "TerritorialNest") then
+            target:support_arrived()
+        end
+        RemoveAttachedUIToObject(invader, 'NestRolePermanent')
+        RemoveAttachedUIToObject(invader, 'NestRoleClose')
+        RemoveAttachedUIToObject(invader, 'NestRoleFar')
+        self:SetCommand("CmdDespawn")
+        return true
+    end
+    invader.pathing_proximity = self.ArrivalDistance or 50000
+    local my_nest_id = invader:GetNestClass()
+    invader.pathing_from = MapFindNearest(invader, true, my_nest_id)
+    -- Destination = nearest same-species nest that is closer to the survivors than the origin AND within ~60 degrees of
+    -- the origin's bearing from the survivor centre. The angular gate keeps support from walking across the player's
+    -- base to a ~180-degree-opposite nest. Mirrors EnhancedTerritorialNest:GetSupportTarget on the unit side.
+    local center = Get_center_of_survivors()
+    local from_bearing = invader.pathing_from and CalcOrientation(center, invader.pathing_from:GetPos())
+    invader.pathing_to = MapFindNearest(invader, true, my_nest_id, function(obj, from)
+        if obj == from or not obj:IsCloserToPlayer(from) then return end
+        if from_bearing and abs(AngleDiff(from_bearing, CalcOrientation(center, obj:GetPos()))) > 60 * 60 then return end
+        return true
+    end, invader.pathing_from)
+    invader:UpdateAttachedUI()
 end
 
 function InvaderBehaviourSupport:OnExpire(invader)
-	Bkob_Log_NA("Expire support behavior!")
-	rawset(invader, 'pathing', nil)
-	rawset(invader, 'path_until', nil)
-	rawset(invader, 'supporting', nil)
-	rawset(invader, 'on_arrive', nil)
-	rawset(invader, 'pathing_proximity', nil)
-	rawset(invader, 'pathing_from', nil)
-	rawset(invader, 'pathing_to', nil)
-	invader:UpdateAttachedUI()
-	return InvaderBehaviourBase.OnExpire(self, invader)
+    Bkob_Log_NA("Expire support behavior!")
+    rawset(invader, 'pathing', nil)
+    rawset(invader, 'path_until', nil)
+    rawset(invader, 'supporting', nil)
+    rawset(invader, 'on_arrive', nil)
+    rawset(invader, 'pathing_proximity', nil)
+    rawset(invader, 'pathing_from', nil)
+    rawset(invader, 'pathing_to', nil)
+    invader:UpdateAttachedUI()
+    return InvaderBehaviourBase.OnExpire(self, invader)
 end
 
 --[[
@@ -91,294 +91,294 @@ end
 Enables non-aggressive movement to the closest object of a certain class
 --]]
 DefineClass.InvaderBehaviourPassiveMove = {
-	__parents = { "InvaderBehaviourBase", },
-	properties = {
-		{
-			id = "target_class",
-			name = "Target Class",
-			help = "Class of the target to move to. If empty, the unit will move to a random point.",
-			editor = "choice",
-			default = "TerritorialNest",
-			items = function(
-				self)
-				return GetSpawnClasses()
-			end,
-		},
-		{ id = 'complex_targeting', name = 'Use more complex targeting logic?', help = 'Instead of just picking the closest target, use a more complex logic to pick the target. Currently this is only used for picking the closest target that is also closer to the player than the unit itself.', editor = 'bool',   default = false },
-		{
-			id = 'targeting_function',
-			name = 'Find_Point_to_move_to',
-			help = 'Function to find the point to move to.',
-			editor = "expression",
-			default = function(self, invader, progress) return Get_center_of_survivors() end,
-			params = "self, invader, progress",
-			no_edit = function(self) return not self.complex_targeting end
-		},
-		{
-			id = "on_arrival",
-			name = "OnArrive",
-			help = "Function this unit performs once it arrives at the target.",
-			editor = "expression",
-			default = function(
-				invader, target, progress)
-				return true
-			end,
-			params = "invader, target, progress",
-		},
-		{ id = "proximity",         name = "Stop if this close",                help = "When the unit is this many meters close to the target, trigger the on_arrival function and interrupt behavior.",                                                                                              editor = "number", default = 50000, scale = "m", min = 5000, },
-	},
-	EditorName = "Passive walk to closest target",
+    __parents = { "InvaderBehaviourBase", },
+    properties = {
+        {
+            id = "target_class",
+            name = "Target Class",
+            help = "Class of the target to move to. If empty, the unit will move to a random point.",
+            editor = "choice",
+            default = "TerritorialNest",
+            items = function(
+                self)
+                return GetSpawnClasses()
+            end,
+        },
+        { id = 'complex_targeting', name = 'Use more complex targeting logic?', help = 'Instead of just picking the closest target, use a more complex logic to pick the target. Currently this is only used for picking the closest target that is also closer to the player than the unit itself.', editor = 'bool',   default = false },
+        {
+            id = 'targeting_function',
+            name = 'Find_Point_to_move_to',
+            help = 'Function to find the point to move to.',
+            editor = "expression",
+            default = function(self, invader, progress) return Get_center_of_survivors() end,
+            params = "self, invader, progress",
+            no_edit = function(self) return not self.complex_targeting end
+        },
+        {
+            id = "on_arrival",
+            name = "OnArrive",
+            help = "Function this unit performs once it arrives at the target.",
+            editor = "expression",
+            default = function(
+                invader, target, progress)
+                return true
+            end,
+            params = "invader, target, progress",
+        },
+        { id = "proximity",         name = "Stop if this close",                help = "When the unit is this many meters close to the target, trigger the on_arrival function and interrupt behavior.",                                                                                              editor = "number", default = 50000, scale = "m", min = 5000, },
+    },
+    EditorName = "Passive walk to closest target",
 }
 
 function InvaderBehaviourPassiveMove:OnAssign(invader, end_time)
-	InvaderBehaviourBase.OnAssign(self, invader, end_time)
-	invader.pathing = true
-	invader.path_until = end_time
-	invader.on_arrive = self.on_arrival
-	invader.pathing_proximity = self.proximity
-	if self.complex_targeting then
-		--print("Having to calculate complex place to move too!")
-		local target = self.targeting_function(self, invader, EventProgress)
-		--print(target)
-		--print(target.class)
-		invader.pathing_to = target
-	else
-		invader.pathing_to = MapFindNearest('map', invader, true, self.target_class)
-	end
-	invader:UpdateAttachedUI()
+    InvaderBehaviourBase.OnAssign(self, invader, end_time)
+    invader.pathing = true
+    invader.path_until = end_time
+    invader.on_arrive = self.on_arrival
+    invader.pathing_proximity = self.proximity
+    if self.complex_targeting then
+        --print("Having to calculate complex place to move too!")
+        local target = self.targeting_function(self, invader, EventProgress)
+        --print(target)
+        --print(target.class)
+        invader.pathing_to = target
+    else
+        invader.pathing_to = MapFindNearest('map', invader, true, self.target_class)
+    end
+    invader:UpdateAttachedUI()
 end
 
 function InvaderBehaviourPassiveMove:OnExpire(invader)
-	rawset(invader, 'pathing', nil)
-	rawset(invader, 'path_until', nil)
-	rawset(invader, 'on_arrive', nil)
-	rawset(invader, 'pathing_proximity', nil)
-	rawset(invader, 'pathing_to', nil)
-	return InvaderBehaviourBase.OnExpire(self, invader)
+    rawset(invader, 'pathing', nil)
+    rawset(invader, 'path_until', nil)
+    rawset(invader, 'on_arrive', nil)
+    rawset(invader, 'pathing_proximity', nil)
+    rawset(invader, 'pathing_to', nil)
+    return InvaderBehaviourBase.OnExpire(self, invader)
 end
 
 --test
 function EnhancedTerritorialNest:new_behavior_qa()
-	--print("Testing new behaviors!")
-	local spawn_def
-	spawn_def = SpawnDefs['passive_move']
-	local instance = {}
-	instance.nest = self
-	spawn_def = spawn_def:CreateInstance(instance)
-	--print("Triggering spawndef!")
-	local t = spawn_def:ResolveTarget()
-	spawn_def:ActivateSpawn(t, {}, 100)
+    --print("Testing new behaviors!")
+    local spawn_def
+    spawn_def = SpawnDefs['passive_move']
+    local instance = {}
+    instance.nest = self
+    spawn_def = spawn_def:CreateInstance(instance)
+    --print("Triggering spawndef!")
+    local t = spawn_def:ResolveTarget()
+    spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function UnitInvader:FindNextScoutingPoint()
-	local valid_point = false
-	print("Trying to find a spot in quadrant,")
-	local box = Get_box_from_quadrant(self.target_quadrant)
-	local retry = 10
-	local range = self.pathing_proximity or (15 * guim)
-	while (retry > 0 and not valid_point) do
-		valid_point = self:FindValidScoutingPoint(box, self.scouted_pos, range)
-		retry = retry - 1
-		range = range + 5 * guim
-	end
-	if valid_point then
-		return valid_point
-	else
-		ForceActivateStoryBit('unable_to_scout', self, true)
-		self.pathing = false
-		return
-	end
+    local valid_point = false
+    print("Trying to find a spot in quadrant,")
+    local box = Get_box_from_quadrant(self.target_quadrant)
+    local retry = 10
+    local range = self.pathing_proximity or (15 * guim)
+    while (retry > 0 and not valid_point) do
+        valid_point = self:FindValidScoutingPoint(box, self.scouted_pos, range)
+        retry = retry - 1
+        range = range + 5 * guim
+    end
+    if valid_point then
+        return valid_point
+    else
+        ForceActivateStoryBit('unable_to_scout', self, true)
+        self.pathing = false
+        return
+    end
 end
 
 function UnitInvader:FindValidScoutingPoint(box_area, scouted_points, min_dist)
-	-- early validation identical to previous implementation
-	if not box_area or min_dist <= 0 then
-		return false
-	end
-	local w = box_area:maxx() - box_area:minx()
-	local h = box_area:maxy() - box_area:miny()
-	if w < min_dist * 2 and h < min_dist * 2 then
-		return false
-	end
+    -- early validation identical to previous implementation
+    if not box_area or min_dist <= 0 then
+        return false
+    end
+    local w = box_area:maxx() - box_area:minx()
+    local h = box_area:maxy() - box_area:miny()
+    if w < min_dist * 2 and h < min_dist * 2 then
+        return false
+    end
 
-	scouted_points = scouted_points or {}
-	local min_sq = min_dist * min_dist
+    scouted_points = scouted_points or {}
+    local min_sq = min_dist * min_dist
 
-	local my_pfclass = self:GetPfClass()
-	-- origin for connectivity: try to find a passable tile near the centre.
-	local my_pos = terrain.FindPassable(self, my_pfclass)
+    local my_pfclass = self:GetPfClass()
+    -- origin for connectivity: try to find a passable tile near the centre.
+    local my_pos = terrain.FindPassable(self, my_pfclass)
 
-	local function filter(x, y)
-		for _, pt in ipairs(scouted_points) do
-			local dx = x - pt:x()
-			local dy = y - pt:y()
-			if dx * dx + dy * dy < min_sq then
-				return false
-			end
-		end
-		if box_area:Dist2D(point(x, y)) > 0 then
-			return false
-		end
-		return true
-	end
+    local function filter(x, y)
+        for _, pt in ipairs(scouted_points) do
+            local dx = x - pt:x()
+            local dy = y - pt:y()
+            if dx * dx + dy * dy < min_sq then
+                return false
+            end
+        end
+        if box_area:Dist2D(point(x, y)) > 0 then
+            return false
+        end
+        return true
+    end
 
-	-- use ConnectivityRandomTile instead of manual loop. the function will
-	-- perform its own randomised attempts and respects connectivity; the final
-	-- argument is our filter defined above.
-	local seed = AsyncRand()
-	local retries = 4096
-	-- ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096, filter_far_from_nest)
-	local pos = ConnectivityRandomTile(seed, my_pos, my_pos, max_int, 0, my_pfclass, retries, filter)
-	--Get_box_from_quadrant(12):Dist2D(point(906300,17715500))
-	if not pos then
-		return false
-	end
-	print(box_area:Dist2D(pos))
-	return pos
+    -- use ConnectivityRandomTile instead of manual loop. the function will
+    -- perform its own randomised attempts and respects connectivity; the final
+    -- argument is our filter defined above.
+    local seed = AsyncRand()
+    local retries = 4096
+    -- ConnectivityRandomTile(seed, origin, center, max_dist, min_dist, Human.pfclass, 4096, filter_far_from_nest)
+    local pos = ConnectivityRandomTile(seed, my_pos, my_pos, max_int, 0, my_pfclass, retries, filter)
+    --Get_box_from_quadrant(12):Dist2D(point(906300,17715500))
+    if not pos then
+        return false
+    end
+    print(box_area:Dist2D(pos))
+    return pos
 end
 
 function UnitInvader:Get_quadrant_to_scout()
-	local my_quad = Get_quadrant_from_obj(self)
-	local my_nesting_species = self:Get_Nesting_Species()
-	if not my_nesting_species then return my_quad end
-	local nest_logs = G_nest_scout_logs[my_nesting_species].quadrants or {}
-	-- Try to scout where I am
-	if not nest_logs[my_quad] or (GameTime() - nest_logs[my_quad]) < year_duration * 2 then
-		return Collapse_quad(my_quad)
-	else
-		local retry = 2
-		local tried_quads = {}
-		tried_quads[Collapse_quad(my_quad)] = true
-		while retry > 0 do
-			for quad in ipairs(table.keys(tried_quads)) do
-				local adjacent = Get_adjacent_quads(Uncollapse_quad(quad))
-				for _, quad in ipairs(adjacent) do
-					if not nest_logs[quad] or (GameTime() - nest_logs[quad]) < year_duration * 2 then
-						return Collapse_quad(quad)
-					else
-						tried_quads[quad] = true
-					end
-				end
-				retry = retry - 1
-			end
-		end
-	end
+    local my_quad = Get_quadrant_from_obj(self)
+    local my_nesting_species = self:Get_Nesting_Species()
+    if not my_nesting_species then return my_quad end
+    local nest_logs = G_nest_scout_logs[my_nesting_species].quadrants or {}
+    -- Try to scout where I am
+    if not nest_logs[my_quad] or (GameTime() - nest_logs[my_quad]) < year_duration * 2 then
+        return Collapse_quad(my_quad)
+    else
+        local retry = 2
+        local tried_quads = {}
+        tried_quads[Collapse_quad(my_quad)] = true
+        while retry > 0 do
+            for quad in ipairs(table.keys(tried_quads)) do
+                local adjacent = Get_adjacent_quads(Uncollapse_quad(quad))
+                for _, quad in ipairs(adjacent) do
+                    if not nest_logs[quad] or (GameTime() - nest_logs[quad]) < year_duration * 2 then
+                        return Collapse_quad(quad)
+                    else
+                        tried_quads[quad] = true
+                    end
+                end
+                retry = retry - 1
+            end
+        end
+    end
 end
 
 function UnitInvader:CheckForNewBehaviors()
-	if self.pathing or self.pathing_to or self.scouting or self.wallbreaking then
-		return true
-	end
-	return false
+    if self.pathing or self.pathing_to or self.scouting or self.wallbreaking then
+        return true
+    end
+    return false
 end
 
 --FindObstructionTarget for future wall breaker behavior
 function UnitInvader:InvaderIdle()
-	self.idling = true
-	if self:IsTimeToDespawn() and self:CanDespawn() then
-		self:SetCommand("CmdDespawn")
-		return
-	end
-	local something_new = self:CheckForNewBehaviors()
-	local forced_until = self.forced_aggression_until
-	if something_new then
-		-- pass to make sure we don't force fail due to the below checks
-	elseif not forced_until or self:TryFailForceAggression() then
-		return
-	end
-	Bkob_Log_NA("Checking what we as an invader should do!")
-	if something_new then
-		print("Pathing too:")
-		print(self.pathing_to)
-		print("And I need to be this close:")
-		print(self.pathing_proximity)
-		print("And I am this far away: ")
-		print(self:GetDist2D(self.pathing_to))
-		local close_enough = self:IsCloser(self.pathing_to, self.pathing_proximity)
-		if self.scouting and close_enough then
-			print(
-				"Unit is scouting and is close enough to their curtrent point. Recording surroundings and rolling a enw point!")
-			self:near_scout_point()
-			-- we will have a new pathing_to prop from the above function
-			self:SetCommand("CmdPassiveMove")
-		elseif self.pathing then
-			print('Unit is trying to get to a specific point!')
-			if close_enough then
-				print("And they are close enough!")
-				--print("Invader Idle call detecting we are too close to the target!")
-				self.pathing = false
-				print("Arrived at passive move target!")
-				if self.on_arrive then
-					local EP = EventProgress
-					self.on_arrive(self, self.pathing_to, EP)
-				end
-				self.pathing = nil
-				self.pathing_to = nil
-				self:UpdateAttachedUI()
-			end
-			Bkob_Log_NA("Telling unit to start (passively) moving to a target!")
-			self:SetCommand("CmdPassiveMove")
-		end
-	elseif GameTime() >= forced_until then
-		Bkob_Log_NA("Stop attacking!")
-		self:ClearForcedAttack()
-	elseif self.forced_aggression_roam then
-		Bkob_Log_NA("Agrily roaming!")
-		self.forced_aggression_roam = nil
-		self:Roam()
-		return true
-	elseif self:IsAttackSearchActive() then
-		local new_target = self:MarkForcedTarget()
-		if new_target and not self:IsAttackTargetIgnored(new_target) then
-			local range = self:GetMaxAttackRange()
-			if pf.GetLinearDist(self, new_target) > range then
-				self.roam_start_pos = false
-				self:SetCommand("CmdForcedApproach", new_target, range)
-			else
-				self:TryAttackTargetReason("InvaderIdle", new_target)
-			end
-		end
-		local scheduled_time = self.forced_aggression_roam_scheduled
-		if not scheduled_time or scheduled_time > self.roam_at_time then
-			-- move to a new position if no attack target is found
-			self:RoamSchedule(0, 3333)
-			self.forced_aggression_roam_scheduled = self.roam_at_time
-		end
-	end
+    self.idling = true
+    if self:IsTimeToDespawn() and self:CanDespawn() then
+        self:SetCommand("CmdDespawn")
+        return
+    end
+    local something_new = self:CheckForNewBehaviors()
+    local forced_until = self.forced_aggression_until
+    if something_new then
+        -- pass to make sure we don't force fail due to the below checks
+    elseif not forced_until or self:TryFailForceAggression() then
+        return
+    end
+    Bkob_Log_NA("Checking what we as an invader should do!")
+    if something_new then
+        print("Pathing too:")
+        print(self.pathing_to)
+        print("And I need to be this close:")
+        print(self.pathing_proximity)
+        print("And I am this far away: ")
+        print(self:GetDist2D(self.pathing_to))
+        local close_enough = self:IsCloser(self.pathing_to, self.pathing_proximity)
+        if self.scouting and close_enough then
+            print(
+                "Unit is scouting and is close enough to their curtrent point. Recording surroundings and rolling a enw point!")
+            self:near_scout_point()
+            -- we will have a new pathing_to prop from the above function
+            self:SetCommand("CmdPassiveMove")
+        elseif self.pathing then
+            print('Unit is trying to get to a specific point!')
+            if close_enough then
+                print("And they are close enough!")
+                --print("Invader Idle call detecting we are too close to the target!")
+                self.pathing = false
+                print("Arrived at passive move target!")
+                if self.on_arrive then
+                    local EP = EventProgress
+                    self.on_arrive(self, self.pathing_to, EP)
+                end
+                self.pathing = nil
+                self.pathing_to = nil
+                self:UpdateAttachedUI()
+            end
+            Bkob_Log_NA("Telling unit to start (passively) moving to a target!")
+            self:SetCommand("CmdPassiveMove")
+        end
+    elseif GameTime() >= forced_until then
+        Bkob_Log_NA("Stop attacking!")
+        self:ClearForcedAttack()
+    elseif self.forced_aggression_roam then
+        Bkob_Log_NA("Agrily roaming!")
+        self.forced_aggression_roam = nil
+        self:Roam()
+        return true
+    elseif self:IsAttackSearchActive() then
+        local new_target = self:MarkForcedTarget()
+        if new_target and not self:IsAttackTargetIgnored(new_target) then
+            local range = self:GetMaxAttackRange()
+            if pf.GetLinearDist(self, new_target) > range then
+                self.roam_start_pos = false
+                self:SetCommand("CmdForcedApproach", new_target, range)
+            else
+                self:TryAttackTargetReason("InvaderIdle", new_target)
+            end
+        end
+        local scheduled_time = self.forced_aggression_roam_scheduled
+        if not scheduled_time or scheduled_time > self.roam_at_time then
+            -- move to a new position if no attack target is found
+            self:RoamSchedule(0, 3333)
+            self.forced_aggression_roam_scheduled = self.roam_at_time
+        end
+    end
 end
 
 function UnitInvader:CmdPassiveMove()
-	print("Got told to move passively!")
-	if not self.pathing_to then
-		print("No idea what we are trying to move too!")
-		self.pathing = false
-		return -- no target found
-	end
-	local closests_exact_pos
-	if IsValid(self.pathing_to) then
-		closests_exact_pos = self.pathing_to:GetPos()
-	else
-		closests_exact_pos = self.pathing_to
-	end
-	-- prefer a tile that respects this unit's pfclass and collision
-	local closest_to_dest = terrain.FindPassableTile(closests_exact_pos, const.tfpPassClass, self)
-	if not ConnectivityCheck(self, closest_to_dest) then
-		print("We cannot reach this class....")
-		return
-	end
-	print("Telling myself to GoTo this position:", closest_to_dest)
-	if self:IsCloser(self.pathing_to, self.pathing_proximity) then
-		--print("I am close enough to trigger my on arrive!")
-		if self.on_arrive then
-			local EP = EventProgress
-			--print("And I do have a function of it! Triggering it")
-			self.on_arrive(self, self.pathing_to, EP)
-		end
-		-- This will stop an infinite loop if the movement behavior is still waiting to timeout
-		self.pathing = false
-	else
-		self:Goto(closest_to_dest)
-	end
+    print("Got told to move passively!")
+    if not self.pathing_to then
+        print("No idea what we are trying to move too!")
+        self.pathing = false
+        return -- no target found
+    end
+    local closests_exact_pos
+    if IsValid(self.pathing_to) then
+        closests_exact_pos = self.pathing_to:GetPos()
+    else
+        closests_exact_pos = self.pathing_to
+    end
+    -- prefer a tile that respects this unit's pfclass and collision
+    local closest_to_dest = terrain.FindPassableTile(closests_exact_pos, const.tfpPassClass, self)
+    if not ConnectivityCheck(self, closest_to_dest) then
+        print("We cannot reach this class....")
+        return
+    end
+    print("Telling myself to GoTo this position:", closest_to_dest)
+    if self:IsCloser(self.pathing_to, self.pathing_proximity) then
+        --print("I am close enough to trigger my on arrive!")
+        if self.on_arrive then
+            local EP = EventProgress
+            --print("And I do have a function of it! Triggering it")
+            self.on_arrive(self, self.pathing_to, EP)
+        end
+        -- This will stop an infinite loop if the movement behavior is still waiting to timeout
+        self.pathing = false
+    else
+        self:Goto(closest_to_dest)
+    end
 end
 
 --[[
@@ -386,109 +386,109 @@ end
 Enables a non-aggressive movement to another more complicated location
 00]]
 DefineClass.InvaderBehaviourNestScout = {
-	__parents = { "InvaderBehaviourBase", },
-	properties = {
-		{ id = "map_hack",        name = "Give scout map hacks?",                      help = "The scout will always learn of all classes it is looking for in the 4% of the map it is exploring", editor = "bool",   default = false },
-		{
-			id = "log_classes",
-			name = "What class should the unit record?",
-			help = "What is this unit looking for?",
-			editor = "string_list",
-			items = function(
-				self)
-				return GetSpawnClasses()
-			end,
-			default = false
-		},
-		{ id = 'distance_points', name = 'Distance between scouting points (in guim)', help = 'Quadrants are approximately 200m x 200m',                                                           editor = 'number', default = 25,   scale = 'm' },
-		{
-			id = "attack_hostile",
-			name = "Is the scout hostile?",
-			help = "Will this unit fight anyone while it is roaming?",
-			editor = "bool",
-			default = false,
-			no_edit = function(
-				self)
-				return self.attack_hostile
-			end
-		},
-		{
-			id = "ForcedGroups",
-			name = "Combat Groups",
-			help =
-			"Define specific combat groups as priority targets. If empty, all groups from the specified combat classes will be targeted. If no classes are specified too, the unit will be aggressive towards everything, but its own.",
-			editor = "set",
-			default = set("Humans"),
-			items = function(
-				self)
-				return CombatGroupsSetItems()
-			end,
-			no_edit = function(
-				self)
-				return self.attack_hostile
-			end
-		},
-		{
-			id = "SearchLabels",
-			name = "Search Labels",
-			help =
-			"Define a label where to search for the targets. If missing, the search will be limited to a radius around.",
-			editor = "string_list",
-			default = { "Survivors" },
-			item_default = "",
-			items = function(
-				self)
-				return BuildingLabelComboItems()
-			end,
-			no_edit = function(
-				self)
-				return self.attack_hostile
-			end
-		},
-		{
-			id = "SearchRadius",
-			name = "Search Radius",
-			help = "Search range for the targets if no search label is defined. Leave 0 to use the invader's default.",
-			editor = "number",
-			default = 200000,
-			scale = "m",
-			no_edit = function(
-				self)
-				return self.attack_hostile
-			end
-		},
-		{
-			id = "ForcedClasses",
-			name = "Target Classes",
-			help =
-			"Define specific combat classes as priority targets. If empty, all classes with the specified combat groups will be targeted. If no groups are specified too, the unit will be aggressive towards everything, but its own..",
-			editor = "string_list",
-			default = {},
-			item_default = "",
-			items = function(
-				self)
-				return ClassDescendantsList("AttackableObject")
-			end,
-			no_edit = function(
-				self)
-				return self.attack_hostile
-			end
-		},
-		{
-			id = "KeepFormation",
-			name = "Keep Group Formation",
-			help = "I true, the invaders will approach keeping close to each other.",
-			editor = "bool",
-			default = true,
-			no_edit = function(
-				self)
-				return self.attack_hostile
-			end
-		},
-	},
-	EditorName = "Scout around the map (based on species logs)",
-	Documentation =
-	[[The <style GedHighlight>Scouting behavior</style> is to be used by nests when trying to find the player's stuff or another species territorial nest.
+    __parents = { "InvaderBehaviourBase", },
+    properties = {
+        { id = "map_hack",        name = "Give scout map hacks?",                      help = "The scout will always learn of all classes it is looking for in the 4% of the map it is exploring", editor = "bool",   default = false },
+        {
+            id = "log_classes",
+            name = "What class should the unit record?",
+            help = "What is this unit looking for?",
+            editor = "string_list",
+            items = function(
+                self)
+                return GetSpawnClasses()
+            end,
+            default = false
+        },
+        { id = 'distance_points', name = 'Distance between scouting points (in guim)', help = 'Quadrants are approximately 200m x 200m',                                                           editor = 'number', default = 25,   scale = 'm' },
+        {
+            id = "attack_hostile",
+            name = "Is the scout hostile?",
+            help = "Will this unit fight anyone while it is roaming?",
+            editor = "bool",
+            default = false,
+            no_edit = function(
+                self)
+                return self.attack_hostile
+            end
+        },
+        {
+            id = "ForcedGroups",
+            name = "Combat Groups",
+            help =
+            "Define specific combat groups as priority targets. If empty, all groups from the specified combat classes will be targeted. If no classes are specified too, the unit will be aggressive towards everything, but its own.",
+            editor = "set",
+            default = set("Humans"),
+            items = function(
+                self)
+                return CombatGroupsSetItems()
+            end,
+            no_edit = function(
+                self)
+                return self.attack_hostile
+            end
+        },
+        {
+            id = "SearchLabels",
+            name = "Search Labels",
+            help =
+            "Define a label where to search for the targets. If missing, the search will be limited to a radius around.",
+            editor = "string_list",
+            default = { "Survivors" },
+            item_default = "",
+            items = function(
+                self)
+                return BuildingLabelComboItems()
+            end,
+            no_edit = function(
+                self)
+                return self.attack_hostile
+            end
+        },
+        {
+            id = "SearchRadius",
+            name = "Search Radius",
+            help = "Search range for the targets if no search label is defined. Leave 0 to use the invader's default.",
+            editor = "number",
+            default = 200000,
+            scale = "m",
+            no_edit = function(
+                self)
+                return self.attack_hostile
+            end
+        },
+        {
+            id = "ForcedClasses",
+            name = "Target Classes",
+            help =
+            "Define specific combat classes as priority targets. If empty, all classes with the specified combat groups will be targeted. If no groups are specified too, the unit will be aggressive towards everything, but its own..",
+            editor = "string_list",
+            default = {},
+            item_default = "",
+            items = function(
+                self)
+                return ClassDescendantsList("AttackableObject")
+            end,
+            no_edit = function(
+                self)
+                return self.attack_hostile
+            end
+        },
+        {
+            id = "KeepFormation",
+            name = "Keep Group Formation",
+            help = "I true, the invaders will approach keeping close to each other.",
+            editor = "bool",
+            default = true,
+            no_edit = function(
+                self)
+                return self.attack_hostile
+            end
+        },
+    },
+    EditorName = "Scout around the map (based on species logs)",
+    Documentation =
+    [[The <style GedHighlight>Scouting behavior</style> is to be used by nests when trying to find the player's stuff or another species territorial nest.
 Scouts will always log anything owned by the player (Buildings, Survivors, Robots, etc...), but can also log any other spawn class if specified.
 Scouting code splits the map into 200m x 200m quadrants, and the unit will pick the closest quadrant that has not been scouted in the last year by its species to explore.
 Scouting behavior:
@@ -505,140 +505,140 @@ Note 2: If <style GedHighlight>map_hack</style> is enabled, the scout will auto 
 --self:SetCommand("CmdForcedApproach", new_target, range)
 
 function InvaderBehaviourNestScout:OnAssign(invader, end_time)
-	if self.attack_hostile then
-		invader:ForceAggressionStart(self.ForcedGroups, self.ForcedClasses, end_time, self.SearchLabels,
-			self.SearchRadius, self.KeepFormation)
-	end
-	-- Initialize scouting state
-	invader.scouting = true
-	invader.observed_objects = {}
-	invader.scouted_pos = {}
-	if not invader.from_nest or not invader.from_nest.quadrant_scouting then
-		invader.target_quadrant = invader:Get_quadrant_to_scout()
-	else
-		invader.target_quadrant = invader.from_nest.quadrant_scouting
-	end
-	invader.pathing = true
-	invader.pathing_to = invader:FindNextScoutingPoint(invader.target_quadrant, invader.scouted_pos)
-	--invader.min_scout_distance = self.distance_points * guim
-	invader.looking_for = self.log_classes
-	invader.map_hack = self.map_hack
-	invader.player_found = false
-	invader.pathing_proximity = 5000
-	-- grant a buff to all scouts, making them able to see past 30 meters
-	if invader:GetDetectionRange() < 30 * guim then
-		if IsKindOf(invader, 'Robot') then
-			invader:AddRobotCondition('scouting_sight_buff_robot', 'mod')
-		else
-			invader:AddHealthCondition('scouting_sight_buff_animal', 'mod')
-		end
-	end
-	if self.map_hack then
-		invader.observed_objects = Get_objs_in_quad(invader.target_quadrant, self.log_classes)
-	end
-	invader:UpdateAttachedUI()
+    if self.attack_hostile then
+        invader:ForceAggressionStart(self.ForcedGroups, self.ForcedClasses, end_time, self.SearchLabels,
+            self.SearchRadius, self.KeepFormation)
+    end
+    -- Initialize scouting state
+    invader.scouting = true
+    invader.observed_objects = {}
+    invader.scouted_pos = {}
+    if not invader.from_nest or not invader.from_nest.quadrant_scouting then
+        invader.target_quadrant = invader:Get_quadrant_to_scout()
+    else
+        invader.target_quadrant = invader.from_nest.quadrant_scouting
+    end
+    invader.pathing = true
+    invader.pathing_to = invader:FindNextScoutingPoint(invader.target_quadrant, invader.scouted_pos)
+    --invader.min_scout_distance = self.distance_points * guim
+    invader.looking_for = self.log_classes
+    invader.map_hack = self.map_hack
+    invader.player_found = false
+    invader.pathing_proximity = 5000
+    -- grant a buff to all scouts, making them able to see past 30 meters
+    if invader:GetDetectionRange() < 30 * guim then
+        if IsKindOf(invader, 'Robot') then
+            invader:AddRobotCondition('scouting_sight_buff_robot', 'mod')
+        else
+            invader:AddHealthCondition('scouting_sight_buff_animal', 'mod')
+        end
+    end
+    if self.map_hack then
+        invader.observed_objects = Get_objs_in_quad(invader.target_quadrant, self.log_classes)
+    end
+    invader:UpdateAttachedUI()
 end
 
 function InvaderBehaviourNestScout:OnExpire(invader)
-	rawset(invader, 'scouting', nil)
-	rawset(invader, 'observed_objects', nil)
-	rawset(invader, 'scouted_pos', nil)
-	rawset(invader, 'target_quadrant', nil)
-	rawset(invader, 'pathing_to', nil)
-	--rawset(invader, 'min_scout_distance', nil)
-	rawset(invader, 'looking_for', nil)
-	rawset(invader, 'map_hack', nil)
-	if IsKindOf(invader, 'Robot') then
-		invader:RemoveRobotCondition('scouting_sight_buff_animal')
-	else
-		invader:RemoveHealthCondition('scouting_sight_buff_animal')
-	end
-	invader:UpdateAttachedUI()
-	return InvaderBehaviourBase.OnExpire(self, invader)
+    rawset(invader, 'scouting', nil)
+    rawset(invader, 'observed_objects', nil)
+    rawset(invader, 'scouted_pos', nil)
+    rawset(invader, 'target_quadrant', nil)
+    rawset(invader, 'pathing_to', nil)
+    --rawset(invader, 'min_scout_distance', nil)
+    rawset(invader, 'looking_for', nil)
+    rawset(invader, 'map_hack', nil)
+    if IsKindOf(invader, 'Robot') then
+        invader:RemoveRobotCondition('scouting_sight_buff_animal')
+    else
+        invader:RemoveHealthCondition('scouting_sight_buff_animal')
+    end
+    invader:UpdateAttachedUI()
+    return InvaderBehaviourBase.OnExpire(self, invader)
 end
 
 local detect_enum_flags = const.efVisible | const.efUnit | const.efAttackable
 local detect_game_flags = const.gofDamageable | const.gofSyncObject
 
 local function Scout_Detect(unit, self, detected_units)
-	--DbgAddSegment(unit, self, RandColor(self.handle))
-	if self == unit
-		or not unit.detect_spot
-		or not self:IsDetectionTarget(unit)
-		or not self:CanDetect(unit) then
-		return
-	end
-	for _, v in ipairs(self.looking_for) do
-		if IsKindOf(unit, v) then
-			print("I detected this, a thing I'm looking for: " .. unit.class)
-			table.insert_unique(self.observed_objects, unit)
-		end
-	end
-	if unit.player then
-		print("I detected something owned by the player!")
-		self.player_found = true
-	end
+    --DbgAddSegment(unit, self, RandColor(self.handle))
+    if self == unit
+        or not unit.detect_spot
+        or not self:IsDetectionTarget(unit)
+        or not self:CanDetect(unit) then
+        return
+    end
+    for _, v in ipairs(self.looking_for) do
+        if IsKindOf(unit, v) then
+            print("I detected this, a thing I'm looking for: " .. unit.class)
+            table.insert_unique(self.observed_objects, unit)
+        end
+    end
+    if unit.player then
+        print("I detected something owned by the player!")
+        self.player_found = true
+    end
 end
 
 function UnitDetection:detect_nearby()
-	local units = self.detected_units
-	if not self.detect_spot or not self:IsDetectionEnabled() then
-		if units then
-			self:ClearDetectionCache()
-		end
-		return
-	end
-	local seed = self:RandSeed("DetectUnits")
-	if not units then
-		units = {}
-		self.detected_units = units
-	end
-	local range = self:GetDetectionRange()
-	self:GetMaxCollisionRadius(range + MaxLosTargetRadius) -- cache information about the surrounding, boosting the surf enum effectiveness
-	self.los_checks = self
-		.los_max_checks                                    -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
-	local collection_idx = self:GetDetectCollectionIdx()
-	MapForEach(self, range, "!collection", collection_idx, "shuffle", seed, "UnitDetection", detect_enum_flags, nil,
-		detect_game_flags, Scout_Detect, self, units)
-	self.los_checks = nil
-	local count = #units
-	for i = count, 1, -1 do
-		local unit = units[i]
-		if time ~= units[unit] then
-			self:UnitExitDetection(unit)
-			units[i] = units[count]
-			units[count] = nil
-			units[unit] = nil
-			count = count - 1
-		end
-	end
+    local units = self.detected_units
+    if not self.detect_spot or not self:IsDetectionEnabled() then
+        if units then
+            self:ClearDetectionCache()
+        end
+        return
+    end
+    local seed = self:RandSeed("DetectUnits")
+    if not units then
+        units = {}
+        self.detected_units = units
+    end
+    local range = self:GetDetectionRange()
+    self:GetMaxCollisionRadius(range + MaxLosTargetRadius) -- cache information about the surrounding, boosting the surf enum effectiveness
+    self.los_checks = self
+        .los_max_checks                                 -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
+    local collection_idx = self:GetDetectCollectionIdx()
+    MapForEach(self, range, "!collection", collection_idx, "shuffle", seed, "UnitDetection", detect_enum_flags, nil,
+        detect_game_flags, Scout_Detect, self, units)
+    self.los_checks = nil
+    local count = #units
+    for i = count, 1, -1 do
+        local unit = units[i]
+        if time ~= units[unit] then
+            self:UnitExitDetection(unit)
+            units[i] = units[count]
+            units[count] = nil
+            units[unit] = nil
+            count = count - 1
+        end
+    end
 end
 
 function UnitInvader:Get_New_Scout_Point()
-	local new_three = self.pathing_to
-	local new_two = self.scouted_pos[3]
-	local new_one = self.scouted_pos[2]
-	self.scouted_pos = {}
-	self.scouted_pos[1] = new_one
-	self.scouted_pos[2] = new_two
-	self.scouted_pos[3] = new_three
-	self.pathing_to = self:FindNextScoutingPoint(self.target_quadrant, self.scouted_pos)
-	if self.pathing_to then
-		print("Pathing to new point!")
-	end
+    local new_three = self.pathing_to
+    local new_two = self.scouted_pos[3]
+    local new_one = self.scouted_pos[2]
+    self.scouted_pos = {}
+    self.scouted_pos[1] = new_one
+    self.scouted_pos[2] = new_two
+    self.scouted_pos[3] = new_three
+    self.pathing_to = self:FindNextScoutingPoint(self.target_quadrant, self.scouted_pos)
+    if self.pathing_to then
+        print("Pathing to new point!")
+    end
 end
 
 function UnitInvader:near_scout_point()
-	print("Recording things around me!")
-	self:Get_New_Scout_Point()
-	if not self.map_hack then
-		self:detect_nearby()
-	end
+    print("Recording things around me!")
+    self:Get_New_Scout_Point()
+    if not self.map_hack then
+        self:detect_nearby()
+    end
 end
 
 function TFormat.ScoutFailed(context_obj)
-	local map_name = GetMapName()
-	local quadrant = 5 --context_obj.target_quadrant
-	local unit = context_obj.actor.class or 'Unknown'
-	return Untranslated('<em>Map Name:  ' .. map_name .. '\nQuadrant:  ' .. quadrant .. '\nUnit:  ' .. unit .. '</em>')
+    local map_name = GetMapName()
+    local quadrant = 5 --context_obj.target_quadrant
+    local unit = context_obj.actor.class or 'Unknown'
+    return Untranslated('<em>Map Name:  ' .. map_name .. '\nQuadrant:  ' .. quadrant .. '\nUnit:  ' .. unit .. '</em>')
 end

--- a/Code/NA_Unit_Invader_Expansion.lua
+++ b/Code/NA_Unit_Invader_Expansion.lua
@@ -1,4 +1,3 @@
-
 -- ============================================================================
 -- Support Behaviour
 -- Spawned by a nest, and the unit will move to the next closest nest of it's species.
@@ -7,15 +6,34 @@
 DefineClass.InvaderBehaviourSupport = {
 	__parents = { "InvaderBehaviourBase", },
 	properties = {
-		{ id = "same_species", name = "Help same species?", help = "Automatically use the species as the primary spawned unit.", 
-			editor = "bool", default = true},
-		{ id = "support_species", name = "Species to Help", help = "The source nest (can be set automatically)", 
-			editor = "choice", default = false, items = function() return Get_species_nests() end, no_edit = function(self) return self.same_species end},
-		{ id = "ArrivalDistance", name = "Arrival Distance", help = "Distance to get close to the target nest before considering arrival", 
-			editor = "number", default = 50000, scale = "m", min = 5000, },
+		{
+			id = "same_species",
+			name = "Help same species?",
+			help = "Automatically use the species as the primary spawned unit.",
+			editor = "bool",
+			default = true
+		},
+		{
+			id = "support_species",
+			name = "Species to Help",
+			help = "The source nest (can be set automatically)",
+			editor = "choice",
+			default = false,
+			items = function() return Get_species_nests() end,
+			no_edit = function(self) return self.same_species end
+		},
+		{
+			id = "ArrivalDistance",
+			name = "Arrival Distance",
+			help = "Distance to get close to the target nest before considering arrival",
+			editor = "number",
+			default = 50000,
+			scale = "m",
+			min = 5000,
+		},
 	},
 	EditorName = "Go to the second closest nest and support them.",
-	
+
 	-- Runtime state
 	support_thread = false,
 	from_nest = false,
@@ -30,7 +48,7 @@ function InvaderBehaviourSupport:OnAssign(invader, end_time)
 	invader.path_until = end_time
 	invader.supporting = true
 	invader.on_arrive = function(invader, target, progress)
-		if IsKindOf(target,"TerritorialNest") then
+		if IsKindOf(target, "TerritorialNest") then
 			target:support_arrived()
 		end
 		RemoveAttachedUIToObject(invader, 'NestRolePermanent')
@@ -41,18 +59,17 @@ function InvaderBehaviourSupport:OnAssign(invader, end_time)
 	end
 	invader.pathing_proximity = self.ArrivalDistance or 50000
 	local my_nest_id = invader:GetNestClass()
-	invader.pathing_from = MapFindNearest(invader,true,my_nest_id)
-	-- Destination = nearest same-species nest that is closer to the survivors than the origin AND
-	-- within ~60 degrees of the origin's bearing from the survivor centre. The angular gate (Ark
-	-- Builder's concern) keeps support from walking across the player's base to a ~180-degree-
-	-- opposite nest. Mirrors EnhancedTerritorialNest:GetSupportTarget on the unit side.
+	invader.pathing_from = MapFindNearest(invader, true, my_nest_id)
+	-- Destination = nearest same-species nest that is closer to the survivors than the origin AND within ~60 degrees of
+	-- the origin's bearing from the survivor centre. The angular gate keeps support from walking across the player's
+	-- base to a ~180-degree-opposite nest. Mirrors EnhancedTerritorialNest:GetSupportTarget on the unit side.
 	local center = Get_center_of_survivors()
 	local from_bearing = invader.pathing_from and CalcOrientation(center, invader.pathing_from:GetPos())
-	invader.pathing_to = MapFindNearest(invader,true,my_nest_id, function(obj, from)
+	invader.pathing_to = MapFindNearest(invader, true, my_nest_id, function(obj, from)
 		if obj == from or not obj:IsCloserToPlayer(from) then return end
-		if from_bearing and abs(AngleDiff(from_bearing, CalcOrientation(center, obj:GetPos()))) > 60*60 then return end
+		if from_bearing and abs(AngleDiff(from_bearing, CalcOrientation(center, obj:GetPos()))) > 60 * 60 then return end
 		return true
-	end,invader.pathing_from)
+	end, invader.pathing_from)
 	invader:UpdateAttachedUI()
 end
 
@@ -76,13 +93,39 @@ Enables non-aggressive movement to the closest object of a certain class
 DefineClass.InvaderBehaviourPassiveMove = {
 	__parents = { "InvaderBehaviourBase", },
 	properties = {
-		{ id = "target_class", name = "Target Class", help = "Class of the target to move to. If empty, the unit will move to a random point.", editor = "choice", default = "TerritorialNest", items = function(self) return GetSpawnClasses() end, },
-		{ id = 'complex_targeting', name = 'Use more complex targeting logic?', help = 'Instead of just picking the closest target, use a more complex logic to pick the target. Currently this is only used for picking the closest target that is also closer to the player than the unit itself.', editor = 'bool', default = false},
-		{ id = 'targeting_function', name = 'Find_Point_to_move_to', help = 'Function to find the point to move to.', editor = "expression",
-			default = function(self, invader, progress) return Get_center_of_survivors() end, params = "self, invader, progress",
-			no_edit = function(self) return not self.complex_targeting end},
-		{ id = "on_arrival", name = "OnArrive", help = "Function this unit performs once it arrives at the target.", editor = "expression", default = function(invader, target, progress) return true end, params = "invader, target, progress", },
-		{ id = "proximity", name = "Stop if this close", help = "When the unit is this many meters close to the target, trigger the on_arrival function and interrupt behavior.", editor = "number", default = 50000, scale = "m", min = 5000, },
+		{
+			id = "target_class",
+			name = "Target Class",
+			help = "Class of the target to move to. If empty, the unit will move to a random point.",
+			editor = "choice",
+			default = "TerritorialNest",
+			items = function(
+				self)
+				return GetSpawnClasses()
+			end,
+		},
+		{ id = 'complex_targeting', name = 'Use more complex targeting logic?', help = 'Instead of just picking the closest target, use a more complex logic to pick the target. Currently this is only used for picking the closest target that is also closer to the player than the unit itself.', editor = 'bool',   default = false },
+		{
+			id = 'targeting_function',
+			name = 'Find_Point_to_move_to',
+			help = 'Function to find the point to move to.',
+			editor = "expression",
+			default = function(self, invader, progress) return Get_center_of_survivors() end,
+			params = "self, invader, progress",
+			no_edit = function(self) return not self.complex_targeting end
+		},
+		{
+			id = "on_arrival",
+			name = "OnArrive",
+			help = "Function this unit performs once it arrives at the target.",
+			editor = "expression",
+			default = function(
+				invader, target, progress)
+				return true
+			end,
+			params = "invader, target, progress",
+		},
+		{ id = "proximity",         name = "Stop if this close",                help = "When the unit is this many meters close to the target, trigger the on_arrival function and interrupt behavior.",                                                                                              editor = "number", default = 50000, scale = "m", min = 5000, },
 	},
 	EditorName = "Passive walk to closest target",
 }
@@ -100,7 +143,7 @@ function InvaderBehaviourPassiveMove:OnAssign(invader, end_time)
 		--print(target.class)
 		invader.pathing_to = target
 	else
-		invader.pathing_to = MapFindNearest('map',invader,true,self.target_class)
+		invader.pathing_to = MapFindNearest('map', invader, true, self.target_class)
 	end
 	invader:UpdateAttachedUI()
 end
@@ -119,12 +162,12 @@ function EnhancedTerritorialNest:new_behavior_qa()
 	--print("Testing new behaviors!")
 	local spawn_def
 	spawn_def = SpawnDefs['passive_move']
-    local instance = {}
-    instance.nest = self
-    spawn_def = spawn_def:CreateInstance(instance)
+	local instance = {}
+	instance.nest = self
+	spawn_def = spawn_def:CreateInstance(instance)
 	--print("Triggering spawndef!")
 	local t = spawn_def:ResolveTarget()
-    spawn_def:ActivateSpawn(t,{},100)
+	spawn_def:ActivateSpawn(t, {}, 100)
 end
 
 function UnitInvader:FindNextScoutingPoint()
@@ -135,13 +178,13 @@ function UnitInvader:FindNextScoutingPoint()
 	local range = self.pathing_proximity or (15 * guim)
 	while (retry > 0 and not valid_point) do
 		valid_point = self:FindValidScoutingPoint(box, self.scouted_pos, range)
-		retry = retry -1
-		range = range + 5*guim
+		retry = retry - 1
+		range = range + 5 * guim
 	end
 	if valid_point then
 		return valid_point
 	else
-		ForceActivateStoryBit('unable_to_scout',self,true)
+		ForceActivateStoryBit('unable_to_scout', self, true)
 		self.pathing = false
 		return
 	end
@@ -173,7 +216,7 @@ function UnitInvader:FindValidScoutingPoint(box_area, scouted_points, min_dist)
 				return false
 			end
 		end
-		if box_area:Dist2D(point(x,y)) > 0 then
+		if box_area:Dist2D(point(x, y)) > 0 then
 			return false
 		end
 		return true
@@ -194,7 +237,6 @@ function UnitInvader:FindValidScoutingPoint(box_area, scouted_points, min_dist)
 	return pos
 end
 
-
 function UnitInvader:Get_quadrant_to_scout()
 	local my_quad = Get_quadrant_from_obj(self)
 	local my_nesting_species = self:Get_Nesting_Species()
@@ -210,7 +252,7 @@ function UnitInvader:Get_quadrant_to_scout()
 		while retry > 0 do
 			for quad in ipairs(table.keys(tried_quads)) do
 				local adjacent = Get_adjacent_quads(Uncollapse_quad(quad))
-				for _,quad in ipairs(adjacent) do
+				for _, quad in ipairs(adjacent) do
 					if not nest_logs[quad] or (GameTime() - nest_logs[quad]) < year_duration * 2 then
 						return Collapse_quad(quad)
 					else
@@ -254,10 +296,11 @@ function UnitInvader:InvaderIdle()
 		print(self:GetDist2D(self.pathing_to))
 		local close_enough = self:IsCloser(self.pathing_to, self.pathing_proximity)
 		if self.scouting and close_enough then
-				print("Unit is scouting and is close enough to their curtrent point. Recording surroundings and rolling a enw point!")
-				self:near_scout_point()
-				-- we will have a new pathing_to prop from the above function
-				self:SetCommand("CmdPassiveMove")
+			print(
+				"Unit is scouting and is close enough to their curtrent point. Recording surroundings and rolling a enw point!")
+			self:near_scout_point()
+			-- we will have a new pathing_to prop from the above function
+			self:SetCommand("CmdPassiveMove")
 		elseif self.pathing then
 			print('Unit is trying to get to a specific point!')
 			if close_enough then
@@ -345,18 +388,107 @@ Enables a non-aggressive movement to another more complicated location
 DefineClass.InvaderBehaviourNestScout = {
 	__parents = { "InvaderBehaviourBase", },
 	properties = {
-		{ id = "map_hack", name = "Give scout map hacks?", help = "The scout will always learn of all classes it is looking for in the 4% of the map it is exploring", editor = "bool", default = false},
-		{ id = "log_classes", name = "What class should the unit record?", help = "What is this unit looking for?", editor = "string_list", items = function (self) return GetSpawnClasses() end, default = false},
-		{ id = 'distance_points', name = 'Distance between scouting points (in guim)', help = 'Quadrants are approximately 200m x 200m', editor = 'number', default = 25, scale = 'm'},
-		{ id = "attack_hostile", name = "Is the scout hostile?", help = "Will this unit fight anyone while it is roaming?", editor = "bool", default = false, no_edit = function(self) return self.attack_hostile end},
-		{ id = "ForcedGroups", name = "Combat Groups", help = "Define specific combat groups as priority targets. If empty, all groups from the specified combat classes will be targeted. If no classes are specified too, the unit will be aggressive towards everything, but its own.", editor = "set", default = set( "Humans" ), items = function (self) return CombatGroupsSetItems() end, no_edit = function(self) return self.attack_hostile end},
-		{ id = "SearchLabels", name = "Search Labels", help = "Define a label where to search for the targets. If missing, the search will be limited to a radius around.", editor = "string_list", default = {"Survivors"}, item_default = "", items = function (self) return BuildingLabelComboItems() end, no_edit = function(self) return self.attack_hostile end},
-		{ id = "SearchRadius", name = "Search Radius", help = "Search range for the targets if no search label is defined. Leave 0 to use the invader's default.", editor = "number", default = 200000, scale = "m", no_edit = function(self) return self.attack_hostile end},
-		{ id = "ForcedClasses", name = "Target Classes", help = "Define specific combat classes as priority targets. If empty, all classes with the specified combat groups will be targeted. If no groups are specified too, the unit will be aggressive towards everything, but its own..", editor = "string_list", default = {}, item_default = "", items = function (self) return ClassDescendantsList("AttackableObject") end, no_edit = function(self) return self.attack_hostile end},
-		{ id = "KeepFormation", name = "Keep Group Formation", help = "I true, the invaders will approach keeping close to each other.", editor = "bool", default = true, no_edit = function(self) return self.attack_hostile end},
+		{ id = "map_hack",        name = "Give scout map hacks?",                      help = "The scout will always learn of all classes it is looking for in the 4% of the map it is exploring", editor = "bool",   default = false },
+		{
+			id = "log_classes",
+			name = "What class should the unit record?",
+			help = "What is this unit looking for?",
+			editor = "string_list",
+			items = function(
+				self)
+				return GetSpawnClasses()
+			end,
+			default = false
+		},
+		{ id = 'distance_points', name = 'Distance between scouting points (in guim)', help = 'Quadrants are approximately 200m x 200m',                                                           editor = 'number', default = 25,   scale = 'm' },
+		{
+			id = "attack_hostile",
+			name = "Is the scout hostile?",
+			help = "Will this unit fight anyone while it is roaming?",
+			editor = "bool",
+			default = false,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "ForcedGroups",
+			name = "Combat Groups",
+			help =
+			"Define specific combat groups as priority targets. If empty, all groups from the specified combat classes will be targeted. If no classes are specified too, the unit will be aggressive towards everything, but its own.",
+			editor = "set",
+			default = set("Humans"),
+			items = function(
+				self)
+				return CombatGroupsSetItems()
+			end,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "SearchLabels",
+			name = "Search Labels",
+			help =
+			"Define a label where to search for the targets. If missing, the search will be limited to a radius around.",
+			editor = "string_list",
+			default = { "Survivors" },
+			item_default = "",
+			items = function(
+				self)
+				return BuildingLabelComboItems()
+			end,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "SearchRadius",
+			name = "Search Radius",
+			help = "Search range for the targets if no search label is defined. Leave 0 to use the invader's default.",
+			editor = "number",
+			default = 200000,
+			scale = "m",
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "ForcedClasses",
+			name = "Target Classes",
+			help =
+			"Define specific combat classes as priority targets. If empty, all classes with the specified combat groups will be targeted. If no groups are specified too, the unit will be aggressive towards everything, but its own..",
+			editor = "string_list",
+			default = {},
+			item_default = "",
+			items = function(
+				self)
+				return ClassDescendantsList("AttackableObject")
+			end,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
+		{
+			id = "KeepFormation",
+			name = "Keep Group Formation",
+			help = "I true, the invaders will approach keeping close to each other.",
+			editor = "bool",
+			default = true,
+			no_edit = function(
+				self)
+				return self.attack_hostile
+			end
+		},
 	},
 	EditorName = "Scout around the map (based on species logs)",
-	Documentation = [[The <style GedHighlight>Scouting behavior</style> is to be used by nests when trying to find the player's stuff or another species territorial nest.
+	Documentation =
+	[[The <style GedHighlight>Scouting behavior</style> is to be used by nests when trying to find the player's stuff or another species territorial nest.
 Scouts will always log anything owned by the player (Buildings, Survivors, Robots, etc...), but can also log any other spawn class if specified.
 Scouting code splits the map into 200m x 200m quadrants, and the unit will pick the closest quadrant that has not been scouted in the last year by its species to explore.
 Scouting behavior:
@@ -374,7 +506,8 @@ Note 2: If <style GedHighlight>map_hack</style> is enabled, the scout will auto 
 
 function InvaderBehaviourNestScout:OnAssign(invader, end_time)
 	if self.attack_hostile then
-		invader:ForceAggressionStart(self.ForcedGroups, self.ForcedClasses, end_time, self.SearchLabels, self.SearchRadius, self.KeepFormation)
+		invader:ForceAggressionStart(self.ForcedGroups, self.ForcedClasses, end_time, self.SearchLabels,
+			self.SearchRadius, self.KeepFormation)
 	end
 	-- Initialize scouting state
 	invader.scouting = true
@@ -386,7 +519,7 @@ function InvaderBehaviourNestScout:OnAssign(invader, end_time)
 		invader.target_quadrant = invader.from_nest.quadrant_scouting
 	end
 	invader.pathing = true
-	invader.pathing_to = invader:FindNextScoutingPoint(invader.target_quadrant,invader.scouted_pos)
+	invader.pathing_to = invader:FindNextScoutingPoint(invader.target_quadrant, invader.scouted_pos)
 	--invader.min_scout_distance = self.distance_points * guim
 	invader.looking_for = self.log_classes
 	invader.map_hack = self.map_hack
@@ -394,10 +527,10 @@ function InvaderBehaviourNestScout:OnAssign(invader, end_time)
 	invader.pathing_proximity = 5000
 	-- grant a buff to all scouts, making them able to see past 30 meters
 	if invader:GetDetectionRange() < 30 * guim then
-		if IsKindOf(invader,'Robot') then
-			invader:AddRobotCondition('scouting_sight_buff_robot','mod')
+		if IsKindOf(invader, 'Robot') then
+			invader:AddRobotCondition('scouting_sight_buff_robot', 'mod')
 		else
-			invader:AddHealthCondition('scouting_sight_buff_animal','mod')
+			invader:AddHealthCondition('scouting_sight_buff_animal', 'mod')
 		end
 	end
 	if self.map_hack then
@@ -415,7 +548,7 @@ function InvaderBehaviourNestScout:OnExpire(invader)
 	--rawset(invader, 'min_scout_distance', nil)
 	rawset(invader, 'looking_for', nil)
 	rawset(invader, 'map_hack', nil)
-	if IsKindOf(invader,'Robot') then
+	if IsKindOf(invader, 'Robot') then
 		invader:RemoveRobotCondition('scouting_sight_buff_animal')
 	else
 		invader:RemoveHealthCondition('scouting_sight_buff_animal')
@@ -430,14 +563,14 @@ local detect_game_flags = const.gofDamageable | const.gofSyncObject
 local function Scout_Detect(unit, self, detected_units)
 	--DbgAddSegment(unit, self, RandColor(self.handle))
 	if self == unit
-	or not unit.detect_spot
-	or not self:IsDetectionTarget(unit)
-	or not self:CanDetect(unit) then
+		or not unit.detect_spot
+		or not self:IsDetectionTarget(unit)
+		or not self:CanDetect(unit) then
 		return
 	end
 	for _, v in ipairs(self.looking_for) do
-		if IsKindOf(unit,v) then
-			print("I detected this, a thing I'm looking for: "..unit.class)
+		if IsKindOf(unit, v) then
+			print("I detected this, a thing I'm looking for: " .. unit.class)
 			table.insert_unique(self.observed_objects, unit)
 		end
 	end
@@ -462,12 +595,14 @@ function UnitDetection:detect_nearby()
 	end
 	local range = self:GetDetectionRange()
 	self:GetMaxCollisionRadius(range + MaxLosTargetRadius) -- cache information about the surrounding, boosting the surf enum effectiveness
-	self.los_checks = self.los_max_checks -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
+	self.los_checks = self
+		.los_max_checks                                    -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
 	local collection_idx = self:GetDetectCollectionIdx()
-	MapForEach(self, range, "!collection", collection_idx, "shuffle", seed, "UnitDetection", detect_enum_flags, nil, detect_game_flags, Scout_Detect, self, units)
+	MapForEach(self, range, "!collection", collection_idx, "shuffle", seed, "UnitDetection", detect_enum_flags, nil,
+		detect_game_flags, Scout_Detect, self, units)
 	self.los_checks = nil
 	local count = #units
-	for i=count,1,-1 do
+	for i = count, 1, -1 do
 		local unit = units[i]
 		if time ~= units[unit] then
 			self:UnitExitDetection(unit)
@@ -487,7 +622,7 @@ function UnitInvader:Get_New_Scout_Point()
 	self.scouted_pos[1] = new_one
 	self.scouted_pos[2] = new_two
 	self.scouted_pos[3] = new_three
-	self.pathing_to = self:FindNextScoutingPoint(self.target_quadrant,self.scouted_pos)
+	self.pathing_to = self:FindNextScoutingPoint(self.target_quadrant, self.scouted_pos)
 	if self.pathing_to then
 		print("Pathing to new point!")
 	end
@@ -505,5 +640,5 @@ function TFormat.ScoutFailed(context_obj)
 	local map_name = GetMapName()
 	local quadrant = 5 --context_obj.target_quadrant
 	local unit = context_obj.actor.class or 'Unknown'
-	return Untranslated('<em>Map Name:  '..map_name..'\nQuadrant:  '..quadrant..'\nUnit:  '..unit..'</em>')
+	return Untranslated('<em>Map Name:  ' .. map_name .. '\nQuadrant:  ' .. quadrant .. '\nUnit:  ' .. unit .. '</em>')
 end


### PR DESCRIPTION
- Repair the growth_event dispatch so it runs instead of crashing: undefined scout_quad/Asleep methods, 2-arg MulDivRound, table-vs-number comparisons, an unguarded scouting grid, and the iapairs/for-in-table loops in GetNearbyEnemiesNonPlayer.
- Implement GetNestToSupport: a nest attacks only when it is the most-forward of its species toward the survivor centre; otherwise it supports a same-species nest that is closer AND within ~60deg of its bearing. The same angular gate steers the support unit's destination, so reinforcements don't path across the base to a ~180deg-opposite nest.
- Guard Get_center_of_survivors against divide-by-zero with no survivors.