### PR TITLE
Fix/aggression

### DIFF
--- a/Code/NA_Aggression.lua
+++ b/Code/NA_Aggression.lua
@@ -1,7 +1,6 @@
-
 local og_produce_output = ProductionDeviceComponent.ProduceOutput
 function ProductionDeviceComponent:ProduceOutput(recipe, def, count, unit)
-	Resource_aggression_check(self.unfinished_item_data.used_resources,self)
+	Resource_aggression_check(self.unfinished_item_data.used_resources, self)
 	og_produce_output(self, recipe, def, count, unit)
 end
 
@@ -34,7 +33,7 @@ function Aggression_log_faction(input)
 	DebugPrint(IsKindOf(nesting_species, "NestingSpeciesPreset"))
 	DebugPrint(IsKindOf(nesting_species.id, "NestingSpeciesPreset"))
 	local to_return = false
-	local threshold = Faction_aggression_threshold or Max(0,6 - Get_difficulty_offset())
+	local threshold = Faction_aggression_threshold or Max(0, 6 - Get_difficulty_offset())
 	local count = 0
 	if Nest_Species_Savegame_Stats[nesting_species] and Nest_Species_Savegame_Stats[nesting_species][nesting_species .. '_aggro_events'] then
 		count = Nest_Species_Savegame_Stats[nesting_species][nesting_species .. '_aggro_events']
@@ -75,18 +74,18 @@ function Resource_aggression_check(unfinished_table, bench)
 	DebugPrint("recipe_res")
 	DebugPrint(recipe_res)
 	--local scale = const.ResourceScale -- 1000 base
-	for _,res in ipairs(recipe_res) do
-		DebugPrint("Checking res: "..res)
+	for _, res in ipairs(recipe_res) do
+		DebugPrint("Checking res: " .. res)
 		if res_table[res] then
 			DebugPrint("it is a res that nests care about")
 			-- already scaled because this is from the recipe
 			local consumed = unfinished_table[res]
-			for _,v in ipairs(res_table[res]) do
+			for _, v in ipairs(res_table[res]) do
 				local roll = AsyncRand(100)
 				local aggression_roll = roll > DivRound(consumed * 100, v.chance)
 				if consumed >= v.chance or aggression_roll then
-					DebugPrint("Aggression triggered for species: "..v.species)
-					Aggression_up(v.species,bench)
+					DebugPrint("Aggression triggered for species: " .. v.species)
+					Aggression_up(v.species, bench)
 					aggroed[#aggroed + 1] = v.species
 				end
 			end
@@ -103,8 +102,8 @@ local function can_spawn_nest(input)
 	local nest_class_def = find_nest_class(input)
 	if not nest_class_def then return nil end
 	local nest_classname = nest_class_def.class
-	DebugPrint("Checking if can spawn nest for species: "..species_id)
-	DebugPrint("Checking how many nests of this clas exist on map: "..nest_classname)
+	DebugPrint("Checking if can spawn nest for species: " .. species_id)
+	DebugPrint("Checking how many nests of this clas exist on map: " .. nest_classname)
 	local count_total = MapCount("map", nest_classname)
 
 	-- In cases where the player needs to do something before spawning is enabled.
@@ -155,7 +154,7 @@ local function can_give_evo(input)
 	end
 end
 
-function Aggression_up(input,location)
+function Aggression_up(input, location)
 	local nest_species = find_nest_species(input)
 	if not nest_species then
 		nest_species = find_nest_species(Get_nest_species_by_region())
@@ -193,7 +192,7 @@ function Aggression_up(input,location)
 		if can_give_evo(species_name) then
 			choice[#choice + 1] = { event = 'evo', weight = 200 }
 		end
-		if  DivRound(count_awake * 100, count_total) < 75 then
+		if DivRound(count_awake * 100, count_total) < 75 then
 			choice[#choice + 1] = { event = 'wakeup', weight = 150 }
 		end
 	end
@@ -211,8 +210,8 @@ function Aggression_up(input,location)
 			end
 		end)
 		local lowest_evo = 10
-		for _,v in ipairs(nests or empty_table) do
-			local tier = EE_get_tier(v.elder_class)   -- lazy-inits EE's tier pivot; nil if species unmapped
+		for _, v in ipairs(nests or empty_table) do
+			local tier = EE_get_tier(v.elder_class) -- lazy-inits EE's tier pivot; nil if species unmapped
 			if tier and tier < lowest_evo then
 				weakest_nest = v
 				lowest_evo = tier
@@ -246,16 +245,17 @@ function Aggression_up(input,location)
 		end
 		--nest_picked:SwitchState("sleepy")
 	elseif option == 'bank' then
-		local species_banked_aggr = species_name..'_banked_aggr'
+		local species_banked_aggr = species_name .. '_banked_aggr'
 		if Nest_Species_Savegame_Stats[species_name] and Nest_Species_Savegame_Stats[species_name][species_banked_aggr] then
-			Nest_Species_Savegame_Stats[species_name][species_banked_aggr] = Nest_Species_Savegame_Stats[species_name][species_banked_aggr] + 5
+			Nest_Species_Savegame_Stats[species_name][species_banked_aggr] = Nest_Species_Savegame_Stats[species_name]
+			[species_banked_aggr] + 5
 		else
 			DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
 			Nest_Species_Savegame_Stats[species_name] = Nest_Species_Savegame_Stats[species_name] or {}
 			Nest_Species_Savegame_Stats[species_name][species_banked_aggr] = 5
 		end
 	elseif option == 'consume' then
-		for i=1, Max(1, Get_difficulty_offset()) do
+		for i = 1, Max(1, Get_difficulty_offset()) do
 			weakest_nest:consume_closest_node()
 		end
 	end

--- a/Code/NA_Aggression.lua
+++ b/Code/NA_Aggression.lua
@@ -97,16 +97,18 @@ function Resource_aggression_check(unfinished_table, bench)
 end
 
 local function can_spawn_nest(input)
-	local nest_species = find_nest_species(input).id
+	local nest_species = find_nest_species(input)
+	if not nest_species then return nil end
+	local species_id = nest_species.id
 	local nest_class_def = find_nest_class(input)
 	if not nest_class_def then return nil end
 	local nest_classname = nest_class_def.class
-	DebugPrint("Checking if can spawn nest for species: "..nest_species.id)
+	DebugPrint("Checking if can spawn nest for species: "..species_id)
 	DebugPrint("Checking how many nests of this clas exist on map: "..nest_classname)
 	local count_total = MapCount("map", nest_classname)
 
 	-- In cases where the player needs to do something before spawning is enabled.
-	if not Nest_Species_Savegame_Stats[nest_species]['spawnflag'] then return false end
+	if not Nest_Species_Savegame_Stats[species_id]['spawnflag'] then return false end
 
 	-- Do nothing if too many nests exist
 	if count_total >= Per_species_nest_max then
@@ -117,7 +119,7 @@ local function can_spawn_nest(input)
 	if GameTime() < Global_nest_spawn_cd then
 		-- cannot spawn due to global cd
 		return false
-	elseif Nest_Species_Savegame_Stats[nest_species] and Nest_Species_Savegame_Stats[nest_species][nest_species .. '_nest_spawn_cd'] and GameTime() < Nest_Species_Savegame_Stats[nest_species][nest_species .. '_nest_spawn_cd'] then
+	elseif Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] and GameTime() < Nest_Species_Savegame_Stats[species_id][species_id .. '_nest_spawn_cd'] then
 		-- cannot spawn due to species specific cd
 		return false
 	else
@@ -127,25 +129,26 @@ local function can_spawn_nest(input)
 end
 
 local function can_give_evo(input)
-	local nest_species = find_nest_species(input).id
+	local nest_species = find_nest_species(input)
 	if not nest_species then return nil end
+	local species_id = nest_species.id
 	if MapCount(true, nest_species.nest_class) <= 0 then
 		return false
 	end
 	local new_evo_time = GameTime() + DivRound(MoonInstance.AttackCooldownMin, 2)
-	local species_evo_var = nest_species.id .. '_evo_cd'
-	if not Nest_Species_Savegame_Stats[nest_species] or not Nest_Species_Savegame_Stats[nest_species][species_evo_var] then
-		Nest_Species_Savegame_Stats[nest_species] = Nest_Species_Savegame_Stats[nest_species] or {}
-		Nest_Species_Savegame_Stats[nest_species][species_evo_var] = new_evo_time
+	local species_evo_var = species_id .. '_evo_cd'
+	if not Nest_Species_Savegame_Stats[species_id] or not Nest_Species_Savegame_Stats[species_id][species_evo_var] then
+		Nest_Species_Savegame_Stats[species_id] = Nest_Species_Savegame_Stats[species_id] or {}
+		Nest_Species_Savegame_Stats[species_id][species_evo_var] = new_evo_time
 		DebugPrint("Nesting species did not have an entry in map vars for their evo events! Alert mod author!")
 		return true
-	elseif Nest_Species_Savegame_Stats[nest_species] and Nest_Species_Savegame_Stats[nest_species][species_evo_var] then
-		if GameTime() < Nest_Species_Savegame_Stats[nest_species][species_evo_var] then
+	elseif Nest_Species_Savegame_Stats[species_id] and Nest_Species_Savegame_Stats[species_id][species_evo_var] then
+		if GameTime() < Nest_Species_Savegame_Stats[species_id][species_evo_var] then
 			-- cannot evo due to species specific cd
 			return false
 		else
-			Nest_Species_Savegame_Stats[nest_species][species_evo_var] = new_evo_time
-			return false
+			Nest_Species_Savegame_Stats[species_id][species_evo_var] = new_evo_time
+			return true
 		end
 	else
 		return false
@@ -155,7 +158,11 @@ end
 function Aggression_up(input,location)
 	local nest_species = find_nest_species(input)
 	if not nest_species then
-		nest_species = Get_nest_species_by_region()
+		nest_species = find_nest_species(Get_nest_species_by_region())
+	end
+	if not nest_species then
+		DebugPrint("Aggression_up: could not resolve a nesting species; skipping\n")
+		return
 	end
 	DebugPrint("Aggression up called\n")
 	DebugPrint("Checking if species is valid")
@@ -204,14 +211,14 @@ function Aggression_up(input,location)
 			end
 		end)
 		local lowest_evo = 10
-		local tiers = get_tier_Table()
-		for _,v in ipairs(nests) do
-			local tier = tiers[v.elder_class]
-			if tier < lowest_evo then
+		for _,v in ipairs(nests or empty_table) do
+			local tier = EE_get_tier(v.elder_class)   -- lazy-inits EE's tier pivot; nil if species unmapped
+			if tier and tier < lowest_evo then
 				weakest_nest = v
 				lowest_evo = tier
 			end
 		end
+		if not weakest_nest then return end
 		DebugPrint("Weakest nest needed, here it is:")
 		DebugPrint(weakest_nest)
 	end
@@ -224,20 +231,27 @@ function Aggression_up(input,location)
 			weakest_nest:change_nest_herd(true)
 		end
 	elseif option == 'wakeup' then
-		local nest_picked = MapGetNearest("map", location, species_nest_name, function(this_nest)
-			if this_nest.state == 'asleep' then
-				return true
-			end
-		end)
-		nest_picked:scout_nearest_quad()
+		local nest_picked
+		if location then
+			nest_picked = MapFindNearest(location, "map", species_nest_name, function(this_nest)
+				return this_nest.state == 'asleep'
+			end)
+		else
+			nest_picked = MapGetFirst("map", species_nest_name, function(this_nest)
+				return this_nest.state == 'asleep'
+			end)
+		end
+		if nest_picked then
+			nest_picked:scout_nearest_quad()
+		end
 		--nest_picked:SwitchState("sleepy")
 	elseif option == 'bank' then
 		local species_banked_aggr = species_name..'_banked_aggr'
-		if Nest_Species_Savegame_Stats[species] and Nest_Species_Savegame_Stats[species_name][species_banked_aggr] then
+		if Nest_Species_Savegame_Stats[species_name] and Nest_Species_Savegame_Stats[species_name][species_banked_aggr] then
 			Nest_Species_Savegame_Stats[species_name][species_banked_aggr] = Nest_Species_Savegame_Stats[species_name][species_banked_aggr] + 5
 		else
 			DebugPrint("Nesting species does not have an entry in map vars for their banked aggro! Alert mod author!")
-			Nest_Species_Savegame_Stats[species_name] = {}
+			Nest_Species_Savegame_Stats[species_name] = Nest_Species_Savegame_Stats[species_name] or {}
 			Nest_Species_Savegame_Stats[species_name][species_banked_aggr] = 5
 		end
 	elseif option == 'consume' then
@@ -250,7 +264,11 @@ end
 function Aggression_down(input)
 	local nest_species = find_nest_species(input)
 	if not nest_species then
-		nest_species = Get_nest_species_by_region()
+		nest_species = find_nest_species(Get_nest_species_by_region())
+	end
+	if not nest_species then
+		DebugPrint("Aggression_down: could not resolve a nesting species; skipping\n")
+		return
 	end
 	local species_nest_name = nest_species.nest_class
 	DebugPrint("Aggression down called\n")

--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -243,9 +243,9 @@ function find_nest_species(input)
 	-- Always resolve to the NestingSpeciesPreset object (or false), regardless of whether
 	-- the caller passed a preset id, a nest class name, the preset itself, or a nest object.
 	if type(input) == 'string' then
-		local by_id = Presets.NestingSpeciesPreset.Default[input]   -- preset id, e.g. "nesting_consortium"
+		local by_id = Presets.NestingSpeciesPreset.Default[input] -- preset id, e.g. "nesting_consortium"
 		if by_id then return by_id end
-		if g_Classes[input] then                                    -- nest class name, e.g. "ConsortiumNest"
+		if g_Classes[input] then                            -- nest class name, e.g. "ConsortiumNest"
 			local species_id = get_species_from_nest(input)
 			if species_id then return Presets.NestingSpeciesPreset.Default[species_id] end
 		end

--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -238,22 +238,23 @@ function Bkob_Log_NA(hard_string, var)
 	end
 end
 
--- input a string or classdef, output the nesting species classdef (If we can find it)
+-- input a preset id, nest class name, preset, or nest object; output the NestingSpeciesPreset (or false)
 function find_nest_species(input)
-	local str_check = type(input) == 'string'
-	local nest_spec_check, nest_entity_check
-	if str_check then
-		nest_spec_check = Presets.NestingSpeciesPreset.Default[input]
-		nest_entity_check = g_Classes[input]
-	else
-		nest_spec_check = IsKindOf(input, "NestingSpecies")
-		nest_entity_check = IsKindOf(input, "TerritorialNest")
+	-- Always resolve to the NestingSpeciesPreset object (or false), regardless of whether
+	-- the caller passed a preset id, a nest class name, the preset itself, or a nest object.
+	if type(input) == 'string' then
+		local by_id = Presets.NestingSpeciesPreset.Default[input]   -- preset id, e.g. "nesting_consortium"
+		if by_id then return by_id end
+		if g_Classes[input] then                                    -- nest class name, e.g. "ConsortiumNest"
+			local species_id = get_species_from_nest(input)
+			if species_id then return Presets.NestingSpeciesPreset.Default[species_id] end
+		end
+		return false
 	end
-	if nest_entity_check then
-		return get_species_from_nest(nest_entity_check.id)
-	end
-	if nest_spec_check then
-		return nest_spec_check
+	if IsKindOf(input, "NestingSpeciesPreset") then return input end
+	if IsKindOf(input, "TerritorialNest") then
+		local species_id = get_species_from_nest(input.class)
+		if species_id then return Presets.NestingSpeciesPreset.Default[species_id] end
 	end
 	return false
 end


### PR DESCRIPTION
find_nest_species now always returns the species preset (or false), so class-name callers (the Consortium storybit, every Aggression_down) resolve correctly instead of crashing on string .id/.nest_class.

- can_spawn_nest/can_give_evo: false-guard input, key stats by species id
- can_give_evo: allow evo once the cooldown expires (was always false)
- wakeup: MapGetNearest -> MapFindNearest; handle nil location and nil nest
- evo/consume: guard empty MapGet result and nil weakest_nest
- bank: fix undefined 'species' global; stop wiping the species stats entry
- tier lookup: use EE_get_tier (lazy-init) and skip unmapped species