### PR TITLE
Fix/attack spawn retry loop

### DIFF
--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -671,7 +671,9 @@ function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
 	local def = spawn_class and g_Classes[spawn_class]
 	local pfclass = def.pfclass
 	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-	if not pos then print("no pos found!") end
+	-- No passable tile at the nest means no spawn anchor; pos feeds GetRandomPlayablePos/IsCloser2D below,
+	-- which throw on nil (this call is not procall-guarded), so bail instead of just logging.
+	if not pos then return nil end
 	local nest_entity_radius = spawndef_instance.nest:GetRadius()
 	local x, y
 	local retry = 10

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -677,10 +677,14 @@ function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
 	local retry = 10
 	local range = spawndef_instance.nest.max_range
 	local target_radius = 30 * guim
+	-- Up to 10 attempts, widening target_radius (no passable spot near the target) or range (spot rejected)
+	-- each pass. retry must decrement on every path or the no-spot branch spins, and x resets on a connectivity
+	-- failure so `not x` keeps the loop going instead of falling through.
 	while not x and retry > 0 do
 		local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
 		if not spot_closest_to_target then
 			target_radius = target_radius * 2
+			retry = retry - 1
 		else
 			x, y = GetRandomPlayablePos(pos, range, guim, AsyncRand(), pfclass, def.radius)
 			local temp_pos = point(x, y)
@@ -693,16 +697,16 @@ function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
 			else
 				local possible_pos = point(x, y)
 				if ConnectivityCheck(possible_pos, spot_closest_to_target, pfclass) then
-					--print("Found a point!")
 					return possible_pos
 				else
+					x = nil
 					retry = retry - 1
 					range = range * 2
 				end
 			end
 		end
-		return nil
 	end
+	return nil
 end
 
 local post_spawn_animal = function(self, obj, target, context)

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -671,17 +671,15 @@ function nest_find_attack_spawn(spawndef_instance, spawn_class, target)
 	local def = spawn_class and g_Classes[spawn_class]
 	local pfclass = def.pfclass
 	local pos = terrain.FindPassableTile(spawndef_instance.nest, const.tfpPassClass, pfclass)
-	-- No passable tile at the nest means no spawn anchor; pos feeds GetRandomPlayablePos/IsCloser2D below,
-	-- which throw on nil (this call is not procall-guarded), so bail instead of just logging.
+	-- pos feeds GetRandomPlayablePos/IsCloser2D below, which throw on nil, and this path isn't procall-guarded.
 	if not pos then return nil end
 	local nest_entity_radius = spawndef_instance.nest:GetRadius()
 	local x, y
 	local retry = 10
 	local range = spawndef_instance.nest.max_range
 	local target_radius = 30 * guim
-	-- Up to 10 attempts, widening target_radius (no passable spot near the target) or range (spot rejected)
-	-- each pass. retry must decrement on every path or the no-spot branch spins, and x resets on a connectivity
-	-- failure so `not x` keeps the loop going instead of falling through.
+	-- Every non-returning branch must decrement retry (else the no-spot path spins) and leave x nil (else
+	-- `not x` falls out before retrying).
 	while not x and retry > 0 do
 		local spot_closest_to_target = terrain.FindPassable(target, pfclass, target_radius)
 		if not spot_closest_to_target then


### PR DESCRIPTION
Two robustness fixes to `nest_find_attack_spawn` (the attack spawn-placement finder).

**Retry loop ran only once.** `return nil` sat inside the `while` loop, so the 10-attempt search ran a single iteration and gave up;
attacks then spawned at the fallback (the base) instead of near the nest. Moving `return nil` out isn't enough on its own; two sibling defects also blocked the loop:
- the no-passable-spot branch grew `target_radius` without decrementing `retry`, so it could spin;
- the connectivity-failure branch decremented `retry` but never reset `x = nil`, so `while not x` fell out before retrying.

Now every non-returning path decrements `retry` (guarantees ≤10 iterations) and leaves `x` nil, so the loop widens `target_radius`/`range` and retries as intended, returning nil only after all attempts.

**Nil nest anchor.** `terrain.FindPassableTile` can return nil, but the code only logged "no pos found!" and continued, passing nil into `GetRandomPlayablePos`/`IsCloser2D` (which throw) on a path that isn't procall-guarded. Now bails with nil.