### PR TITLE
Refactor/lookup tables

### DIFF
--- a/Code/NA_Helper.lua
+++ b/Code/NA_Helper.lua
@@ -308,25 +308,11 @@ function find_nest_species(input)
 	return false
 end
 
+-- PXImpossible is the Project X (Repaired) mod's added difficulty, not vanilla; `or 7` covers an
+-- unknown mod-added difficulty or a nil result when there is no active Game.
+local DIFFICULTY_OFFSET = { Easy = 1, Medium = 2, Hard = 3, VeryHard = 4, Insane = 5, PXImpossible = 6 }
 function Get_difficulty_offset()
-	local difficulty_offset = 2
-	local difficulty = GetGameDifficulty()
-	if difficulty == 'Easy' then
-		difficulty_offset = 1
-	elseif difficulty == 'Medium' then
-		difficulty_offset = 2
-	elseif difficulty == 'Hard' then
-		difficulty_offset = 3
-	elseif difficulty == 'VeryHard' then
-		difficulty_offset = 4
-	elseif difficulty == 'Insane' then
-		difficulty_offset = 5
-	elseif difficulty == 'PXImpossible' then
-		difficulty_offset = 6
-	else
-		difficulty_offset = 7
-	end
-	return difficulty_offset
+	return DIFFICULTY_OFFSET[GetGameDifficulty()] or 7
 end
 
 --assuming a string of the nest class
@@ -349,32 +335,11 @@ function get_species_from_nest(nest_class)
 	end
 end
 
+local NEST_BY_REGION = { Desertum = 'ShriekerNest', Sobrius = 'ShriekerNest', Saltu = 'ScissorhandsNest' }
 function Get_nest_species_by_region(region)
 	region = region or Region.id
 	DebugPrint("Getting nest class id by region\n")
-	if region == 'Desertum' then
-		return get_species_from_nest('ShriekerNest')
-	elseif region == 'Sobrius' then
-		return get_species_from_nest("ShriekerNest")
-	elseif region == 'Saltu' then
-		return get_species_from_nest('ScissorhandsNest')
-	else
-		return get_species_from_nest('ShriekerNest')
-	end
-end
-
-function Get_nest_entity_by_region(region)
-	region = region or Region.id
-	DebugPrint("Getting nest class id by region\n")
-	if region == 'Desertum' then
-		return ('ShriekerNest')
-	elseif region == 'Sobrius' then
-		return get_species_from_nest("ShriekerNest")
-	elseif region == 'Saltu' then
-		return get_species_from_nest('ScissorhandsNest')
-	else
-		return get_species_from_nest('ShriekerNest')
-	end
+	return get_species_from_nest(NEST_BY_REGION[region] or 'ShriekerNest')
 end
 
 function Is_DLC_Present()
@@ -451,9 +416,9 @@ function NA_QA(full_log)
 	full_log = full_log or false
 	EE_debug = full_log
 	print("Testing regions default nests")
-	print(Get_nest_entity_by_region('Desertum') == 'nesting_shriekers')
-	print(Get_nest_entity_by_region('Sobrius') == 'nesting_shriekers')
-	print(Get_nest_entity_by_region('Saltu') == 'nesting_scissorhands')
+	print(Get_nest_species_by_region('Desertum') == 'nesting_shriekers')
+	print(Get_nest_species_by_region('Sobrius') == 'nesting_shriekers')
+	print(Get_nest_species_by_region('Saltu') == 'nesting_scissorhands')
 	--assert(Get_nest_by_region('Desertum')=='nesting_shriekers')
 	--assert(Get_nest_by_region('Sobrius')=='nesting_shriekers')
 	--assert(Get_nest_by_region('Saltu')=='nesting_scissorhands')

--- a/Code/NA_NestExpansion.lua
+++ b/Code/NA_NestExpansion.lua
@@ -390,16 +390,13 @@ function EnhancedTerritorialNest:consume_closest_node()
 	self:get_next_consume_time()
 end
 
+local STORYBIT_POPUP_IMAGE = {
+	ShriekerNest     = 'Mod/TGkJ3Tu/PicsOritDidntHappen/Shrieker_Nest.PNG',
+	ScissorhandsNest = 'Mod/TGkJ3Tu/PicsOritDidntHappen/Scissor_Nest.PNG',
+	ConsortiumNest   = 'Mod/TGkJ3Tu/PicsOritDidntHappen/ConsortiumNestVariant.PNG',
+}
 function EnhancedTerritorialNest:GetStoryBitPopupImage()
-	if self.class == 'ShriekerNest' then
-		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-	elseif self.class == 'ScissorhandsNest' then
-		return 'Mod/TGkJ3Tu/Scissor_Nest.PNG'
-	elseif self.class == 'ConsortiumNest' then
-		return 'ConsortiumNestVariant.PNG'
-	else
-		return 'Mod/TGkJ3Tu/Shrieker_Nest.PNG'
-	end
+	return STORYBIT_POPUP_IMAGE[self.class] or 'Mod/TGkJ3Tu/PicsOritDidntHappen/Shrieker_Nest.PNG'
 end
 
 -- Closest does 2 things


### PR DESCRIPTION
Three small if/elseif chains become lookup tables, with one bug fix folded in.

- Get_difficulty_offset and Get_nest_species_by_region → lookup tables. Behavior-identical, same fallbacks.
- GetStoryBitPopupImage → lookup table, and its image paths are corrected; they were missing the PicsOritDidntHappen/ folder (the Consortium one also the mod prefix), so nest storybit popups rendered no art. They now point at the real assets.
- Removes the dead Get_nest_entity_by_region (no callers) and repoints its NA_QA debug prints at Get_nest_species_by_region, which also corrects that check (the old function returned the wrong type for one region).

No behavior change except the popup art now renders.