### PR TITLE
Fix nest species-stats never populating (RegisterTarget nil-index crash)

### DIFF
--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -80,9 +80,12 @@ end
 function Setup_nest_mod()
 	CreateGameTimeThread(function()
 		WaitMsg("DlcsLoaded")
-		if not Nest_Species_Savegame_Stats then
-			NA_create_runtime()
-		end
+		-- Populate per-species stats unconditionally; NA_create_runtime skips any species already present
+		-- (line 57), so it is safe on both new games and savegame loads. The old
+		-- `if not Nest_Species_Savegame_Stats` guard was dead -- the MapVar defaults to {} (truthy), so it
+		-- never fired and every Nest_Species_Savegame_Stats[id] read nil (regression from commit 460df25,
+		-- which extracted this loop into NA_create_runtime but gated the call on an always-false condition).
+		NA_create_runtime()
 		if Nest_scouting_quadrants == {} then
 			CreateMapGrid()
 		end

--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -80,11 +80,8 @@ end
 function Setup_nest_mod()
 	CreateGameTimeThread(function()
 		WaitMsg("DlcsLoaded")
-		-- Populate per-species stats unconditionally; NA_create_runtime skips any species already present
-		-- (line 57), so it is safe on both new games and savegame loads. The old
-		-- `if not Nest_Species_Savegame_Stats` guard was dead -- the MapVar defaults to {} (truthy), so it
-		-- never fired and every Nest_Species_Savegame_Stats[id] read nil (regression from commit 460df25,
-		-- which extracted this loop into NA_create_runtime but gated the call on an always-false condition).
+		-- Unguarded on purpose: an `if not Nest_Species_Savegame_Stats` check is a trap (the MapVar defaults
+		-- to {}, always truthy), and NA_create_runtime is idempotent, so a guard would only ever skip it.
 		NA_create_runtime()
 		if Nest_scouting_quadrants == {} then
 			CreateMapGrid()

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -500,9 +500,13 @@ function EnhancedTerritorialNest:can_be_aggressive(who)
 end
 
 function EnhancedTerritorialNest:RegisterTarget(unit, time)
-	if not Nest_Species_Savegame_Stats then
-		NA_create_runtime()
+	-- nest_species has no class default (set lazily in expand()/growth_event()); the engine UnitDetection
+	-- sweep can reach RegisterTarget first, leaving Nest_Species_Savegame_Stats[self.nest_species] a nil
+	-- index. Resolve it here as the other call sites do, and bail if the species can't be resolved.
+	if not self.nest_species then
+		self.nest_species = get_species_from_nest(self.class)
 	end
+	if not self.nest_species then return end
 	local wake_up_flag = false
 	if unit.player then
 		self.attacked_by_player = true

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -500,9 +500,8 @@ function EnhancedTerritorialNest:can_be_aggressive(who)
 end
 
 function EnhancedTerritorialNest:RegisterTarget(unit, time)
-	-- nest_species has no class default (set lazily in expand()/growth_event()); the engine UnitDetection
-	-- sweep can reach RegisterTarget first, leaving Nest_Species_Savegame_Stats[self.nest_species] a nil
-	-- index. Resolve it here as the other call sites do, and bail if the species can't be resolved.
+	-- The detection sweep can reach RegisterTarget before expand()/growth_event() lazily assign
+	-- nest_species, which would otherwise index Stats[nil] below.
 	if not self.nest_species then
 		self.nest_species = get_species_from_nest(self.class)
 	end


### PR DESCRIPTION
Fix nest species-stats never populating (RegisterTarget nil-index crash)

Setup_nest_mod gated NA_create_runtime() behind `if not Nest_Species_Savegame_Stats`, but that MapVar defaults to {} (truthy), so the guard never fired and the per-species stats were never populated; every Nest_Species_Savegame_Stats[id] access then read nil. Regression from 460df25, which extracted the populate loop into NA_create_runtime but changed the call from unconditional to that dead guard.

Call NA_create_runtime() unconditionally. It is idempotent (the per-id guard at line 57 skips species already present), so it is safe on new games and savegame loads, and forward-compatible for saves predating a newly added species.

Also resolve nest_species lazily in RegisterTarget: it has no class default and the engine UnitDetection sweep can reach RegisterTarget before expand()/growth_event() assign it, which would index Stats[nil]. Mirrors the existing lazy-init at the other call sites.