### PR TITLE
Memoise survivor centre per GameTime tick

### DIFF
--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -1,8 +1,7 @@
 -------------------- MOD SETUP ---------------------
 local hour_duration = const.HourDuration
 
--- Per-tick memo for Get_center_of_survivors (see its definition). Declared here so both
--- Setup_nest_mod (resets the stamp on map load) and Get_center_of_survivors capture them as upvalues.
+-- Up here, not beside Get_center_of_survivors, so Setup_nest_mod's stamp reset can capture them too.
 local survivor_centre_cache = false
 local survivor_centre_stamp = false
 
@@ -83,8 +82,8 @@ function NA_create_runtime()
 end
 
 function Setup_nest_mod()
-	-- Invalidate the survivor-centre memo: GameTime resets across maps, so a stamp left over from a
-	-- prior map could otherwise match this map's GameTime and return a stale (off-map) centre.
+	-- Reset across maps: GameTime restarts, so a stamp from a prior map could match and return a stale
+	-- off-map centre.
 	survivor_centre_stamp = false
 	CreateGameTimeThread(function()
 		WaitMsg("DlcsLoaded")
@@ -384,11 +383,8 @@ function NA_tutorial()
 	Nest_tutorial = true
 end
 
--- The survivor centre is identical for every caller within one GameTime tick, but a wave of
--- simultaneous nest updates (each nest's GetSupportTarget / get_proximity / IsClosestToPlayer, etc.)
--- would otherwise re-average the whole party once per nest. Memoise it per tick: the first call in a
--- tick computes and stamps it with GameTime(); later calls in the same tick return the cached point.
--- The stamp is cleared on map load (Setup_nest_mod) so a value from a prior map can never survive.
+-- Identical for every caller within a GameTime tick, but a wave of nest updates would re-average the
+-- whole party once per nest -- so cache it per tick.
 function Get_center_of_survivors()
 	if survivor_centre_stamp == GameTime() then
 		return survivor_centre_cache

--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -1,6 +1,11 @@
 -------------------- MOD SETUP ---------------------
 local hour_duration = const.HourDuration
 
+-- Per-tick memo for Get_center_of_survivors (see its definition). Declared here so both
+-- Setup_nest_mod (resets the stamp on map load) and Get_center_of_survivors capture them as upvalues.
+local survivor_centre_cache = false
+local survivor_centre_stamp = false
+
 MapVar("Global_nest_spawn_cd", 0)
 MapVar("Nest_Notifications", 1)
 MapVar("Nest_Species_Savegame_Stats", {})
@@ -78,6 +83,9 @@ function NA_create_runtime()
 end
 
 function Setup_nest_mod()
+	-- Invalidate the survivor-centre memo: GameTime resets across maps, so a stamp left over from a
+	-- prior map could otherwise match this map's GameTime and return a stale (off-map) centre.
+	survivor_centre_stamp = false
 	CreateGameTimeThread(function()
 		WaitMsg("DlcsLoaded")
 		if not Nest_Species_Savegame_Stats then
@@ -376,7 +384,15 @@ function NA_tutorial()
 	Nest_tutorial = true
 end
 
+-- The survivor centre is identical for every caller within one GameTime tick, but a wave of
+-- simultaneous nest updates (each nest's GetSupportTarget / get_proximity / IsClosestToPlayer, etc.)
+-- would otherwise re-average the whole party once per nest. Memoise it per tick: the first call in a
+-- tick computes and stamps it with GameTime(); later calls in the same tick return the cached point.
+-- The stamp is cleared on map load (Setup_nest_mod) so a value from a prior map can never survive.
 function Get_center_of_survivors()
+	if survivor_centre_stamp == GameTime() then
+		return survivor_centre_cache
+	end
 	local surv = GetValidSurvivorsOnMap()
 	local sum_x = 0
 	local sum_y = 0
@@ -389,11 +405,15 @@ function Get_center_of_survivors()
 		sum_y = sum_y + y
 		count = count + 1
 	end
+	local center
 	if count == 0 then
 		-- no valid survivors (rare; e.g. a wipe) -> fall back to map centre to avoid a /0 crash
-		return GetMapBox():Center()
+		center = GetMapBox():Center()
+	else
+		center = point(DivRound(sum_x, count), DivRound(sum_y, count))
 	end
-	local center = point(DivRound(sum_x, count), DivRound(sum_y, count))
+	survivor_centre_cache = center
+	survivor_centre_stamp = GameTime()
 	return center
 end
 


### PR DESCRIPTION
Get_center_of_survivors averages the whole survivor party and is called by every nest's per-tick decision (GetSupportTarget, get_proximity, IsClosestToPlayer, the invader pathing default, decay_speed). A wave of simultaneous nest updates re-ran that average once per nest, yet the value is identical for all callers within one GameTime tick.

Cache it keyed on GameTime(): the first call in a tick computes and stamps it, later calls return the cached point. The stamp is cleared in Setup_nest_mod so a value from a prior map can't survive a reload; GameTime resets across maps and could otherwise match the stamp.