### PR TITLE
Fix nest scouting-invader crashes

### DIFF
--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -382,7 +382,7 @@ end
 function EnhancedTerritorialNest:get_proximity()
 	local center = AveragePoint2D(GetValidSurvivorsOnMap())
 	local dist_to_center = self:GetDist2D(center)
-	local rate = 150 * guim     -- 150 meters per thresholdz
+	local rate = 150 * guim  -- 150 meters per thresholdz
 	local prox = DivRound(dist_to_center, rate)
 	prox = Max(1, Min(5, prox)) -- closest nests have a prox of 1
 	self.proximity = prox
@@ -780,13 +780,14 @@ function ReportScoutingResults(quad_no, species, objects_to_report, player_found
 	scout_quad_logs['map_objs'] = objects_to_report
 	for _, obj in ipairs(objects_to_report) do
 		if IsKindOf(obj, "TerritorialNest") and obj.nest_species ~= species then
+			local that_species = obj.nest_species
 			if scout_quad_logs[that_species] then
-				scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = nest
-				nest:MarkScouted(self.nest_species, GameTime())
+				scout_quad_logs[that_species][#scout_quad_logs[that_species] + 1] = obj
 			else
 				scout_quad_logs[that_species] = {}
-				scout_quad_logs[that_species][1] = nest
+				scout_quad_logs[that_species][1] = obj
 			end
+			nest:MarkScouted(that_species, GameTime())
 		end
 		scout_quad_logs['map_objs'][#scout_quad_logs['map_objs'] + 1] = nest
 	end
@@ -1047,7 +1048,7 @@ function EnhancedTerritorialNest:GetSupportTarget()
 	MapForEach("map", self.class, function(nest, me)
 		if nest == me then return end
 		local n_dist = nest:GetDist2D(center)
-		if n_dist >= my_dist then return end                                                           -- only nests ahead of me (closer to the survivors)
+		if n_dist >= my_dist then return end                                                     -- only nests ahead of me (closer to the survivors)
 		if abs(AngleDiff(my_bearing, CalcOrientation(center, nest:GetPos()))) > sector then return end -- same sector only
 		if not best or n_dist < best_dist then
 			best, best_dist = nest, n_dist

--- a/Code/NA_Unit_Invader_Expansion.lua
+++ b/Code/NA_Unit_Invader_Expansion.lua
@@ -238,31 +238,37 @@ function UnitInvader:FindValidScoutingPoint(box_area, scouted_points, min_dist)
 end
 
 function UnitInvader:Get_quadrant_to_scout()
-	local my_quad = Get_quadrant_from_obj(self)
+	local my_quad = Get_quadrant_from_obj(self, true) -- integer quadrant number
 	local my_nesting_species = self:Get_Nesting_Species()
 	if not my_nesting_species then return my_quad end
-	local nest_logs = G_nest_scout_logs[my_nesting_species].quadrants or {}
-	-- Try to scout where I am
-	if not nest_logs[my_quad] or (GameTime() - nest_logs[my_quad]) < year_duration * 2 then
-		return Collapse_quad(my_quad)
-	else
-		local retry = 2
-		local tried_quads = {}
-		tried_quads[Collapse_quad(my_quad)] = true
-		while retry > 0 do
-			for quad in ipairs(table.keys(tried_quads)) do
-				local adjacent = Get_adjacent_quads(Uncollapse_quad(quad))
-				for _, quad in ipairs(adjacent) do
-					if not nest_logs[quad] or (GameTime() - nest_logs[quad]) < year_duration * 2 then
-						return Collapse_quad(quad)
-					else
-						tried_quads[quad] = true
-					end
+	-- A quadrant needs scouting if this species never scouted it, or last did so over two years ago.
+	-- Freshness test mirrors EnhancedTerritorialNest:scout_nearest_quad (NA_NestExpansion.lua).
+	local function needs_scouting(quad_no)
+		local log = Nest_scouting_quadrants[quad_no] and Nest_scouting_quadrants[quad_no][my_nesting_species]
+		if not log then return true end
+		return log.last_scout == 0 or (GameTime() - log.last_scout) >= const.Scale.years * 2
+	end
+	-- Prefer the quadrant we are already in.
+	if needs_scouting(my_quad) then
+		return my_quad
+	end
+	-- Otherwise search outward (up to two rings of adjacency) for the nearest stale quadrant.
+	local tried = { [my_quad] = true }
+	local frontier = { my_quad }
+	for _ = 1, 2 do
+		local next_frontier = {}
+		for _, q in ipairs(frontier) do
+			for _, adj in ipairs(Get_adjacent_quads(q)) do
+				if not tried[adj] then
+					if needs_scouting(adj) then return adj end
+					tried[adj] = true
+					next_frontier[#next_frontier + 1] = adj
 				end
-				retry = retry - 1
 			end
 		end
+		frontier = next_frontier
 	end
+	return my_quad -- nothing stale nearby; scout where we are
 end
 
 function UnitInvader:CheckForNewBehaviors()
@@ -596,22 +602,15 @@ function UnitDetection:detect_nearby()
 	local range = self:GetDetectionRange()
 	self:GetMaxCollisionRadius(range + MaxLosTargetRadius) -- cache information about the surrounding, boosting the surf enum effectiveness
 	self.los_checks = self
-		.los_max_checks                                    -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
+		.los_max_checks                                 -- Limit the maximum allowed LOS checks. The enum is randomized, so we should eventually check all units.
 	local collection_idx = self:GetDetectCollectionIdx()
 	MapForEach(self, range, "!collection", collection_idx, "shuffle", seed, "UnitDetection", detect_enum_flags, nil,
 		detect_game_flags, Scout_Detect, self, units)
 	self.los_checks = nil
-	local count = #units
-	for i = count, 1, -1 do
-		local unit = units[i]
-		if time ~= units[unit] then
-			self:UnitExitDetection(unit)
-			units[i] = units[count]
-			units[count] = nil
-			units[unit] = nil
-			count = count - 1
-		end
-	end
+	-- Scout_Detect fills self.observed_objects (the scout's report); it does not maintain the
+	-- detected_units cache, so the engine's copied prune loop here was both broken (undefined
+	-- `time`, and no per-pass timestamps to compare) and redundant with the engine's own
+	-- UnitDetection:OnObjUpdate, which owns that cache. Removed.
 end
 
 function UnitInvader:Get_New_Scout_Point()


### PR DESCRIPTION
The growth_event "scout" dispatch now spawns scout invaders, exposing several undefined-global crashes on the scouting path:

- Get_quadrant_to_scout: read undefined G_nest_scout_logs and year_duration. Rewritten to use the real Nest_scouting_quadrants[quad][species].last_scout with const.Scale.years, integer quad keys, and a correct "scout the stale quadrant" test (was inverted) plus a terminating outward search.
- ReportScoutingResults: undefined globals that_species and self. Define that_species = obj.nest_species, bucket found nests by their own species, and mark scouted via the passed-in nest.
- detect_nearby: remove the engine-copied prune loop that read an undefined `time`; Scout_Detect fills observed_objects and never maintained that cache, which the engine's own UnitDetection:OnObjUpdate already owns.