### PR TITLE
Fix/nest consume defects

### DIFF
--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -312,9 +312,14 @@ function EnhancedTerritorialNest:give_ep_to_struct(ep)
 	if not ep then return end
 	Bkob_Log_NA("Nest storing EP in support structures\n")
 	local spore_building_def = g_Classes[Presets.NestingSpeciesPreset.Default[self.nest_species].spore_buildings]
+	-- spore_buildings defaults to false, so g_Classes[false] can be nil here.
+	if not spore_building_def then return end
 	Bkob_Log_NA(spore_building_def.class)
 	Bkob_Log_NA(self.territorial_range)
 	local spores_near = MapGet(self, self.territorial_range, spore_building_def.class)
+	-- Bail rather than error: consume_closest_node set consume_time = max_int before calling us, so an
+	-- error here is procall-caught but never recovered and the nest never consumes again.
+	if not spores_near or #spores_near == 0 then return end
 	Bkob_Log_NA("There are this many spore buildings near me: ", #spores_near)
 	local progress_each = DivRound(ep, #spores_near)
 	local spore_res = Resources[spore_building_def.MineResource] --Resources[spores_near[1]]

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -248,7 +248,9 @@ function EnhancedTerritorialNest:expand()
 	while nodes < 30 and grows < max_growths do
 		--(nodes)
 		--("expanded the distance ",grows,' times')
-		nodes = MapCount(self, (self.territorial_range + (grows * expand_by)) * guim, function(thing)
+		-- territorial_range is already in engine units, so the old outer `* guim` double-scaled it to a
+		-- map-wide radius. Scale only the per-growth expansion (expand_by metres) instead.
+		nodes = MapCount(self, self.territorial_range + (grows * expand_by * guim), function(thing)
 			if not IsKindOf(thing, 'NestSpore') then return true end
 		end)
 		grows = grows + 1


### PR DESCRIPTION
Guard give_ep_to_struct against nil spore-def and zero divide

give_ep_to_struct could strand a nest two ways, both via the procall-caught OnObjUpdate path after consume_closest_node set consume_time = max_int (so the catch leaves it stuck and the nest never consumes again):

- spore_buildings has default false (NA_NestPreset), so for any species without one g_Classes[false] is nil and the spore_building_def.class log indexes nil;
- with no spore building in territorial range, #spores_near is 0 and DivRound(ep, 0) errors.

Return early in both cases. All nine species set spore_buildings, so the nil-def path is latent today but reachable via Convert_nest_into.