### PR TITLE
Fix undefined-global typo in Juno spawn storybit prerequisite

### DIFF
--- a/items.lua
+++ b/items.lua
@@ -2527,7 +2527,7 @@ PlaceObj('ModItemFolder', {
 						return true
 					end 
 					end)
-					return nests_convertible > 0
+					return nest_convertible > 0
 				end,
 				param_bindings = false,
 			}),


### PR DESCRIPTION
The new_nest_juno_actual prerequisite's CheckExpression assigned a local nest_convertible but returned nests_convertible (no such global), so the comparison ran nil > 0 and threw under the prerequisite procall.